### PR TITLE
Add operator argument to `where` template function

### DIFF
--- a/docs/content/templates/functions.md
+++ b/docs/content/templates/functions.md
@@ -79,6 +79,25 @@ e.g.
        {{ .Content}}
     {{ end }}
 
+It can also be used with an operator like `!=`, `>=`, `in` etc. Without an operator (like above), `where` compares a given field with a matching value in a way like `=` is specified.
+
+e.g.
+
+    {{ range where .Data.Pages "Section" "!=" "post" }}
+       {{ .Content}}
+    {{ end }}
+
+Following operators are now available
+
+- `=`, `==`, `eq`: True if a given field value equals a matching value
+- `!=`, `<>`, `ne`: True if a given field value doesn't equal a matching value
+- `>=`, `ge`: True if a given field value is greater than or equal to a matching value
+- `>`, `gt`: True if a given field value is greater than a matching value
+- `<=`, `le`: True if a given field value is lesser than or equal to a matching value
+- `<`, `lt`: True if a given field value is lesser than a matching value
+- `in`: True if a given field value is included in a matching value. A matching value must be an array or a slice
+- `not in`: True if a given field value isn't included in a matching value. A matching value must be an array or a slice
+
 *where and first can be stacked*
 
 e.g.


### PR DESCRIPTION
It allows to use `where` template function like SQL `where` clause.
For example,

    {{ range where .Data.Pages "Type" "!=" "post" }}
        {{ .Content }}
    {{ end }}

Now these operators are implemented:

    =, ==, eq, !=, <>, ne, >=, ge, >, gt, <=, le, <, lt, in, not in

It also fixes `TestWhere` more readable