### PR TITLE
use fsnotify 0.9.3

### DIFF
--- a/watcher/batcher.go
+++ b/watcher/batcher.go
@@ -1,8 +1,9 @@
 package watcher
 
 import (
-	"github.com/howeyc/fsnotify"
 	"time"
+
+	"gopkg.in/fsnotify.v0"
 )
 
 type Batcher struct {


### PR DESCRIPTION
This contains a few fixes (v0.9.1 through v0.9.3) but the same API and few internal changes.

https://github.com/go-fsnotify/fsnotify/blob/master/CHANGELOG.md#v093--2014-12-31

A good first step before switching to v1.

ref https://github.com/go-fsnotify/fsnotify/issues/35