### PR TITLE
Very experimental support for mmark

### DIFF
--- a/helpers/general.go
+++ b/helpers/general.go
@@ -58,6 +58,8 @@ func GuessType(in string) string {
 	switch strings.ToLower(in) {
 	case "md", "markdown", "mdown":
 		return "markdown"
+	case "mmark":
+		return "mmark"
 	case "rst":
 		return "rst"
 	case "html", "htm":

--- a/helpers/general_test.go
+++ b/helpers/general_test.go
@@ -15,6 +15,7 @@ func TestGuessType(t *testing.T) {
 		{"markdown", "markdown"},
 		{"mdown", "markdown"},
 		{"rst", "rst"},
+		{"mmark", "mmark"},
 		{"html", "html"},
 		{"htm", "html"},
 		{"excel", "unknown"},


### PR DESCRIPTION
Piqued by @karland's mention of https://github.com/miekg/mmark, and noticing how it has the definition list support, I was interested to see how it would work with Hugo.  So, here is a quick patch to get it to work, mostly copied and modified from existing calls to blackfriday.  (No, I cannot yet write that many lines of Go off the top of my head yet.  Still learning.  :wink:)

To use, either name the content files as `*.mmark`, or add `markup = "mmark"` in the front matter of your `*.md` content files.

Also tracked as https://github.com/miekg/mmark/issues/3

Not all mmark HTML flags are exposed, and there are a few other details where I am unsure about, hence the experimental status.  Feel free to experiment!  Comments, discussions and contributions welcome!

Note: The experimental AsciiDoc support in PR #826 should go in first.