### PR TITLE
Revert "Temporarily disable failing menu test"

### DIFF
--- a/hugolib/menu_test.go
+++ b/hugolib/menu_test.go
@@ -96,10 +96,7 @@ type testMenuState struct {
 	oldBaseUrl interface{}
 }
 
-// temporarily disabled
-// will be enabled once the cast related build issues is fixed
-// todo bep
-func _TestPageMenu(t *testing.T) {
+func TestPageMenu(t *testing.T) {
 	ts := setupMenuTests(t)
 	defer resetMenuTestState(ts)
 


### PR DESCRIPTION
This reverts commit e4a22255ccb818f8b55a20f56ddcfda869db250f.