### PR TITLE
[commands/new.go] Update theme.toml etc.

### DIFF
--- a/commands/new.go
+++ b/commands/new.go
@@ -1,3 +1,5 @@
+// Copyright © 2014-2015 Steve Francia <spf@spf13.com>.
+//
 // Licensed under the Simple Public License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/hugo/create"
@@ -72,7 +75,7 @@ as you see fit.
 	Run: NewTheme,
 }
 
-//NewContent adds new content to a Hugo site.
+// NewContent adds new content to a Hugo site.
 func NewContent(cmd *cobra.Command, args []string) {
 	InitializeConfig()
 
@@ -135,7 +138,7 @@ func NewSite(cmd *cobra.Command, args []string) {
 	createConfig(createpath, configFormat)
 }
 
-//NewTheme creates a new Hugo theme.
+// NewTheme creates a new Hugo theme.
 func NewTheme(cmd *cobra.Command, args []string) {
 	InitializeConfig()
 
@@ -169,7 +172,7 @@ func NewTheme(cmd *cobra.Command, args []string) {
 
 	by := []byte(`The MIT License (MIT)
 
-Copyright (c) 2014 YOUR_NAME_HERE
+Copyright (c) ` + time.Now().Format("2006") + ` YOUR_NAME_HERE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -200,7 +203,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 func mkdir(x ...string) {
 	p := filepath.Join(x...)
 
-	err := os.MkdirAll(p, 0777) // rwx, rw, r
+	err := os.MkdirAll(p, 0777) // before umask
 	if err != nil {
 		jww.FATAL.Fatalln(err)
 	}
@@ -217,19 +220,24 @@ func touchFile(x ...string) {
 
 func createThemeMD(inpath string) (err error) {
 
-	in := map[string]interface{}{
-		"name":        helpers.MakeTitle(filepath.Base(inpath)),
-		"license":     "MIT",
-		"source_repo": "",
-		"author":      "",
-		"description": "",
-		"tags":        []string{"", ""},
-	}
+	by := []byte(`name = "` + strings.Title(helpers.MakeTitle(filepath.Base(inpath))) + `"
+license = "MIT"
+licenselink = "https://github.com/.../.../LICENSE.md"
+description = ""
+homepage = "http://siteforthistheme.com/"
+tags = ["", ""]
+features = ["", ""]
 
-	by, err := parser.InterfaceToConfig(in, parser.FormatToLeadRune("toml"))
-	if err != nil {
-		return err
-	}
+[author]
+  name = ""
+  homepage = ""
+
+# If porting an existing theme
+[original]
+  name = ""
+  homepage = ""
+  repo = ""
+`)
 
 	err = helpers.WriteToDisk(filepath.Join(inpath, "theme.toml"), bytes.NewReader(by), hugofs.SourceFs)
 	if err != nil {
@@ -240,7 +248,11 @@ func createThemeMD(inpath string) (err error) {
 }
 
 func createConfig(inpath string, kind string) (err error) {
-	in := map[string]string{"baseurl": "http://yourSiteHere", "title": "my new hugo site", "languageCode": "en-us"}
+	in := map[string]string{
+		"baseurl":      "http://yourSiteHere/",
+		"title":        "My New Hugo Site",
+		"languageCode": "en-us",
+	}
 	kind = parser.FormatSanitize(kind)
 
 	by, err := parser.InterfaceToConfig(in, parser.FormatToLeadRune(kind))


### PR DESCRIPTION
- Add copyright years and author to the top of the file
- Write the current year from time.Now() to LICENSE.md
- Update theme.toml template to match that listed at https://github.com/spf13/hugoThemes/blob/master/README.md#themetoml
- Correct comment regarding `os.MkdirAll(p, 0777)`
- In createConfig(), split the `map[string]string` definition into multiple lines to facilitate future expansion.  Also add a trailing slash to sample "baseurl" definition.

----

### Note about the `theme.toml` template update:

Initially, I experimented with expanding the original `map[string]interface{}`:

```go
	in := map[string]interface{}{
		"name":        strings.Title(helpers.MakeTitle(filepath.Base(inpath))),
		"license":     "MIT",
		"licenselink": "",
		"description": "",
		"homepage":    "",
		"tags":        []string{"", ""},
		"features":    []string{"", ""},
		"author": map[string]interface{}{
			"name":     "",
			"homepage": "",
		},
		"original": map[string]interface{}{
			"author":   "",
			"homepage": "",
			"repo":     "",
		},
	}
```

However, since the map keys’ order isn't preserved, I thought it would be better to use `struct` instead.

```go
	in := struct {
		Name        string   `toml:"name"`
		License     string   `toml:"license"`
		LicenseLink string   `toml:"licenselink"`
		Description string   `toml:"description"`
		HomePage    string   `toml:"homepage"`
		Tags        []string `toml:"tags"`
		Features    []string `toml:"features"`
		Author      struct {
			Name     string `toml:"name"`
			HomePage string `toml:"homepage"`
		} `toml:"author"`
		Original struct {
			Name     string `toml:"name"`
			HomePage string `toml:"homepage"`
			Repo     string `toml:"repo"`
		} `toml:"original"`
	}{
		Name:     strings.Title(helpers.MakeTitle(filepath.Base(inpath))),
		License:  "MIT",
		Tags:     []string{"", ""},
		Features: []string{"", ""},
	}
```

Struct is less expensive than map, though the size of the `hugo` executable binary does increase by a little, around 10KB?

And, finally, to add a comment, I experimented with to this:

```go
	by = bytes.Replace(by, []byte("[original]"), []byte("# If porting an existing theme\n[original]"), 1)
```

But then I thought, as the `hugo` binary itself (as of v0.13-DEV) does not read any values from `theme.toml`, and since we do not allow `theme.yaml` or `theme.json`, why all the trouble?  Instead, the most efficient and flexible way to create `theme.toml` would be writing it out directly, the very same way we create `LICENSE.md`, and that is what you see in this Pull Request.  The `hugo` binary actually shrinks by 128 bytes (in Linux) after this!  :-)

But yes, we can always go back to using `struct` or `map` if necessary in a future release, hence the code blocks in this comment—for copy-and-paste.  ;-)