### PR TITLE
Updated the 'examples' section of the docs.

### DIFF
--- a/docs/content/extras/highlighting.md
+++ b/docs/content/extras/highlighting.md
@@ -49,7 +49,7 @@ If you want to highlight code, you need to either fence the code with ``` accord
 Not doing either will result in the text being rendered as HTML. This will prevent Pygments highlighting from working.
 
 ```
-{{</* highlight html */>}}
+{{% highlight html %}}
 <section id="main">
   <div>
     <h1 id="title">{{ .Title }}</h1>
@@ -58,7 +58,7 @@ Not doing either will result in the text being rendered as HTML. This will preve
     {{ end }}
   </div>
 </section>
-{{</* /highlight */>}}
+{{% /highlight %}}
 ```
 
 ### Example Output


### PR DESCRIPTION
The original gives usage as {{< highlight html >}}, when it should be {{% highlight html %}}