### PR TITLE
Adding top level .Hugo variable with Version, CommitID & BuildDate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 COMMIT_HASH=`git rev-parse --short HEAD 2>/dev/null`
 BUILD_DATE=`date +%FT%T%z`
-LDFLAGS=-ldflags "-X github.com/spf13/hugo/commands.commitHash ${COMMIT_HASH} -X github.com/spf13/hugo/commands.buildDate ${BUILD_DATE}"
+LDFLAGS=-ldflags "-X github.com/spf13/hugo/hugolib.CommitHash ${COMMIT_HASH} -X github.com/spf13/hugo/hugolib.BuildDate ${BUILD_DATE}"
 
 all: gitinfo
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Hugo
-A Fast and Flexible Static Site Generator built with love by [spf13](http://spf13.com) 
+A Fast and Flexible Static Site Generator built with love by [spf13](http://spf13.com)
 and [friends](http://github.com/spf13/hugo/graphs/contributors) in Go.
 
 [![Build Status](https://travis-ci.org/spf13/hugo.png)](https://travis-ci.org/spf13/hugo)
@@ -85,7 +85,7 @@ When Hugo is built using the above steps, the `version` sub-command will include
 
 To do this, replace the `go build` command with the following *(replace `/path/to/hugo` with the actual path)*:
 
-    go build -ldflags "-X /path/to/hugo/commands.commitHash `git rev-parse --short HEAD 2>/dev/null` -X github.com/spf13/hugo/commands.buildDate `date +%FT%T`"  
+    go build -ldflags "-X /path/to/hugo/hugolib.CommitHash `git rev-parse --short HEAD 2>/dev/null` -X github.com/spf13/hugo/hugolib.BuildDate `date +%FT%T`"
 
 This will result in hugo version output that looks similar to:
 
@@ -118,7 +118,7 @@ We welcome your contributions.  To make the process as seamless as possible, we 
 * When you're ready to create a pull request, be sure to:
      * Have test cases for the new code.  If you have questions about how to do it, please ask in your pull request.
      * Run `go fmt`
-     * Squash your commits into a single commit.  `git rebase -i`.  It's okay to force update your pull request.  
+     * Squash your commits into a single commit.  `git rebase -i`.  It's okay to force update your pull request.
      * Make sure `go test ./...` passes, and go build completes.  Our Travis CI loop will catch most things that are missing.  The exception: Windows.  We run on Windows from time to time, but if you have access, please check on a Windows machine too.
 
 **Complete documentation is available at [Hugo Documentation](http://gohugo.io).**

--- a/commands/version.go
+++ b/commands/version.go
@@ -22,29 +22,25 @@ import (
 
 	"bitbucket.org/kardianos/osext"
 	"github.com/spf13/cobra"
+	"github.com/spf13/hugo/hugolib"
 )
 
 var timeLayout string // the layout for time.Time
-
-var (
-	commitHash string
-	buildDate  string
-)
 
 var version = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number of Hugo",
 	Long:  `All software has versions. This is Hugo's`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if buildDate == "" {
+		if hugolib.BuildDate == "" {
 			setBuildDate() // set the build date from executable's mdate
 		} else {
 			formatBuildDate() // format the compile time
 		}
-		if commitHash == "" {
-			fmt.Printf("Hugo Static Site Generator v0.13-DEV buildDate: %s\n", buildDate)
+		if hugolib.CommitHash == "" {
+			fmt.Printf("Hugo Static Site Generator v%s BuildDate: %s\n", hugolib.Version, hugolib.BuildDate)
 		} else {
-			fmt.Printf("Hugo Static Site Generator v0.13-DEV-%s buildDate: %s\n", strings.ToUpper(commitHash), buildDate)
+			fmt.Printf("Hugo Static Site Generator v%s-%s BuildDate: %s\n", hugolib.Version, strings.ToUpper(hugolib.CommitHash), hugolib.BuildDate)
 		}
 	},
 }
@@ -52,7 +48,7 @@ var version = &cobra.Command{
 // setBuildDate checks the ModTime of the Hugo executable and returns it as a
 // formatted string.  This assumes that the executable name is Hugo, if it does
 // not exist, an empty string will be returned.  This is only called if the
-// buildDate wasn't set during compile time.
+// hugolib.BuildDate wasn't set during compile time.
 //
 // osext is used for cross-platform.
 func setBuildDate() {
@@ -68,12 +64,12 @@ func setBuildDate() {
 		return
 	}
 	t := fi.ModTime()
-	buildDate = t.Format(time.RFC3339)
+	hugolib.BuildDate = t.Format(time.RFC3339)
 }
 
-// formatBuildDate formats the buildDate according to the value in
+// formatBuildDate formats the hugolib.BuildDate according to the value in
 // .Params.DateFormat, if it's set.
 func formatBuildDate() {
-	t, _ := time.Parse("2006-01-02T15:04:05-0700", buildDate)
-	buildDate = t.Format(time.RFC3339)
+	t, _ := time.Parse("2006-01-02T15:04:05-0700", hugolib.BuildDate)
+	hugolib.BuildDate = t.Format(time.RFC3339)
 }

--- a/docs/content/templates/variables.md
+++ b/docs/content/templates/variables.md
@@ -46,6 +46,7 @@ matter, content or derived from file location.
 **.IsNode** Always false for pages.<br>
 **.IsPage** Always true for page.<br>
 **.Site** See site variables below<br>
+**.Hugo** See site variables below<br>
 
 ## Page Params
 
@@ -70,6 +71,7 @@ includes indexes, lists and the homepage.
 **.IsNode** Always true for nodes.<br>
 **.IsPage** Always false for nodes.<br>
 **.Site** See site variables below<br>
+**.Hugo** See site variables below<br>
 
 ## Site Variables
 
@@ -80,3 +82,12 @@ Also available is `.Site` which has the following:
 **.Site.LastChange** The date of the last change of the most recent content.<br>
 **.Site.Recent** Array of all content ordered by Date, newest first.<br>
 **.Site.Params** A container holding the values from `params` in your site configuration file.<br>
+
+## Hugo Variables
+
+Also available is `.Hugo` which has the following:
+
+**.Hugo.Generator** Meta tag for the version of Hugo that generated the site. Highly recommended to be included by default in all theme headers so we can start to track Hugo usage and popularity. e.g. `<meta name="generator" content="Hugo 0.13" />`<br>
+**.Hugo.Version** The current version of the Hugo binary you are using e.g. `0.13-DEV`<br>
+**.Hugo.CommitHash** The git commit hash of the current Hugo binary e.g. `0e8bed9ccffba0df554728b46c5bbf6d78ae5247`<br>
+**.Hugo.BuildDate** The compile date of the current Hugo binary formatted with RFC 3339 e.g. `2002-10-02T10:00:00-05:00`<br>

--- a/hugolib/hugo.go
+++ b/hugolib/hugo.go
@@ -1,0 +1,25 @@
+package hugolib
+
+const Version = "0.13-DEV"
+
+var (
+	CommitHash string
+	BuildDate  string
+)
+
+// Hugo contains all the information about the current Hugo environment
+type HugoInfo struct {
+	Version    string
+	Generator  string
+	CommitHash string
+	BuildDate  string
+}
+
+func NewHugoInfo() HugoInfo {
+	return HugoInfo{
+		Version:    Version,
+		CommitHash: CommitHash,
+		BuildDate:  BuildDate,
+		Generator:  `<meta name="generator" content="Hugo ` + Version + `" />`,
+	}
+}

--- a/hugolib/node.go
+++ b/hugolib/node.go
@@ -29,6 +29,7 @@ type Node struct {
 	Params      map[string]interface{}
 	Date        time.Time
 	Sitemap     Sitemap
+	Hugo        *HugoInfo
 	UrlPath
 }
 

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -66,6 +66,7 @@ type Site struct {
 	Taxonomies  TaxonomyList
 	Source      source.Input
 	Sections    Taxonomy
+	Hugo        HugoInfo
 	Info        SiteInfo
 	Shortcodes  map[string]ShortcodeFunc
 	Menus       Menus
@@ -93,6 +94,7 @@ type SiteInfo struct {
 	Files           []*source.File
 	Recent          *Pages // legacy, should be identical to Pages
 	Menus           *Menus
+	Hugo            *HugoInfo
 	Title           string
 	Author          map[string]interface{}
 	LanguageCode    string
@@ -264,6 +266,7 @@ func (s *Site) initialize() (err error) {
 
 	s.Menus = Menus{}
 
+	s.Hugo = NewHugoInfo()
 	s.initializeSiteInfo()
 
 	s.Shortcodes = make(map[string]ShortcodeFunc)
@@ -291,6 +294,7 @@ func (s *Site) initializeSiteInfo() {
 		Menus:           &s.Menus,
 		Params:          params,
 		Permalinks:      permalinks,
+		Hugo:            &s.Hugo,
 	}
 }
 
@@ -1106,6 +1110,7 @@ func (s *Site) NewNode() *Node {
 	return &Node{
 		Data: make(map[string]interface{}),
 		Site: &s.Info,
+		Hugo: &s.Hugo,
 	}
 }
 


### PR DESCRIPTION
This originated with the discussion here: http://discuss.gohugo.io/t/template-variables-to-pull-hugo-version-information/419

As Hugo gains popularity and more themes are built, there is going to be needed information about the current Hugo environment to determine what the version supports. I attempted to follow the pattern in `hugolib/site.go` to add `hugolib/hugo.go`, to add a top level .Hugo variable that can be accessed from shortcodes, templates and partials.

As of right now, the version is a string constant at the top of the file that would need to be changed manually with each release, that shouldn't be too onerous. If we wanted to get fancier, maybe it could pull from the current commit / tag. I'm not sure the best way to go with that.

@spf13 I'm not quite sure how to expose that variable to the templating system, but I imagine it shouldn't be difficult.

The first thing I am using the version for is for a meta generator shortcode.
```
{{% hugo-generator %}}

// outputs
<meta name="generator" content="Hugo 0.13" />
```

I still have issues running all the tests on my Windows machine, which makes it a little harder to verify tests before pushing.