### PR TITLE
StaticRelativePath inserts a relative path to static content

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -136,6 +136,7 @@ func InitializeConfig() {
 	viper.SetDefault("FootnoteAnchorPrefix", "")
 	viper.SetDefault("FootnoteReturnLinkContents", "")
 	viper.SetDefault("NewContentEditor", "")
+	viper.SetDefault("StaticRelativePath", "")
 	viper.SetDefault("Blackfriday", map[string]bool{"angledQuotes": false})
 
 	if hugoCmdV.PersistentFlags().Lookup("buildDrafts").Changed {
@@ -238,7 +239,7 @@ func copyStatic() error {
 		return nil
 	}
 
-	publishDir := helpers.AbsPathify(viper.GetString("PublishDir")) + "/"
+	publishDir := helpers.AbsPathify(viper.GetString("PublishDir")) + "/" + viper.GetString("StaticRelativePath")
 
 	syncer := fsync.NewSyncer()
 	syncer.NoTimes = viper.GetBool("notimes")


### PR DESCRIPTION
Useful if static content needs to be placed in a deep subdirectory.
Keeps the static directory clean.  Location of static content can be
configured from config.yaml rather than directory structure.