### PR TITLE
Version uses binary name instead of hugo

### DIFF
--- a/commands/version.go
+++ b/commands/version.go
@@ -58,7 +58,7 @@ func setBuildDate() {
 		fmt.Println(err)
 		return
 	}
-	fi, err := os.Lstat(filepath.Join(dir, "hugo"))
+	fi, err := os.Lstat(filepath.Join(dir, filepath.Base(fname)))
 	if err != nil {
 		fmt.Println(err)
 		return


### PR DESCRIPTION
On Windows the binary name is hugo.exe and running hugo version results in
this error:
    GetFileAttributesEx D:\Dev\Go\gopath\bin\hugo: The system cannot find the file specified.

This fixes that error and allows the binary name to be something other
than hugo on any OS.