### PR TITLE
Add example code to Summaries

### DIFF
--- a/docs/content/content/summaries.md
+++ b/docs/content/content/summaries.md
@@ -29,3 +29,14 @@ If the summary content divider exists within a piece of content, Hugo will split
 When using user-defined summaries, <code>&#60;&#33;&#45;&#45;more&#45;&#45;&#62;</code>, Hugo will preserve the HTML in the summary.
 
 The summary content divider only applies to the content that it appears in.
+
+## Showing Summaries
+
+You can show content summaries with the following code. You could do this, for example, on a [list](/templates/list/) node.
+
+    {{ range first 10 .Data.Pages }}
+      <div class="summary">
+        <h4><a href="{{ .Permalink }}">{{ .Title }}</a></h4>
+        {{ .Summary }}
+      </div>
+    {{ end }}


### PR DESCRIPTION
I was initially confused about how to use summaries. The only example code I found in the docs was on the page for list nodes, but that uses `Render "summary"`, which is for views, not an article summary. I thought a little example here might clarify the issue for future users.