### PR TITLE
taxonomies -> Taxonomies

### DIFF
--- a/docs/content/taxonomies/usage.md
+++ b/docs/content/taxonomies/usage.md
@@ -22,7 +22,7 @@ Notice the format is **singular key** : *plural value*.
 ### config.yaml
 
     ---
-    taxonomies:
+    Taxonomies:
         tag: "tags"
         category: "categories"
         series: "series"


### PR DESCRIPTION
Only after changing "taxonomies" to "Taxonomies" custom taxonomies appeared to work (hugo 0.11).