### PR TITLE
Add support for excluding pages from the feed

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -54,6 +54,7 @@ type Page struct {
 	frontmatter       []byte
 	sourceFrontmatter []byte
 	sourceContent     []byte
+	ExcludeFromFeed		bool
 	PageMeta
 	File
 	Position
@@ -385,6 +386,8 @@ func (page *Page) update(f interface{}) error {
 			page.Status = cast.ToString(v)
 		case "sitemap":
 			page.Sitemap = parseSitemap(cast.ToStringMap(v))
+		case "excludefromfeed":
+			page.ExcludeFromFeed = cast.ToBool(v)
 		default:
 			// If not one of the explicit values, store in Params
 			switch vv := v.(type) {

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -779,10 +779,19 @@ func (s *Site) RenderHomePage() error {
 		n.Title = "Recent Content"
 		n.Permalink = s.permalink("index.xml")
 		high := 50
-		if len(s.Pages) < high {
-			high = len(s.Pages)
+
+		filteredPages := make(Pages, 0)
+		for _, p := range s.Pages {
+			if !p.ExcludeFromFeed {
+				filteredPages = append(filteredPages, p)
+			}
 		}
-		n.Data["Pages"] = s.Pages[:high]
+
+		if len(filteredPages) < high {
+			high = len(filteredPages)
+		}
+
+		n.Data["Pages"] = filteredPages[:high]
 		if len(s.Pages) > 0 {
 			n.Date = s.Pages[0].Date
 		}


### PR DESCRIPTION
This commit adds the possibility to exclude pages from the main RSS
feed.

It adds a new attribute on the page called excludefromfeed and in the
site generator it will just ignore those pages when generating the feed.