### PR TITLE
Fix for issue 839 and 490 on Windows

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -358,7 +358,7 @@ func NewWatcher(port int) error {
 						continue
 					}
 
-					isstatic := strings.HasPrefix(ev.Name, helpers.AbsPathify(viper.GetString("StaticDir"))) || strings.HasPrefix(ev.Name, helpers.AbsPathify("themes/"+viper.GetString("theme"))+"/static/")
+					isstatic := strings.HasPrefix(ev.Name, helpers.GetStaticDirPath()) || strings.HasPrefix(ev.Name, helpers.GetThemesDirPath())
 					static_changed = static_changed || isstatic
 					dynamic_changed = dynamic_changed || !isstatic
 

--- a/helpers/path.go
+++ b/helpers/path.go
@@ -174,9 +174,17 @@ func AbsPathify(inPath string) string {
 	return filepath.Clean(filepath.Join(viper.GetString("WorkingDir"), inPath))
 }
 
+func GetStaticDirPath() string {
+	return AbsPathify(viper.GetString("StaticDir"))
+}
+
+func GetThemesDirPath() string {
+	return AbsPathify("themes"+string(os.PathSeparator)+viper.GetString("theme")) + string(os.PathSeparator) + "static" + string(os.PathSeparator)
+}
+
 func MakeStaticPathRelative(inPath string) (string, error) {
-	staticDir := AbsPathify(viper.GetString("StaticDir"))
-	themeStaticDir := AbsPathify("themes/"+viper.GetString("theme")) + "/static/"
+	staticDir := GetStaticDirPath()
+	themeStaticDir := GetThemesDirPath()
 
 	return MakePathRelative(inPath, staticDir, themeStaticDir)
 }

--- a/helpers/path.go
+++ b/helpers/path.go
@@ -179,7 +179,7 @@ func GetStaticDirPath() string {
 }
 
 func GetThemesDirPath() string {
-	return AbsPathify("themes"+string(os.PathSeparator)+viper.GetString("theme")) + string(os.PathSeparator) + "static" + string(os.PathSeparator)
+	return AbsPathify(filepath.Join("themes", viper.GetString("theme"), "static"))
 }
 
 func MakeStaticPathRelative(inPath string) (string, error) {

--- a/livereload/livereload.go
+++ b/livereload/livereload.go
@@ -15,6 +15,7 @@ package livereload
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/websocket"
 )
@@ -44,7 +45,8 @@ func ForceRefresh() {
 
 func RefreshPath(s string) {
 	// Tell livereload a file has changed - will force a hard refresh if not CSS or an image
-	wsHub.broadcast <- []byte(`{"command":"reload","path":"` + s + "\"" + `,"originalPath":"","liveCSS":true,"liveImg":true}`)
+	url_path := strings.Replace(s, "\\", "/", -1) // If path has backslashes on Windows, make path work for URL
+	wsHub.broadcast <- []byte(`{"command":"reload","path":"` + url_path + "\"" + `,"originalPath":"","liveCSS":true,"liveImg":true}`)
 }
 
 func ServeJS(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
The paths were seen as changed but not static because of the backslashes in ev.Name. Once the backslashes were added, I discovered that the JSON sent to livereload was invalid and failed to work because it had backslashes.

Hence the code to replace the backslashes from the path to make them work in JSON and for the URL.

With this fix, changes to a stylesheet are shown on the page, and if it's a single file that changed, it's reflected in the browser without reloading the whole page.