### PR TITLE
Fixed invalid link to partials in templates

### DIFF
--- a/docs/content/templates/content.md
+++ b/docs/content/templates/content.md
@@ -111,7 +111,7 @@ It makes use of [partial templates](/layout/partials/)
 
 ## project/single.html
 This content template is used for [spf13.com](http://spf13.com/).
-It makes use of [partial templates](/layout/partials/)
+It makes use of [partial templates](/templates/partials/)
 
 
     {{ partial "header.html" . }}

--- a/docs/content/templates/content.md
+++ b/docs/content/templates/content.md
@@ -63,7 +63,7 @@ same as the other types, but the directory must be called "\_default".
 
 ## post/single.html
 This content template is used for [spf13.com](http://spf13.com/).
-It makes use of [partial templates](/layout/partials/)
+It makes use of [partial templates](/templates/partials/)
 
     {{ partial "header.html" . }}
     {{ partial "subheader.html" . }}


### PR DESCRIPTION
I've found that those don't load the content in the website, but after I've seen that they are alias, however the alias work for "page variables" link but not for those.