### PR TITLE
ignore root path, no need strip traling slash

### DIFF
--- a/helpers/url.go
+++ b/helpers/url.go
@@ -15,11 +15,12 @@ package helpers
 
 import (
 	"fmt"
-	"github.com/PuerkitoBio/purell"
-	"github.com/spf13/viper"
 	"net/url"
 	"path"
 	"strings"
+
+	"github.com/PuerkitoBio/purell"
+	"github.com/spf13/viper"
 )
 
 type PathBridge struct {
@@ -120,8 +121,8 @@ func AddContextRoot(baseUrl, relativePath string) string {
 
 	newPath := path.Join(url.Path, relativePath)
 
-	// path strips traling slash
-	if strings.HasSuffix(relativePath, "/") {
+	// path strips traling slash, ignore root path.
+	if newPath != "/" && strings.HasSuffix(relativePath, "/") {
 		newPath += "/"
 	}
 	return newPath

--- a/helpers/url_test.go
+++ b/helpers/url_test.go
@@ -81,6 +81,8 @@ func TestAddContextRoot(t *testing.T) {
 		// cannot guess that the context root is already added int the example below
 		{"http://example.com/sub/", "/sub/foo", "/sub/sub/foo"},
 		{"http://example.com/тря", "/трям/", "/тря/трям/"},
+		{"http://example.com", "/", "/"},
+		{"http://example.com/bar", "//", "/bar/"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Sometimes I just want use that `{{ "/" | SafeUrl }}`, but in this case will generate `//` path, 
so we need ignore root path.