### PR TITLE
Add config options to disable footnote anchor prefix and/or header ID suffix

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -123,6 +123,8 @@ func InitializeConfig() {
 	viper.SetDefault("BuildDrafts", false)
 	viper.SetDefault("BuildFuture", false)
 	viper.SetDefault("UglyUrls", false)
+	viper.SetDefault("DisableFootnoteAnchorPrefix", false)
+	viper.SetDefault("DisableHeaderIDSuffix", false)
 	viper.SetDefault("Verbose", false)
 	viper.SetDefault("CanonifyUrls", false)
 	viper.SetDefault("Indexes", map[string]string{"tag": "tags", "category": "categories"})

--- a/helpers/content.go
+++ b/helpers/content.go
@@ -85,8 +85,11 @@ func GetHtmlRenderer(defaultFlags int, ctx RenderingContext) blackfriday.Rendere
 		FootnoteReturnLinkContents: viper.GetString("FootnoteReturnLinkContents"),
 	}
 
-	if len(ctx.DocumentId) != 0 {
+	if len(ctx.DocumentId) != 0 && !viper.GetBool("DisableFootnoteAnchorPrefix") {
 		renderParameters.FootnoteAnchorPrefix = ctx.DocumentId + ":" + renderParameters.FootnoteAnchorPrefix
+	}
+
+	if len(ctx.DocumentId) != 0 && !viper.GetBool("DisableHeaderIDSuffix") {
 		renderParameters.HeaderIDSuffix = ":" + ctx.DocumentId
 	}
 


### PR DESCRIPTION
The new config options are

* `DisableFootnoteAnchorPrefix` - bool - default: `false`
* `DisableHeaderIDSuffix` - bool - default: `false`

My site depends on anchor IDs being generated without the suffix, so I added this configuration option to disable the automatic suffix behavior.  I understand the risk of duplicate IDs, so that's why this is defaulting to `false`.

So, if the config file contains:

```toml
DisableHeaderIDSuffix = true
```

Then this:

```markdown
# My Header
```

will generate:

```html
<h1 id="my-header">My Header</h1>
```