### PR TITLE
Fix eq and ne tpl function issue

### DIFF
--- a/tpl/template.go
+++ b/tpl/template.go
@@ -94,6 +94,21 @@ func New() Template {
 }
 
 func Eq(x, y interface{}) bool {
+	normalize := func(v interface{}) interface{} {
+		vv := reflect.ValueOf(v)
+		switch vv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return vv.Int()
+		case reflect.Float32, reflect.Float64:
+			return vv.Float()
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return vv.Uint()
+		default:
+			return v
+		}
+	}
+	x = normalize(x)
+	y = normalize(y)
 	return reflect.DeepEqual(x, y)
 }
 


### PR DESCRIPTION
`eq` and `ne` template functions don't work as expected when those are
used with a raw number and a calculated value by add, sub etc. It's
caused by both numbers type differences. For example, `eq 5 (add 2 3)`
returns `false` because raw 5 is `int` while `add 2 3` returns 5 with
`int64`

This normalizes `int`, `uint` and `float` type values to `int64`,
`uint64` and `float64` before comparing them. Other type of value is
passed to comparing function without any changes.

Fix #961