### PR TITLE
Add in-section Next/Prev section pointers

### DIFF
--- a/docs/content/layout/variables.md
+++ b/docs/content/layout/variables.md
@@ -31,6 +31,8 @@ matter, content or derived from file location.
 **.TableOfContents** The rendered table of contents for this content<br>
 **.Prev** Pointer to the previous content (based on pub date)<br>
 **.Next** Pointer to the following content (based on pub date)<br>
+**.PrevInSection** Pointer to the previous content within the same section (based on pub date)<br>
+**.NextInSection** Pointer to the following content within the same section (based on pub date)<br>
 **.FuzzyWordCount** The approximate number of words in the content.<br>
 **.WordCount** The number of words in the content.<br>
 **.ReadingTime** The estimated time it takes to read the content in minutes.<br>

--- a/docs/content/meta/release-notes.md
+++ b/docs/content/meta/release-notes.md
@@ -5,6 +5,9 @@ aliases: ["/doc/release-notes/"]
 groups: ["meta"]
 groups_weight: 10
 ---
+## Next release
+  * Added section Prev/Next pointers.
+
 ## **0.10.0** March 1, 2014
   * [Syntax highlighting](/extras/highlighting) powered by pygments (**slow**)
   * Ability to [sort content](/content/ordering) many more ways

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -74,6 +74,8 @@ type PageMeta struct {
 type Position struct {
 	Prev *Page
 	Next *Page
+	PrevInSection *Page
+	NextInSection *Page
 }
 
 type Pages []*Page

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -341,10 +341,10 @@ func (s *Site) BuildSiteMeta() (err error) {
 
 		for i, wp := range s.Sections[k] {
 			if i > 0 {
-				wp.Page.NextInSection = s.Sections[k][i - 1].Page;
+				wp.Page.PrevInSection = s.Sections[k][i - 1].Page;
 			}
 			if i < len(s.Sections[k]) - 1 {
-				wp.Page.PrevInSection = s.Sections[k][i + 1].Page;
+				wp.Page.NextInSection = s.Sections[k][i + 1].Page;
 			}
 		}
 	}

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -338,6 +338,15 @@ func (s *Site) BuildSiteMeta() (err error) {
 
 	for k := range s.Sections {
 		s.Sections[k].Sort()
+
+		for i, wp := range s.Sections[k] {
+			if i > 0 {
+				wp.Page.NextInSection = s.Sections[k][i - 1].Page;
+			}
+			if i < len(s.Sections[k]) - 1 {
+				wp.Page.PrevInSection = s.Sections[k][i + 1].Page;
+			}
+		}
 	}
 
 	s.Info.Indexes = s.Indexes


### PR DESCRIPTION
Allows navigation to be added to pages that is restricted to the current section.

Templates can use `.PrevInSection` and `.NextInSection` in the same way they use `.Prev` and `.Next`.

Issue: #211

(Moved from #259)