### PR TITLE
Add trim and replace template functions

### DIFF
--- a/docs/content/templates/functions.md
+++ b/docs/content/templates/functions.md
@@ -276,6 +276,16 @@ Removes any trailing newline characters. Useful in a pipeline to remove newlines
 
 e.g., `{{chomp "<p>Blockhead</p>\n"` → `"<p>Blockhead</p>"`
 
+### trim
+Trim returns a slice of the string with all leading and trailing characters contained in cutset removed.
+
+e.g. `{{ trim "++Batman--" "+-" }}` → "Batman"
+
+### replace
+Replace all occurences of the search string with the replacement string.
+
+e.g. `{{ replace "Batman and Robin" "Robin" "Catwoman" }}` → "Batman and Catwoman"
+
 ### highlight
 Take a string of code and a language, uses Pygments to return the syntax highlighted code in HTML. Used in the [highlight shortcode](/extras/highlighting).
 

--- a/tpl/template.go
+++ b/tpl/template.go
@@ -880,6 +880,24 @@ func Chomp(text interface{}) (string, error) {
 	return chompRegexp.ReplaceAllString(s, ""), nil
 }
 
+// Trim leading/trailing characters defined by b from a
+func Trim(a interface{}, b string) (string, error) {
+	aStr, err := cast.ToStringE(a)
+	if err != nil {
+		return "", err
+	}
+	return strings.Trim(aStr, b), nil
+}
+
+// Replace all occurences of b with c in a
+func Replace(a interface{}, b string, c string) (string, error) {
+	aStr, err := cast.ToStringE(a)
+	if err != nil {
+		return "", err
+	}
+	return strings.Replace(aStr, b, c, -1), nil
+}
+
 func SafeHtml(text string) template.HTML {
 	return template.HTML(text)
 }
@@ -1237,8 +1255,8 @@ func init() {
 		"relref":      RelRef,
 		"apply":       Apply,
 		"chomp":       Chomp,
-    "replace":     func(a string, b string, c string) string { return strings.Replace(a, b, c, -1) },
-    "trim":        func(a string, b string) string { return strings.Trim(a, b) },
+		"replace":     Replace,
+		"trim":        Trim,
 	}
 
 	chompRegexp = regexp.MustCompile("[\r\n]+$")

--- a/tpl/template.go
+++ b/tpl/template.go
@@ -1237,6 +1237,8 @@ func init() {
 		"relref":      RelRef,
 		"apply":       Apply,
 		"chomp":       Chomp,
+    "replace":     func(a string, b string, c string) string { return strings.Replace(a, b, c, -1) },
+    "trim":        func(a string, b string) string { return strings.Trim(a, b) },
 	}
 
 	chompRegexp = regexp.MustCompile("[\r\n]+$")


### PR DESCRIPTION
When working with muut i needed something that could transform "/article/photoswipe-gallery-hugo/" to "article-photoswipe-gallery-hugo". I could have made a custom function doing exactly this, but I thinj it's better solved with two more generic function used together:

     {{ $muutname := trim ( replace .RelPermalink "/" "-" ) "-" }}

