### PR TITLE
Handle empty front matter in archetype.

### DIFF
--- a/create/content.go
+++ b/create/content.go
@@ -81,6 +81,10 @@ func NewContent(kind, name string) (err error) {
 		return false
 	}
 
+	if newmetadata == nil {
+		newmetadata = make(map[string]interface{})
+	}
+
 	if !caseimatch(newmetadata, "date") {
 		newmetadata["date"] = time.Now()
 	}


### PR DESCRIPTION
If an archetype has deliberately empty front matter (e.g., to suppress
generation of the 'draft' field or to force a particular front matter type
instead of the default TOML), we should handle it gracefully rather than
panic ("assignment to entry in nil map").