### PR TITLE
note in archetype.md to alert that ending carriage return may be nessary to avoid EOF errors.

### DIFF
--- a/docs/content/content/archetypes.md
+++ b/docs/content/content/archetypes.md
@@ -28,6 +28,7 @@ I use ‘tags’ and ‘categories’ for my taxonomies.
     categories = ["x", "y"]
     +++
 
+__NOTE:__  Some editors (e.g. Sublime) do not insert an EOL at the last line.  If you get an EOF error using `hugo new` type a carriage return `<Enter>` after the closing `+++` in each archetype file.
 
 ## Using archetypes
 


### PR DESCRIPTION
Already someone has added this to the troubleshooting section but users having this issue might not visit that page thus this quick note in archetype.md itself.  It would have saved me a bunch of time :-).  Hope you can update the docs site now and not wait until next release.