### PR TITLE
Change "ctrl+c" to "Ctrl+C"

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -228,7 +228,7 @@ func build(watches ...bool) {
 
 	if BuildWatch {
 		jww.FEEDBACK.Println("Watching for changes in", helpers.AbsPathify(viper.GetString("ContentDir")))
-		jww.FEEDBACK.Println("Press ctrl+c to stop")
+		jww.FEEDBACK.Println("Press Ctrl+C to stop")
 		utils.CheckErr(NewWatcher(0))
 	}
 }

--- a/commands/server.go
+++ b/commands/server.go
@@ -126,7 +126,7 @@ func serve(port int) {
 
 	u.Scheme = "http"
 	jww.FEEDBACK.Printf("Web Server is available at %s\n", u.String())
-	fmt.Println("Press ctrl+c to stop")
+	fmt.Println("Press Ctrl+C to stop")
 
 	err = http.ListenAndServe(":"+strconv.Itoa(port), nil)
 	if err != nil {

--- a/docs/content/overview/quickstart.md
+++ b/docs/content/overview/quickstart.md
@@ -101,7 +101,7 @@ your content:
     in 5 ms
     Serving pages from exampleHugoSite/public
     Web Server is available at http://localhost:1313
-    Press ctrl+c to stop
+    Press Ctrl+C to stop
 
 We specified two options here:
 
@@ -133,7 +133,7 @@ Stop the Hugo process by hitting <kbd>Ctrl</kbd>+<kbd>C</kbd>. Then run the foll
     Watching for changes in exampleHugoSite/content
     Serving pages from exampleHugoSite/public
     Web Server is available at http://localhost:1313
-    Press ctrl+c to stop
+    Press Ctrl+C to stop
 
 Open your [favorite editor](http://vim.spf13.com/), edit and save your content, and watch as Hugo rebuilds and reloads automatically.
 

--- a/docs/content/overview/usage.md
+++ b/docs/content/overview/usage.md
@@ -71,7 +71,7 @@ is saved.
        28 pages created
        in 18 ms
        Watching for changes in /Users/spf13/Code/hugo/docs/content
-       Press ctrl+c to stop
+       Press Ctrl+C to stop
 
 Hugo can even run a server and create your site at the same time! Hugo
 implements [LiveReload](/extras/livereload/) technology to automatically reload any open pages in
@@ -80,7 +80,7 @@ all browsers (including mobile).
     $ hugo server -ws ~/mysite
        Watching for changes in /Users/spf13/Code/hugo/docs/content
        Web Server is available at http://localhost:1313
-       Press ctrl+c to stop
+       Press Ctrl+C to stop
        28 pages created
        0 tags created
        in 18 ms

--- a/docs/content/tutorials/creating-a-new-theme.md
+++ b/docs/content/tutorials/creating-a-new-theme.md
@@ -207,7 +207,7 @@ WARN: 2014/09/29 Unable to locate layout: [404.html]
 in 2 ms
 Serving pages from /Users/quoha/Sites/zafta/public
 Web Server is available at http://localhost:1313
-Press ctrl+c to stop
+Press Ctrl+C to stop
 ```
 
 Connect to the listed URL (it's on the line that starts with "Web Server"). If everything is working correctly, you should get a page that shows the following:
@@ -463,7 +463,7 @@ in 2 ms
 Watching for changes in /Users/quoha/Sites/zafta/content
 Serving pages from /Users/quoha/Sites/zafta/public
 Web Server is available at http://localhost:1313
-Press ctrl+c to stop
+Press Ctrl+C to stop
 INFO: 2014/09/29 File System Event: ["/Users/quoha/Sites/zafta/themes/zafta/layouts/index.html": MODIFY|ATTRIB]
 Change detected, rebuilding site
 


### PR DESCRIPTION
Hehe, really trivial patch.  I know that Jekyll uses `ctrl+c`, but I think most newcomers are more used to seeing `Ctrl+C`, corresponding to the key caps on our keyboards.  :-)