### PR TITLE
Add site-wide/per-page [blackfriday] `fractions` option

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -136,7 +136,7 @@ func InitializeConfig() {
 	viper.SetDefault("FootnoteAnchorPrefix", "")
 	viper.SetDefault("FootnoteReturnLinkContents", "")
 	viper.SetDefault("NewContentEditor", "")
-	viper.SetDefault("Blackfriday", map[string]bool{"angledQuotes": false, "plainIdAnchors": false})
+	viper.SetDefault("Blackfriday", map[string]bool{"angledQuotes": false, "fractions": true, "plainIdAnchors": false})
 
 	if hugoCmdV.PersistentFlags().Lookup("buildDrafts").Changed {
 		viper.Set("BuildDrafts", Draft)

--- a/docs/content/overview/configuration.md
+++ b/docs/content/overview/configuration.md
@@ -92,6 +92,21 @@ But Hugo does expose some options---as listed in the table below, matched with t
 </tr>
 
 <tr>
+<td><code>fractions</code></td>
+<td><code>true</code></td>
+<td><code>HTML_SMARTYPANTS_FRACTIONS</code></td>
+</tr>
+<tr>
+<td class="purpose-title">Purpose:</td>
+<td class="purpose-description" colspan="2">Enable smart fractions
+<small>(e.g.&nbsp;<code>5/12</code> renders to <sup>5</sup>&frasl;<sub>12</sub> (<code>&lt;sup&gt;5&lt;/sup&gt;&amp;frasl;&lt;sub&gt;12&lt;/sub&gt;</code>))
+<strong>Caveat:</strong> Even with <code>fractions = false</code>,
+Blackfriday would still convert 1/2, 1/4 and 3/4 to ½&nbsp;(<code>&amp;frac12;</code>),
+¼&nbsp;(<code>&amp;frac14;</code>) and ¾&nbsp;(<code>&amp;frac34;</code>) respectively,
+but only these three.</small></td>
+</tr>
+
+<tr>
 <td><code>plainIdAnchors</code></td>
 <td><code>false</code></td>
 <td><code>FootnoteAnchorPrefix</code> and <code>HeaderIDSuffix</code></td>
@@ -112,11 +127,13 @@ But Hugo does expose some options---as listed in the table below, matched with t
 </tr>
 <tr>
 <td><pre><code>[blackfriday]
-    angledQuotes = true
-    plainIdAnchors = true
+  angledQuotes = true
+  fractions = false
+  plainIdAnchors = true
 </code></pre></td>
 <td><pre><code>blackfriday:
   angledQuotes: true
+  fractions: false
   plainIdAnchors: true
 </code></pre></td>
 </tr>

--- a/helpers/content.go
+++ b/helpers/content.go
@@ -95,11 +95,10 @@ func GetHtmlRenderer(defaultFlags int, ctx RenderingContext) blackfriday.Rendere
 	htmlFlags := defaultFlags
 	htmlFlags |= blackfriday.HTML_USE_XHTML
 	htmlFlags |= blackfriday.HTML_USE_SMARTYPANTS
-	htmlFlags |= blackfriday.HTML_SMARTYPANTS_FRACTIONS
 	htmlFlags |= blackfriday.HTML_SMARTYPANTS_LATEX_DASHES
 	htmlFlags |= blackfriday.HTML_FOOTNOTE_RETURN_LINKS
 
-	var angledQuotes bool
+	var angledQuotes, fractions bool
 
 	if m, ok := ctx.ConfigFlags["angledQuotes"]; ok {
 		angledQuotes = m
@@ -107,6 +106,14 @@ func GetHtmlRenderer(defaultFlags int, ctx RenderingContext) blackfriday.Rendere
 
 	if angledQuotes {
 		htmlFlags |= blackfriday.HTML_SMARTYPANTS_ANGLED_QUOTES
+	}
+
+	if m, ok := ctx.ConfigFlags["fractions"]; ok {
+		fractions = m
+	}
+
+	if fractions {
+		htmlFlags |= blackfriday.HTML_SMARTYPANTS_FRACTIONS
 	}
 
 	return blackfriday.HtmlRendererWithParameters(htmlFlags, "", "", renderParameters)


### PR DESCRIPTION
Make Blackfriday's `HTML_SMARTYPANTS_FRACTIONS` option
user-configurable.  Defaults to `true` as before.  See
discussions at:

http://discuss.gohugo.io/t/any-way-to-disable-smart-fractions/328

Thanks to @bjornerik and @spf13 for laying the groundwork
making it easy to expose Blackfriday's underlying configurable
options.