### PR TITLE
Print template parsing errors to aid troubleshooting

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -269,6 +269,7 @@ func (s *Site) Process() (err error) {
 		return
 	}
 	s.prepTemplates()
+	s.Tmpl.PrintErrors()
 	s.timerStep("initialize & template prep")
 	if err = s.CreatePages(); err != nil {
 		return

--- a/tpl/template.go
+++ b/tpl/template.go
@@ -50,6 +50,7 @@ type Template interface {
 	AddTemplate(name, tpl string) error
 	AddInternalTemplate(prefix, name, tpl string) error
 	AddInternalShortcode(name, tpl string) error
+	PrintErrors()
 }
 
 type templateErr struct {
@@ -1251,6 +1252,12 @@ func (t *GoHtmlTemplate) LoadTemplatesWithPrefix(absPath string, prefix string) 
 
 func (t *GoHtmlTemplate) LoadTemplates(absPath string) {
 	t.loadTemplates(absPath, "")
+}
+
+func (t *GoHtmlTemplate) PrintErrors() {
+	for _, e := range t.errors {
+		jww.ERROR.Println(e.err)
+	}
 }
 
 func init() {


### PR DESCRIPTION
Added a new Template.PrintErrors() function call,
used in hugolib/site.go#Process() so it does not clutter
up `go test -v ./...` results.

Special thanks to @tatsushid for mapping out the call trace
which makes it a lot easier to find the appropriate places
to place the Template.PrintErrors() call.

Fixes #316