### PR TITLE
Suppress errors for symbolic links witch point to a file.

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -279,7 +279,19 @@ func getDirList() []string {
 		}
 
 		if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
-			jww.ERROR.Printf("Symbolic links not supported, skipping '%s'", path)
+			link, err := filepath.EvalSymlinks(path)
+			if err != nil {
+				jww.ERROR.Printf("Cannot read symbolic link '%s', error was: %s", path, err)
+				return nil
+			}
+			linkfi, err := os.Stat(link)
+			if err != nil {
+				jww.ERROR.Printf("Cannot stat '%s', error was: %s", link, err)
+				return nil
+			}
+			if !linkfi.Mode().IsRegular() {
+				jww.ERROR.Printf("Symbolic links for directories not supported, skipping '%s'", path)
+			}
 			return nil
 		}
 

--- a/source/filesystem.go
+++ b/source/filesystem.go
@@ -15,13 +15,14 @@ package source
 
 import (
 	"bytes"
-	"github.com/spf13/hugo/helpers"
-	jww "github.com/spf13/jwalterweatherman"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/spf13/hugo/helpers"
+	jww "github.com/spf13/jwalterweatherman"
 )
 
 type Input interface {
@@ -85,7 +86,19 @@ func (f *Filesystem) captureFiles() {
 		}
 
 		if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
-			jww.ERROR.Printf("Symbolic links not supported, skipping '%s'", filePath)
+			link, err := filepath.EvalSymlinks(filePath)
+			if err != nil {
+				jww.ERROR.Printf("Cannot read symbolic link '%s', error was: %s", filePath, err)
+				return nil
+			}
+			linkfi, err := os.Stat(link)
+			if err != nil {
+				jww.ERROR.Printf("Cannot stat '%s', error was: %s", link, err)
+				return nil
+			}
+			if !linkfi.Mode().IsRegular() {
+				jww.ERROR.Printf("Symbolic links for directories not supported, skipping '%s'", filePath)
+			}
 			return nil
 		}
 

--- a/tpl/template.go
+++ b/tpl/template.go
@@ -1222,7 +1222,19 @@ func (t *GoHtmlTemplate) loadTemplates(absPath string, prefix string) {
 		}
 
 		if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
-			jww.ERROR.Printf("Symbolic links not supported, skipping '%s'", absPath)
+			link, err := filepath.EvalSymlinks(absPath)
+			if err != nil {
+				jww.ERROR.Printf("Cannot read symbolic link '%s', error was: %s", absPath, err)
+				return nil
+			}
+			linkfi, err := os.Stat(link)
+			if err != nil {
+				jww.ERROR.Printf("Cannot stat '%s', error was: %s", link, err)
+				return nil
+			}
+			if !linkfi.Mode().IsRegular() {
+				jww.ERROR.Printf("Symbolic links for directories not supported, skipping '%s'", absPath)
+			}
 			return nil
 		}
 


### PR DESCRIPTION
This pull does not log the error `Symbolic links for directories not supported, skipping` for symbolic links which point to a file.

I'm not sure if the reordering of imports in `filesystem.go` my edtior does are correct, seems to work here.