### PR TITLE
Experimental AsciiDoc support with external helpers

### DIFF
--- a/helpers/general.go
+++ b/helpers/general.go
@@ -56,6 +56,8 @@ func GuessType(in string) string {
 	switch strings.ToLower(in) {
 	case "md", "markdown", "mdown":
 		return "markdown"
+	case "asciidoc", "ad":
+		return "asciidoc"
 	case "rst":
 		return "rst"
 	case "html", "htm":

--- a/helpers/general_test.go
+++ b/helpers/general_test.go
@@ -14,6 +14,8 @@ func TestGuessType(t *testing.T) {
 		{"md", "markdown"},
 		{"markdown", "markdown"},
 		{"mdown", "markdown"},
+		{"asciidoc", "asciidoc"},
+		{"ad", "asciidoc"},
 		{"rst", "rst"},
 		{"html", "html"},
 		{"htm", "html"},

--- a/hugolib/handler_page.go
+++ b/hugolib/handler_page.go
@@ -96,7 +96,22 @@ func (h asciidocHandler) Extensions() []string { return []string{"asciidoc", "ad
 func (h asciidocHandler) PageConvert(p *Page, t tpl.Template) HandledResult {
 	p.ProcessShortcodes(t)
 
-	// TODO(spf13) Add Ascii Doc Logic here
+	// TODO(spf13) Add/Refactor AsciiDoc Logic here
+	tmpContent, tmpTableOfContents := helpers.ExtractTOC(p.renderContent(helpers.RemoveSummaryDivider(p.rawContent)))
+
+	if len(p.contentShortCodes) > 0 {
+		tmpContentWithTokensReplaced, err := replaceShortcodeTokens(tmpContent, shortcodePlaceholderPrefix, -1, true, p.contentShortCodes)
+
+		if err != nil {
+			jww.FATAL.Printf("Fail to replace short code tokens in %s:\n%s", p.BaseFileName(), err.Error())
+			return HandledResult{err: err}
+		} else {
+			tmpContent = tmpContentWithTokensReplaced
+		}
+	}
+
+	p.Content = helpers.BytesToHTML(tmpContent)
+	p.TableOfContents = helpers.BytesToHTML(tmpTableOfContents)
 
 	//err := p.Convert()
 	return HandledResult{page: p, err: nil}


### PR DESCRIPTION
See #470

 * Based on existing support for reStructuredText files

 * Handles content files with extensions `.asciidoc` and `.ad`

 * Pipes content through `asciidoctor --safe -`.
   If `asciidoctor` is not installed, then `asciidoc --safe -`.

 * To make sure `asciidoctor` or `asciidoc` is found, after adding
   a piece of AsciiDoc content, run `hugo` with the `-v` flag
   and look for this message:

        INFO: 2015/01/23 Rendering with /usr/bin/asciidoctor ...

Caveats:

 * The final "Last updated" timestamp is currently not stripped.

 * When `hugo` is run with `-v`, you may see a lot of these messages

        INFO: 2015/01/23 Rendering with /usr/bin/asciidoctor ...

   if you have lots of `*.ad` or `*.asciidoc` files.

 * Some versions of `asciidoc` may have trouble with its safe mode.
   To test if you are affected, try this:

        $ echo "Hello" | asciidoc --safe -
        asciidoc: ERROR: unsafe: ifeval invalid
        asciidoc: FAILED: ifeval invalid safe document

   If so, I recommend that you install `asciidoctor` instead.

Feedback and patches welcome!

Ideally, we should be using https://github.com/VonC/asciidocgo,
@VonC's wonderful Go implementation of Asciidoctor.  However,
there is still a bit of work needed for asciidocgo to expose
its API so that Hugo can actually use it.

Until then, hope this "experimental AsciiDoc support through external
helpers" can serve as a stopgap solution for our community. :-)