### PR TITLE
Apply a function over a sequence

### DIFF
--- a/docs/content/templates/functions.md
+++ b/docs/content/templates/functions.md
@@ -258,11 +258,75 @@ Removes any trailing newline characters. Useful in a pipeline to remove newlines
 e.g., `{{chomp "<p>Blockhead</p>\n"` → `"<p>Blockhead</p>"`
 
 ### highlight
-Take a string of code and a language, uses Pygments to return the syntax
-highlighted code in HTML. Used in the [highlight
-shortcode](/extras/highlighting).
+Take a string of code and a language, uses Pygments to return the syntax highlighted code in HTML. Used in the [highlight shortcode](/extras/highlighting).
 
 ### ref, relref
 Looks up a content page by relative path or logical name to return the permalink (`ref`) or relative permalink (`relref`). Requires a Node or Page object (usually satisfied with `.`). Used in the [`ref` and `relref` shortcodes]({{% ref "extras/crossreferences.md" %}}).
 
 e.g. {{ ref . "about.md" }}
+
+## Advanced
+
+### apply
+
+Given a map, array, or slice, returns a new slice with a function applied over it. Expects at least three parameters, depending on the function being applied. The first parameter is the sequence to operate on; the second is the name of the function as a string, which must be in the Hugo function map (generally, it is these functions documented here). After that, the parameters to the applied function are provided, with the string `"."` standing in for each element of the sequence the function is to be applied against. An example is in order:
+
+    +++
+    names: [ "Derek Perkins", "Joe Bergevin", "Tanner Linsley" ]
+    +++
+
+    {{ apply .Params.names "urlize" "." }} → [ "derek-perkins", "joe-bergevin", "tanner-linsley" ]
+
+This is roughly equivalent to:
+
+    {{ range .Params.names }}{{ . | urlize }}{{ end }}
+
+However, it isn’t possible to provide the output of a range to the `delimit` function, so you need to `apply` it. A more complete example should explain this. Let's say you have two partials for displaying tag links in a post,  "post/tag/list.html" and "post/tag/link.html", as shown below.
+
+    <!-- post/tag/list.html -->
+    {{ with .Params.tags }}
+    <div class="tags-list">
+      Tags:
+      {{ $len := len . }}
+      {{ if eq $len 1 }}
+        {{ partial "post/tag/link" (index . 0) }}
+      {{ else }}
+        {{ $last := sub $len 1 }}
+        {{ range first $last . }}
+          {{ partial "post/tag/link" . }},
+        {{ end }}
+        {{ partial "post/tag/link" (index . $last) }}
+      {{ end }}
+    </div>
+    {{ end }}
+
+
+    <!-- post/tag/link.html -->
+    <a class="post-tag post-tag-{{ . | urlize }}" href="/tags/{{ . | urlize }}">{{ . }}</a>
+
+This works, but the complexity of "post/tag/list.html" is fairly high; the Hugo template needs to perform special behaviour for the case where there’s only one tag, and it has to treat the last tag as special. Additionally, the tag list will be rendered something like "Tags: tag1 , tag2 , tag3" because of the way that the HTML is generated and it is interpreted by a browser.
+
+This is Hugo. We have a better way. If this were your "post/tag/list.html" instead, all of those problems are fixed automatically (this first version separates all of the operations for ease of reading; the combined version will be shown after the explanation).
+
+    <!-- post/tag/list.html -->
+    {{ with.Params.tags }}
+    <div class="tags-list">
+      Tags:
+      {{ $sort := sort . }}
+      {{ $links := apply $sort "partial" "post/tag/link" "." }}
+      {{ $clean := apply $links "chomp" "." }}
+      {{ delimit $clean ", " }}
+    </div>
+    {{ end }}
+
+In this version, we are now sorting the tags, converting them to links with "post/tag/link.html", cleaning off stray newlines, and joining them together in a delimited list for presentation. That can also be written as:
+
+    <!-- post/tag/list.html -->
+    {{ with.Params.tags }}
+    <div class="tags-list">
+      Tags:
+      {{ delimit (apply (apply (sort .) "partial" "post/tag/link" ".") "chomp" ".") ", " }}
+    </div>
+    {{ end }}
+
+`apply` does not work when receiving the sequence as an argument through a pipeline.

