### PR TITLE
Fix for page.GetParam() for JSON and TOML maps

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"github.com/spf13/hugo/helpers"
 	"github.com/spf13/hugo/parser"
+	"reflect"
 
 	"github.com/spf13/cast"
 	"github.com/spf13/hugo/hugofs"
@@ -522,9 +523,13 @@ func (page *Page) GetParam(key string) interface{} {
 		return cast.ToTime(v)
 	case []string:
 		return helpers.SliceToLower(v.([]string))
-	case map[interface{}]interface{}:
+	case map[string]interface{}: // JSON and TOML
+		return v
+	case map[interface{}]interface{}: // YAML
 		return v
 	}
+
+	jww.ERROR.Printf("GetParam(\"%s\"): Unknown type %s\n", key, reflect.TypeOf(v))
 	return nil
 }
 

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -3,10 +3,12 @@ package hugolib
 import (
 	"html/template"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/spf13/cast"
 	"github.com/spf13/hugo/helpers"
 )
 
@@ -219,6 +221,9 @@ an_integer = 1
 a_float = 1.3
 a_bool = false
 a_date = 1979-05-27T07:32:00Z
+
+[a_table]
+a_key = "a_value"
 +++
 Front Matter with various frontmatter types`
 
@@ -498,6 +503,13 @@ func TestDifferentFrontMatterVarTypes(t *testing.T) {
 	}
 	if page.GetParam("a_date") != dateval {
 		t.Errorf("frontmatter not handling dates correctly should be %s, got: %s", dateval, page.GetParam("a_date"))
+	}
+	param := page.GetParam("a_table")
+	if param == nil {
+		t.Errorf("frontmatter not handling tables correctly should be type of %v, got: type of %v", reflect.TypeOf(page.Params["a_table"]), reflect.TypeOf(param))
+	}
+	if cast.ToStringMap(param)["a_key"] != "a_value" {
+		t.Errorf("frontmatter not handling values inside a table correctly should be %s, got: %s", "a_value", cast.ToStringMap(page.Params["a_table"])["a_key"])
 	}
 }
 


### PR DESCRIPTION
Setting per-page Blackfriday angledQuotes did not work
with TOML or JSON front matter, but it does work with YAML.

It turns out that page.Params("blackfriday") returns
type map[interface{}]interface{} for YAML, but
type map[string]interface{} for JSON and TOML.

This patch updates page.GetParam() to catch the latter,
with an error message if page.GetParam() does not recognize
a type.  A test is also added.