### PR TITLE
Move s.prepUrl() before prepending BaseUrl.

### DIFF
--- a/hugolib/menu_test.go
+++ b/hugolib/menu_test.go
@@ -283,7 +283,7 @@ func doTestMenuWithUnicodeUrls(t *testing.T, canonifyUrls, uglyUrls bool) {
 	expectedBase := "/%D0%BD%D0%BE%D0%B2%D0%BE%D1%81%D1%82%D0%B8-%D0%BF%D1%80%D0%BE%D0%B5%D0%BA%D1%82%D0%B0"
 
 	if !canonifyUrls {
-		expectedBase = "/zoo" + expectedBase
+		expectedBase = "/Zoo" + expectedBase
 	}
 
 	var expected string
@@ -440,7 +440,7 @@ func getTestMenuState(s *Site, t *testing.T) *testMenuState {
 	}
 
 	viper.Set("menu", menus["menu"])
-	viper.Set("baseurl", "http://foo.local/zoo/")
+	viper.Set("baseurl", "http://foo.local/Zoo/")
 
 	return menuState
 }

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -614,10 +614,11 @@ func (s *Site) getMenusFromConfig() Menus {
 					if strings.HasPrefix(menuEntry.Url, "/") {
 						// make it match the nodes
 						menuEntryUrl := menuEntry.Url
+						menuEntry.Url = s.prepUrl(menuEntryUrl)
 						if !s.Info.canonifyUrls {
 							menuEntryUrl = helpers.AddContextRoot(string(s.Info.BaseUrl), menuEntryUrl)
 						}
-						menuEntry.Url = s.prepUrl(menuEntryUrl)
+						menuEntry.Url = menuEntryUrl
 					}
 
 					if ret[name] == nil {

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -614,7 +614,7 @@ func (s *Site) getMenusFromConfig() Menus {
 					if strings.HasPrefix(menuEntry.Url, "/") {
 						// make it match the nodes
 						menuEntryUrl := menuEntry.Url
-						menuEntry.Url = s.prepUrl(menuEntryUrl)
+						menuEntryUrl = s.prepUrl(menuEntryUrl)
 						if !s.Info.canonifyUrls {
 							menuEntryUrl = helpers.AddContextRoot(string(s.Info.BaseUrl), menuEntryUrl)
 						}


### PR DESCRIPTION
When we have an absolute menu url specified in the config file
(e.g., `menu: { main: { name: "News", url: "/news" } }`),
its menu entry is generated by prefixing it with the BaseUrl.
The result is then run through prepUrl(), which uses helpers.Urlize to
convert urls such as 'My First Link' to 'my-first-link'.

The behaviour is backwards: we do not want to run helpers.Urlize on the
BaseUrl, only on the absolute component. Currently, a BaseUrl such as
'http://my.edu/ENG101' will be converted to 'http://my.edu/eng101',
resulting in broken links in all of my menus.

This commit switches the URL prep and BaseUrl prepending actions around. I
would argue that these URLs shouldn't be run through prepUrl anyway
because the site developer has specified them explicitly in a config file
and might be surprised for, e.g., URLs to change case, but that's another
commit for another time.