--- a/docs/content/templates/functions.md
+++ b/docs/content/templates/functions.md
@@ -252,6 +252,11 @@ Convert all characters in string to titlecase.
 
 e.g. `{{title "BatMan"}}` → "Batman"
 
+### chomp
+Removes any trailing newline characters. Useful in a pipeline to remove newlines added by other processing (including `markdownify`).
+
+e.g., `{{chomp "<p>Blockhead</p>\n"` → `"<p>Blockhead</p>"`
+
 ### highlight
 Take a string of code and a language, uses Pygments to return the syntax
 highlighted code in HTML. Used in the [highlight

--- a/tpl/template.go
+++ b/tpl/template.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -37,6 +38,7 @@ import (
 var localTemplates *template.Template
 var tmpl Template
 var funcMap template.FuncMap
+var chompRegexp *regexp.Regexp
 
 type Template interface {
 	ExecuteTemplate(wr io.Writer, name string, data interface{}) error
@@ -667,6 +669,15 @@ func RelRef(page interface{}, ref string) template.HTML {
 	return refPage(page, ref, "RelRef")
 }
 
+func Chomp(text interface{}) (string, error) {
+	s, err := cast.ToStringE(text)
+	if err != nil {
+		return "", err
+	}
+
+	return chompRegexp.ReplaceAllString(s, ""), nil
+}
+
 func SafeHtml(text string) template.HTML {
 	return template.HTML(text)
 }
@@ -1022,5 +1033,8 @@ func init() {
 		"partial":     Partial,
 		"ref":         Ref,
 		"relref":      RelRef,
+		"chomp":       Chomp,
 	}
+
+	chompRegexp = regexp.MustCompile("[\r\n]+$")
 }

--- a/tpl/template.go
+++ b/tpl/template.go
@@ -204,7 +204,6 @@ func compareGetFloat(a interface{}, b interface{}) (float64, float64) {
 }
 
 func Intersect(l1, l2 interface{}) (interface{}, error) {
-
 	if l1 == nil || l2 == nil {
 		return make([]interface{}, 0), nil
 	}
@@ -305,7 +304,6 @@ func indirect(v reflect.Value) (rv reflect.Value, isNil bool) {
 // First is exposed to templates, to iterate over the first N items in a
 // rangeable list.
 func First(limit interface{}, seq interface{}) (interface{}, error) {
-
 	limitv, err := cast.ToIntE(limit)
 
 	if err != nil {
@@ -335,7 +333,7 @@ func First(limit interface{}, seq interface{}) (interface{}, error) {
 }
 
 var (
-	zero reflect.Value
+	zero      reflect.Value
 	errorType = reflect.TypeOf((*error)(nil)).Elem()
 )
 

--- a/tpl/template.go
+++ b/tpl/template.go
@@ -36,6 +36,7 @@ import (
 
 var localTemplates *template.Template
 var tmpl Template
+var funcMap template.FuncMap
 
 type Template interface {
 	ExecuteTemplate(wr io.Writer, name string, data interface{}) error
@@ -83,40 +84,6 @@ func New() Template {
 	}
 
 	localTemplates = &templates.Template
-
-	funcMap := template.FuncMap{
-		"urlize":      helpers.Urlize,
-		"sanitizeurl": helpers.SanitizeUrl,
-		"eq":          Eq,
-		"ne":          Ne,
-		"gt":          Gt,
-		"ge":          Ge,
-		"lt":          Lt,
-		"le":          Le,
-		"in":          In,
-		"intersect":   Intersect,
-		"isset":       IsSet,
-		"echoParam":   ReturnWhenSet,
-		"safeHtml":    SafeHtml,
-		"markdownify": Markdownify,
-		"first":       First,
-		"where":       Where,
-		"delimit":     Delimit,
-		"sort":        Sort,
-		"highlight":   Highlight,
-		"add":         func(a, b interface{}) (interface{}, error) { return doArithmetic(a, b, '+') },
-		"sub":         func(a, b interface{}) (interface{}, error) { return doArithmetic(a, b, '-') },
-		"div":         func(a, b interface{}) (interface{}, error) { return doArithmetic(a, b, '/') },
-		"mod":         Mod,
-		"mul":         func(a, b interface{}) (interface{}, error) { return doArithmetic(a, b, '*') },
-		"modBool":     ModBool,
-		"lower":       func(a string) string { return strings.ToLower(a) },
-		"upper":       func(a string) string { return strings.ToUpper(a) },
-		"title":       func(a string) string { return strings.Title(a) },
-		"partial":     Partial,
-		"ref":         Ref,
-		"relref":      RelRef,
-	}
 
 	templates.Funcs(funcMap)
 	templates.LoadEmbedded()
@@ -1020,4 +987,40 @@ func (t *GoHtmlTemplate) LoadTemplatesWithPrefix(absPath string, prefix string) 
 
 func (t *GoHtmlTemplate) LoadTemplates(absPath string) {
 	t.loadTemplates(absPath, "")
+}
+
+func init() {
+	funcMap = template.FuncMap{
+		"urlize":      helpers.Urlize,
+		"sanitizeurl": helpers.SanitizeUrl,
+		"eq":          Eq,
+		"ne":          Ne,
+		"gt":          Gt,
+		"ge":          Ge,
+		"lt":          Lt,
+		"le":          Le,
+		"in":          In,
+		"intersect":   Intersect,
+		"isset":       IsSet,
+		"echoParam":   ReturnWhenSet,
+		"safeHtml":    SafeHtml,
+		"markdownify": Markdownify,
+		"first":       First,
+		"where":       Where,
+		"delimit":     Delimit,
+		"sort":        Sort,
+		"highlight":   Highlight,
+		"add":         func(a, b interface{}) (interface{}, error) { return doArithmetic(a, b, '+') },
+		"sub":         func(a, b interface{}) (interface{}, error) { return doArithmetic(a, b, '-') },
+		"div":         func(a, b interface{}) (interface{}, error) { return doArithmetic(a, b, '/') },
+		"mod":         Mod,
+		"mul":         func(a, b interface{}) (interface{}, error) { return doArithmetic(a, b, '*') },
+		"modBool":     ModBool,
+		"lower":       func(a string) string { return strings.ToLower(a) },
+		"upper":       func(a string) string { return strings.ToUpper(a) },
+		"title":       func(a string) string { return strings.Title(a) },
+		"partial":     Partial,
+		"ref":         Ref,
+		"relref":      RelRef,
+	}
 }


### PR DESCRIPTION
> __Note__: The description below is no longer valid. See [this comment](https://github.com/spf13/hugo/pull/706#issuecomment-66401985) for a current correct description of this PR, which is ready but I have some suggested usability improvements.

@derekperkins, I was playing around with the code in #683 tonight and it’s
missing some functionality that I really want—and I mostly have it working, but
there are some incompatibilities with the `delimit` function as written.

Basically, I want to replace this:

```html
{{ with .Params.tags }}
<div class="tags-list">
  <span class="dark-red">Tags</span><span class="decorative-marker">//</span>
  {{ $len := len . }}
  {{ if eq $len 1 }}
    {{ partial "post/tag/link" (index . 0) }}
  {{ else }}
    {{ $last := sub $len 1 }}
    {{ range first $last . }}
      {{ partial "post/tag/link" . }},
    {{ end }}
    {{ partial "post/tag/link" (index . $last) }}
  {{ end }}
</div>
{{ end }}
```

with this:

```html
{{ with .Params.tags }}
<div class="tags-list">
  <span class="dark-red">Tags</span><span class="decorative-marker">//</span>
  {{ delimit (apply (sort .) "partial" "post/tag/link" ".") ", " }}
</div>
{{ end }}
```

This means:

1. Sort .Params.tags.
2. Loop over .Params.tags, replacing each tag with the output of `partial`
   with `"post/tag/link"` as the partial and the tag as the context (`.`).
3. Delimit the resulting objects with `", "`.

The result of `partial` is an HTML template, which is not trivially convertible
to a string, so I’m hitting panics in the delimit code because it tries to
`cast.StringE` each value. If that isn’t done, you can’t easily concatenate the
delimiters to HTML template…and you want it to be `safeHtml` in this case (but
I could probably do that with an appropriate `| safeHtml` at the end of the
`delimit`).

There’s a few things I don’t like about this particular syntax, but it offers
some intriguing capabilities if we can get it working (I *do* have `apply`
working in this branch, but not with your functions underneath).