### PR TITLE
More initialism corrections (golint)

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -135,7 +135,7 @@ func serve(port int) {
 	}
 }
 
-// fixUrl massages the BaseUrl into a form needed for serving
+// fixURL massages the BaseURL into a form needed for serving
 // all pages correctly.
 func fixURL(s string) (string, error) {
 	useLocalhost := false
@@ -164,7 +164,7 @@ func fixURL(s string) (string, error) {
 		if strings.Contains(host, ":") {
 			host, _, err = net.SplitHostPort(u.Host)
 			if err != nil {
-				return "", fmt.Errorf("Failed to split BaseUrl hostpost: %s", err)
+				return "", fmt.Errorf("Failed to split BaseURL hostpost: %s", err)
 			}
 		}
 		u.Host = fmt.Sprintf("%s:%d", host, serverPort)

--- a/docs/content/content/organization.md
+++ b/docs/content/content/organization.md
@@ -67,7 +67,7 @@ This isn't in the front matter, but is the actual name of the file minus the
 extension. This will be the name of the file in the destination.
 
 ### slug
-Defined in the front matter, the slug can take the place of the filename for the
+Defined in the front matter, the `slug` can take the place of the filename for the
 destination.
 
 ### filepath
@@ -75,18 +75,18 @@ The actual path to the file on disk. Destination will create the destination
 with the same path. Includes [section](/content/sections/).
 
 ### section
-section can be provided in the front matter overriding the section derived from
+`section` can be provided in the front matter overriding the section derived from
 the source content location on disk. See [section](/content/sections/).
 
 ### path
-path can be provided in the front matter. This will replace the actual
+`path` can be provided in the front matter. This will replace the actual
 path to the file on disk. Destination will create the destination with the same
 path. Includes [section](/content/sections/).
 
 ### url
 A complete URL can be provided. This will override all the above as it pertains
-to the end destination. This must be the path from the baseurl (starting with a "/").
-When a url is provided, it will be used exactly. Using url will ignore the
+to the end destination. This must be the path from the baseURL (starting with a "/").
+When a `url` is provided, it will be used exactly. Using `url` will ignore the
 `--uglyUrls` setting.
 
 
@@ -116,27 +116,27 @@ When a url is provided, it will be used exactly. Using url will ignore the
     http://spf13.com/projects/hugo
 
 
-       baseUrl       section  slug
+       baseURL       section  slug
     ⊢-----^--------⊣ ⊢--^---⊣ ⊢-^⊣
     http://spf13.com/projects/hugo
 
 
-       baseUrl       section          slug
+       baseURL       section          slug
     ⊢-----^--------⊣ ⊢--^--⊣        ⊢--^--⊣
     http://spf13.com/extras/indexes/example
 
 
-       baseUrl            path       slug
+       baseURL            path       slug
     ⊢-----^--------⊣ ⊢------^-----⊣ ⊢--^--⊣
     http://spf13.com/extras/indexes/example
 
 
-       baseUrl            url
+       baseURL            url
     ⊢-----^--------⊣ ⊢-----^-----⊣
     http://spf13.com/projects/hugo
 
 
-       baseUrl               url
+       baseURL               url
     ⊢-----^--------⊣ ⊢--------^-----------⊣
     http://spf13.com/extras/indexes/example
 

--- a/docs/content/extras/dynamiccontent.md
+++ b/docs/content/extras/dynamiccontent.md
@@ -19,8 +19,8 @@ any [JSON](http://www.json.org/) or
 [CSV](http://en.wikipedia.org/wiki/Comma-separated_values) file
 from nearly any resource.
 
-"Dynamic Content" currently consists of two functions, `getJson`
-and `getCsv`, which are available in **all template files**.
+"Dynamic Content" currently consists of two functions, `getJSON`
+and `getCSV`, which are available in **all template files**.
 
 ## Implementation details
 
@@ -28,33 +28,33 @@ and `getCsv`, which are available in **all template files**.
 
 In any HTML template or Markdown document, call the functions like this:
 
-	{{ $dataJ := getJson "url" }}
-	{{ $dataC := getCsv "separator" "url" }}
+	{{ $dataJ := getJSON "url" }}
+	{{ $dataC := getCSV "separator" "url" }}
 
 or, if you use a prefix or postfix for the URL, the functions
 accept [variadic arguments](http://en.wikipedia.org/wiki/Variadic_function):
 
-	{{ $dataJ := getJson "url prefix" "arg1" "arg2" "arg n" }}
-	{{ $dataC := getCsv  "separator" "url prefix" "arg1" "arg2" "arg n" }}
+	{{ $dataJ := getJSON "url prefix" "arg1" "arg2" "arg n" }}
+	{{ $dataC := getCSV  "separator" "url prefix" "arg1" "arg2" "arg n" }}
 
-The separator for `getCsv` must be put in the first position and can only
+The separator for `getCSV` must be put in the first position and can only
 be one character long.
 
 All passed arguments will be joined to the final URL; for example:
 
 	{{ $urlPre := "https://api.github.com" }}
-	{{ $gistJ := getJson $urlPre "/users/GITHUB_USERNAME/gists" }}
+	{{ $gistJ := getJSON $urlPre "/users/GITHUB_USERNAME/gists" }}
 
 will resolve internally to:
 
-	{{ $gistJ := getJson "https://api.github.com/users/GITHUB_USERNAME/gists" }}
+	{{ $gistJ := getJSON "https://api.github.com/users/GITHUB_USERNAME/gists" }}
 
 Finally, you can range over an array. This example will output the
 first 5 gists for a GitHub user:
 
 	<ul>
 	  {{ $urlPre := "https://api.github.com" }}
-	  {{ $gistJ := getJson $urlPre "/users/GITHUB_USERNAME/gists" }}
+	  {{ $gistJ := getJSON $urlPre "/users/GITHUB_USERNAME/gists" }}
 	  {{ range first 5 $gistJ }}
 	    {{ if .public }}
 	      <li><a href="{{ .html_url }}" target="_blank">{{ .description }}</a></li>
@@ -65,7 +65,7 @@ first 5 gists for a GitHub user:
 
 ### Example for CSV files
 
-For `getCsv`, the one-character long separator must be placed in the
+For `getCSV`, the one-character long separator must be placed in the
 first position followed by the URL.
 
 	<table>
@@ -79,7 +79,7 @@ first position followed by the URL.
 	  <tbody>
 	  {{ $url := "http://a-big-corp.com/finance/employee-salaries.csv" }}
 	  {{ $sep := "," }}
-	  {{ range $i, $r := getCsv $sep $url }}
+	  {{ range $i, $r := getCSV $sep $url }}
 	    <tr>
 	      <td>{{ index $r 0 }}</td>
 	      <td>{{ index $r 1 }}</td>
@@ -113,7 +113,7 @@ other authentication methods are not implemented.
 
 ### Loading local files
 
-To load local files with the two functions `getJson` and `getCsv`, the
+To load local files with the two functions `getJSON` and `getCSV`, the
 source files must reside within Hugo's working directory. The file
 extension does not matter but the content.
 

--- a/docs/content/extras/menus.md
+++ b/docs/content/extras/menus.md
@@ -27,7 +27,7 @@ access it via `.Site.Menus.main`.
 
 A menu entry has the following properties:
 
-* **Url**        string
+* **URL**        string
 * **Name**       string
 * **Menu**       string
 * **Identifier** string
@@ -112,15 +112,15 @@ And the equivalent example `config.yaml`:
             Pre: "<i class='fa fa-heart'></i>"
             Weight: -110
             Identifier: "about"
-            Url: "/about/"
+            URL: "/about/"
           - Name: "getting started"
             Pre: "<i class='fa fa-road'></i>"
             Weight: -100
-            Url: "/getting-started/"
+            URL: "/getting-started/"
     ---            
 
 
-**NOTE:** The urls must be relative to the context root. If the `BaseUrl` is `http://example.com/mysite/`, then the urls in the menu must not include the context root `mysite`. 
+**NOTE:** The URLs must be relative to the context root. If the `BaseURL` is `http://example.com/mysite/`, then the URLs in the menu must not include the context root `mysite`.
   
 ## Nesting
 
@@ -164,12 +164,12 @@ The following is an example:
                 </a>
                 <ul class="sub">
                     {{ range .Children }}
-                    <li{{if $currentNode.IsMenuCurrent "main" . }} class="active"{{end}}><a href="{{.Url}}"> {{ .Name }} </a> </li>
+                    <li{{if $currentNode.IsMenuCurrent "main" . }} class="active"{{end}}><a href="{{.URL}}"> {{ .Name }} </a> </li>
                     {{ end }}
                 </ul>
               {{else}}
                 <li>
-                <a class="" href="{{.Url}}">
+                <a class="" href="{{.URL}}">
                     {{ .Pre }}
                     <span>{{ .Name }}</span>
                 </a>

--- a/docs/content/extras/pagination.md
+++ b/docs/content/extras/pagination.md
@@ -17,16 +17,16 @@ Hugo supports pagination for the home page, sections and taxonomies. It's built 
 
 Pagination can be configured in the site configuration (e.g. `config.toml`):
 
-* `Paginate` (default `10`) 
+* `Paginate` (default `10`)
 * `PaginatePath` (default `page`)
 
 Setting `Paginate` to a positive value will split the list pages for the home page, sections and taxonomies into chunks of that size. But note that the generation of the pagination pages for sections, taxonomies and home page is *lazy* --- the pages will not be created if not referenced by a `.Paginator` (see below).
 
- `PaginatePath` is used to adapt the `Url` to the pages in the paginator (the default setting will produce urls on the form `/page/1/`. 
+`PaginatePath` is used to adapt the `URL` to the pages in the paginator (the default setting will produce URLs on the form `/page/1/`.
 
 ## List the pages
 
-**A `.Paginator` is provided to help building a pager menu. This is only relevant for the templates for the home page and the list pages (sections and taxonomies).**  
+**A `.Paginator` is provided to help building a pager menu. This is only relevant for the templates for the home page and the list pages (sections and taxonomies).**
 
 There are two ways to configure and use a `.Paginator`:
 
@@ -37,7 +37,7 @@ For a given **Node**, it's one of the options above. The `.Paginator` is static 
 
 ## Build the navigation
 
-The `.Paginator` contains enough information to build a paginator interface. 
+The `.Paginator` contains enough information to build a paginator interface.
 
 The easiest way to add this to your pages is to include the built-in template (with `Bootstrap`-compatible styles):
 
@@ -67,7 +67,7 @@ Without the where-filter, the above is simpler:
 If you want to build custom navigation, you can do so using the `.Paginator` object:
 
 * `PageNumber`: The current page's number in the pager sequence
-* `Url`: The relative Url to the current pager
+* `URL`: The relative URL to the current pager
 * `Pages`: The pages in the current pager
 * `NumberOfElements`: The number of elements on this page
 * `HasPrev`: Whether there are page(s) before the current

--- a/docs/content/overview/configuration.md
+++ b/docs/content/overview/configuration.md
@@ -40,11 +40,11 @@ The following is an example of a toml config file with some of the default value
     builddrafts = false
     baseurl = "http://yoursite.example.com/"
     canonifyurls = true
-
+    
     [taxonomies]
       category = "categories"
       tag = "tags"
-       
+    
     [params]
       description = "Tesla's Awesome Hugo Site"
       author = "Nikola Tesla"
@@ -74,67 +74,67 @@ Following is a list of Hugo-defined variables that you can configure and their c
     ---
     archetypedir:               "archetype"
     # hostname (and path) to the root eg. http://spf13.com/
-    baseurl:                    "" 
+    baseURL:                    ""
     # include content marked as draft
-    buildDrafts:                false 
+    buildDrafts:                false
     # include content with datePublished in the future
-    buildFuture:                false 
-    canonifyUrls:               false
+    buildFuture:                false
+    canonifyURLs:               false
     # config file (default is path/config.yaml|json|toml)
-    config:                     "config.toml"    
+    config:                     "config.toml"
     contentdir:                 "content"
     dataDir:                    "data"
     defaultExtension:           "html"
     defaultLayout:              "post"
     # filesystem path to write files to
-    destination:                ""    
+    destination:                ""
     disableLiveReload:          false
     # Do not build RSS files
-    disableRSS:                 false 
+    disableRSS:                 false
     # Do not build Sitemap file
-    disableSitemap:             false 
+    disableSitemap:             false
     # edit new content with this editor, if provided
-    editor:                     ""    
+    editor:                     ""
     footnoteAnchorPrefix:       ""
     footnoteReturnLinkContents: ""
     languageCode:               ""
     layoutdir:                  "layouts"
     # Enable Logging
-    log:                        false 
+    log:                        false
     # Log File path (if set, logging enabled automatically)
-    logFile:                    ""    
+    logFile:                    ""
     # "yaml", "toml", "json"
-    metaDataFormat:             "toml" 
+    metaDataFormat:             "toml"
     newContentEditor:           ""
     # Don't sync modification time of files
-    noTimes:                    false 
+    noTimes:                    false
     paginate:                   10
     paginatePath:               "page"
-    permalinks:         
+    permalinks:
     # Pluralize titles in lists using inflect
-    pluralizeListTitles:         true 
+    pluralizeListTitles:         true
     publishdir:                 "public"
     # color-codes for highlighting derived from this style
     pygmentsStyle:              "monokai"
     # true: use pygments-css or false: color-codes directly
-    pygmentsUseClasses:         false 
+    pygmentsUseClasses:         false
     sitemap:                    ""
-    # filesystem path to read files relative from 
-    source:                     ""    
+    # filesystem path to read files relative from
+    source:                     ""
     staticdir:                  "static"
     # display memory and timing of different steps of the program
-    stepAnalysis:               false 
+    stepAnalysis:               false
     # theme to use (located in /themes/THEMENAME/)
-    theme:                      ""    
+    theme:                      ""
     title:                      ""
     # if true, use /filename.html instead of /filename/
-    uglyUrls:                   false 
+    uglyURLs:                   false
     # verbose output
-    verbose:                    false 
+    verbose:                    false
     # verbose logging
-    verboseLog:                 false 
+    verboseLog:                 false
     # watch filesystem for changes and recreate as needed
-    watch:                      false 
+    watch:                      false
     ---
 
 

--- a/docs/content/taxonomies/displaying.md
+++ b/docs/content/taxonomies/displaying.md
@@ -52,7 +52,7 @@ content.
 
     <ul>
       {{ range .Site.Taxonomies.series.golang }}
-        <li><a href="{{ .Url }}">{{ .Name }}</a></li>
+        <li><a href="{{ .URL }}">{{ .Name }}</a></li>
       {{ end }}
     </ul>
 

--- a/docs/content/templates/content.md
+++ b/docs/content/templates/content.md
@@ -67,7 +67,7 @@ It makes use of [partial templates](/templates/partials/)
 
     {{ partial "header.html" . }}
     {{ partial "subheader.html" . }}
-    {{ $baseurl := .Site.BaseUrl }}
+    {{ $baseurl := .Site.BaseURL }}
 
     <section id="main">
       <h1 id="title">{{ .Title }}</h1>
@@ -116,7 +116,7 @@ It makes use of [partial templates](/templates/partials/)
 
     {{ partial "header.html" . }}
     {{ partial "subheader.html" . }}
-    {{ $baseurl := .Site.BaseUrl }}
+    {{ $baseurl := .Site.BaseURL }}
 
     <section id="main">
       <h1 id="title">{{ .Title }}</h1>

--- a/docs/content/templates/functions.md
+++ b/docs/content/templates/functions.md
@@ -262,7 +262,7 @@ Takes a string and sanitizes it for usage in URLs, converts spaces to "-".
 
 e.g. `<a href="/tags/{{ . | urlize }}">{{ . }}</a>`
 
-### safeHtml
+### safeHTML
 Declares the provided string as a "safe" HTML document fragment
 so Go html/template will not filter it.  It should not be used
 for HTML from a third-party, or HTML with unclosed tags or comments.
@@ -271,11 +271,11 @@ Example: Given a site-wide `config.toml` that contains this line:
 
     copyright = "© 2015 Jane Doe.  <a href=\"http://creativecommons.org/licenses/by/4.0/\">Some rights reserved</a>."
 
-`{{ .Site.Copyright | safeHtml }}` would then output:
+`{{ .Site.Copyright | safeHTML }}` would then output:
 
 > © 2015 Jane Doe.  <a href="http://creativecommons.org/licenses/by/4.0/">Some rights reserved</a>.
 
-However, without the `safeHtml` function, html/template assumes
+However, without the `safeHTML` function, html/template assumes
 `.Site.Copyright` to be unsafe, escaping all HTML tags,
 rendering the whole string as plain-text like this:
 
@@ -284,7 +284,7 @@ rendering the whole string as plain-text like this:
 </blockquote>
 
 <!--
-### safeHtmlAttr
+### safeHTMLAttr
 Declares the provided string as a "safe" HTML attribute
 from a trusted source, for example, ` dir="ltr"`,
 so Go html/template will not filter it.
@@ -295,11 +295,11 @@ Example: Given a site-wide `config.toml` that contains this menu entry:
         name = "IRC: #golang at freenode"
         url = "irc://irc.freenode.net/#golang"
 
-* `<a href="{{ .Url }}">` ⇒ `<a href="#ZgotmplZ">` (Bad!)
-* `<a {{ printf "href=%q" .Url | safeHtmlAttr }}>` ⇒ `<a href="irc://irc.freenode.net/#golang">` (Good!)
+* `<a href="{{ .URL }}">` ⇒ `<a href="#ZgotmplZ">` (Bad!)
+* `<a {{ printf "href=%q" .URL | safeHTMLAttr }}>` ⇒ `<a href="irc://irc.freenode.net/#golang">` (Good!)
 -->
 
-### safeCss
+### safeCSS
 Declares the provided string as a known "safe" CSS string
 so Go html/templates will not filter it.
 "Safe" means CSS content that matches any of:
@@ -311,13 +311,13 @@ so Go html/templates will not filter it.
 
 Example: Given `style = "color: red;"` defined in the front matter of your `.md` file:
 
-* `<p style="{{ .Params.style | safeCss }}">…</p>` ⇒ `<p style="color: red;">…</p>` (Good!)
+* `<p style="{{ .Params.style | safeCSS }}">…</p>` ⇒ `<p style="color: red;">…</p>` (Good!)
 * `<p style="{{ .Params.style }}">…</p>` ⇒ `<p style="ZgotmplZ">…</p>` (Bad!)
 
 Note: "ZgotmplZ" is a special value that indicates that unsafe content reached a
 CSS or URL context.
 
-### safeUrl
+### safeURL
 Declares the provided string as a "safe" URL or URL substring (see [RFC 3986][]).
 A URL like `javascript:checkThatFormNotEditedBeforeLeavingPage()` from a trusted
 source should go in the page, but by default dynamic `javascript:` URLs are
@@ -325,7 +325,7 @@ filtered out since they are a frequently exploited injection vector.
 
 [RFC 3986]: http://tools.ietf.org/html/rfc3986
 
-Without `safeUrl`, only the URI schemes `http:`, `https:` and `mailto:`
+Without `safeURL`, only the URI schemes `http:`, `https:` and `mailto:`
 are considered safe by Go.  If any other URI schemes, e.g.&nbsp;`irc:` and
 `javascript:`, are detected, the whole URL would be replaced with
 `#ZgotmplZ`.  This is to "defang" any potential attack in the URL,
@@ -341,16 +341,16 @@ The following template:
 
     <ul class="sidebar-menu">
       {{ range .Site.Menus.main }}
-      <li><a href="{{ .Url }}">{{ .Name }}</a></li>
+      <li><a href="{{ .URL }}">{{ .Name }}</a></li>
       {{ end }}
     </ul>
 
 would produce `<li><a href="#ZgotmplZ">IRC: #golang at freenode</a></li>`
 for the `irc://…` URL.
 
-To fix this, add ` | safeUrl` after `.Url` on the 3rd line, like this:
+To fix this, add ` | safeURL` after `.URL` on the 3rd line, like this:
 
-      <li><a href="{{ .Url | safeUrl }}">{{ .Name }}</a></li>
+      <li><a href="{{ .URL | safeURL }}">{{ .Name }}</a></li>
 
 With this change, we finally get `<li><a href="irc://irc.freenode.net/#golang">IRC: #golang at freenode</a></li>`
 as intended.

--- a/docs/content/templates/go-templates.md
+++ b/docs/content/templates/go-templates.md
@@ -236,14 +236,14 @@ Could be rewritten as
 
 By default, Go Templates remove HTML comments from output. This has the unfortunate side effect of removing Internet Explorer conditional comments. As a workaround, use something like this:
 
-    {{ "<!--[if lt IE 9]>" | safeHtml }}
+    {{ "<!--[if lt IE 9]>" | safeHTML }}
       <script src="html5shiv.js"></script>
-    {{ "<![endif]-->" | safeHtml }}
+    {{ "<![endif]-->" | safeHTML }}
 
 Alternatively, use the backtick (`` ` ``) to quote the IE conditional comments, avoiding the tedious task of escaping every double quotes (`"`) inside, as demonstrated in the [examples](http://golang.org/pkg/text/template/#hdr-Examples) in the Go text/template documentation, e.g.:
 
 ```
-{{ `<!--[if lt IE 7]><html class="no-js lt-ie9 lt-ie8 lt-ie7"><![endif]-->` | safeHtml }}
+{{ `<!--[if lt IE 7]><html class="no-js lt-ie9 lt-ie8 lt-ie7"><![endif]-->` | safeHTML }}
 ```
 
 ## Context (a.k.a. the dot)
@@ -355,7 +355,7 @@ January 1st, instead of hunting through your templates.
 
 ```
 {{if .Site.Params.CopyrightHTML}}<footer>
-<div class="text-center">{{.Site.Params.CopyrightHTML | safeHtml}}</div>
+<div class="text-center">{{.Site.Params.CopyrightHTML | safeHTML}}</div>
 </footer>{{end}}
 ```
 

--- a/docs/content/templates/homepage.md
+++ b/docs/content/templates/homepage.md
@@ -56,7 +56,7 @@ It makes use of [partial templates](/templates/partials/) and uses a similar app
 
         {{ partial "meta.html" . }}
 
-        <base href="{{ .Site.BaseUrl }}">
+        <base href="{{ .Site.BaseURL }}">
         <title>{{ .Site.Title }}</title>
         <link rel="canonical" href="{{ .Permalink }}">
         <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />

--- a/docs/content/templates/partials.md
+++ b/docs/content/templates/partials.md
@@ -60,7 +60,7 @@ This header template is used for [spf13.com](http://spf13.com/):
 
         {{ partial "meta.html" . }}
 
-        <base href="{{ .Site.BaseUrl }}">
+        <base href="{{ .Site.BaseURL }}">
         <title> {{ .Title }} : spf13.com </title>
         <link rel="canonical" href="{{ .Permalink }}">
         {{ if .RSSlink }}<link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Title }}" />{{ end }}

--- a/docs/content/templates/sitemap.md
+++ b/docs/content/templates/sitemap.md
@@ -39,7 +39,7 @@ Protocol](http://www.sitemaps.org/protocol.html).
       {{ range .Data.Pages }}
       <url>
         <loc>{{ .Permalink }}</loc>
-        <lastmod>{{ safeHtml ( .Date.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ with .Sitemap.ChangeFreq }}
+        <lastmod>{{ safeHTML ( .Date.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ with .Sitemap.ChangeFreq }}
         <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
         <priority>{{ .Sitemap.Priority }}</priority>{{ end }}
       </url>

--- a/docs/content/templates/variables.md
+++ b/docs/content/templates/variables.md
@@ -72,7 +72,7 @@ includes taxonomies, lists and the homepage.
 **.Title**  The title for the content.<br>
 **.Date** The date the content is published on.<br>
 **.Permalink** The Permanent link for this node<br>
-**.Url** The relative URL for this node.<br>
+**.URL** The relative URL for this node.<br>
 **.Ref(ref)** Returns the permalink for `ref`. See [cross-references]({{% ref "extras/crossreferences.md" %}}). Does not handle in-page fragments correctly.<br>
 **.RelRef(ref)** Returns the relative permalink for `ref`. See [cross-references]({{% ref "extras/crossreferences.md" %}}). Does not handle in-page fragments correctly.<br>
 **.RSSLink** Link to the taxonomies' RSS link.<br>
@@ -86,7 +86,7 @@ includes taxonomies, lists and the homepage.
 
 Also available is `.Site` which has the following:
 
-**.Site.BaseUrl** The base URL for the site as defined in the site configuration file.<br>
+**.Site.BaseURL** The base URL for the site as defined in the site configuration file.<br>
 **.Site.Taxonomies** The [taxonomies](/taxonomies/usage/) for the entire site.  Replaces the now-obsolete `.Site.Indexes` since v0.11.<br>
 **.Site.LastChange** The date of the last change of the most recent content.<br>
 **.Site.Pages** Array of all content ordered by Date, newest first.  Replaces the now-deprecated `.Site.Recent` starting v0.13.<br>

--- a/docs/layouts/partials/menu.html
+++ b/docs/layouts/partials/menu.html
@@ -16,12 +16,12 @@
             </a>
                 <ul class="sub{{if $currentNode.HasMenuCurrent "main" . }} open{{end}}">
                     {{ range .Children }}
-                    <li{{if $currentNode.IsMenuCurrent "main" . }} class="active"{{end}}><a href="{{.Url}}">{{ .Name }}</a> </li>
+                    <li{{if $currentNode.IsMenuCurrent "main" . }} class="active"{{end}}><a href="{{.URL}}">{{ .Name }}</a> </li>
                     {{ end }}
                 </ul>
               {{else}}
                 <li>
-                <a class="" href="{{.Url}}">
+                <a class="" href="{{.URL}}">
                     {{ .Pre }}
                     <!--<i class="icon_house_alt"></i>-->
                     <span>{{ .Name }}</span>

--- a/helpers/path.go
+++ b/helpers/path.go
@@ -330,7 +330,7 @@ func PathPrep(ugly bool, in string) string {
 	return PrettifyPath(in)
 }
 
-// Same as PrettifyUrlPath() but for file paths.
+// Same as PrettifyURLPath() but for file paths.
 //     /section/name.html       becomes /section/name/index.html
 //     /section/name/           becomes /section/name/index.html
 //     /section/name/index.html becomes /section/name/index.html

--- a/helpers/url.go
+++ b/helpers/url.go
@@ -69,7 +69,7 @@ func sanitizeURLWithFlags(in string, f purell.NormalizationFlags) string {
 	// in issues #157, #622, etc., without forcing
 	// relative URLs to begin with '/'.
 	// Once the fixes are in, let's remove this kludge
-	// and restore SanitizeUrl() to the way it was.
+	// and restore SanitizeURL() to the way it was.
 	//                         -- @anthonyfok, 2015-02-16
 	//
 	// Begin temporary kludge
@@ -87,12 +87,12 @@ func sanitizeURLWithFlags(in string, f purell.NormalizationFlags) string {
 
 }
 
-// SanitizeUrl sanitizes the input URL string.
+// SanitizeURL sanitizes the input URL string.
 func SanitizeURL(in string) string {
 	return sanitizeURLWithFlags(in, purell.FlagsSafe|purell.FlagRemoveTrailingSlash|purell.FlagRemoveDotSegments|purell.FlagRemoveDuplicateSlashes|purell.FlagRemoveUnnecessaryHostDots|purell.FlagRemoveEmptyPortSeparator)
 }
 
-// SanitizeUrlKeepTrailingSlash is the same as SanitizeUrl, but will keep any trailing slash.
+// SanitizeURLKeepTrailingSlash is the same as SanitizeURL, but will keep any trailing slash.
 func SanitizeURLKeepTrailingSlash(in string) string {
 	return sanitizeURLWithFlags(in, purell.FlagsSafe|purell.FlagRemoveDotSegments|purell.FlagRemoveDuplicateSlashes|purell.FlagRemoveUnnecessaryHostDots|purell.FlagRemoveEmptyPortSeparator)
 }
@@ -147,7 +147,7 @@ func MakePermalink(host, plink string) *url.URL {
 
 // AddContextRoot adds the context root to an URL if it's not already set.
 // For relative URL entries on sites with a base url with a context root set (i.e. http://example.com/mysite),
-// relative URLs must not include the context root if canonifyUrls is enabled. But if it's disabled, it must be set.
+// relative URLs must not include the context root if canonifyURLs is enabled. But if it's disabled, it must be set.
 func AddContextRoot(baseURL, relativePath string) string {
 
 	url, err := url.Parse(baseURL)
@@ -185,7 +185,7 @@ func URLPrep(ugly bool, in string) string {
 	return url
 }
 
-// PrettifyUrl takes a URL string and returns a semantic, clean URL.
+// PrettifyURL takes a URL string and returns a semantic, clean URL.
 func PrettifyURL(in string) string {
 	x := PrettifyURLPath(in)
 
@@ -200,7 +200,7 @@ func PrettifyURL(in string) string {
 	return x
 }
 
-// PrettifyUrlPath takes a URL path to a content and converts it
+// PrettifyURLPath takes a URL path to a content and converts it
 // to enable pretty URLs.
 //     /section/name.html       becomes /section/name/index.html
 //     /section/name/           becomes /section/name/index.html
@@ -209,7 +209,7 @@ func PrettifyURLPath(in string) string {
 	return PrettiyPath(in, pathBridge)
 }
 
-// Uglify does the opposite of PrettifyUrlPath().
+// Uglify does the opposite of PrettifyURLPath().
 //     /section/name/index.html becomes /section/name.html
 //     /section/name/           becomes /section/name.html
 //     /section/name.html       becomes /section/name.html

--- a/helpers/url_test.go
+++ b/helpers/url_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestUrlize(t *testing.T) {
+func TestURLize(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected string
@@ -26,7 +26,7 @@ func TestUrlize(t *testing.T) {
 	}
 }
 
-func TestSanitizeUrl(t *testing.T) {
+func TestSanitizeURL(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected string
@@ -76,7 +76,7 @@ func TestMakePermalink(t *testing.T) {
 	}
 }
 
-func TestUrlPrep(t *testing.T) {
+func TestURLPrep(t *testing.T) {
 	type test struct {
 		ugly   bool
 		input  string

--- a/hugolib/menu.go
+++ b/hugolib/menu.go
@@ -19,10 +19,11 @@ import (
 	"strings"
 
 	"github.com/spf13/cast"
+	"github.com/spf13/hugo/helpers"
 )
 
 type MenuEntry struct {
-	Url        string
+	URL        string
 	Name       string
 	Menu       string
 	Identifier string
@@ -36,6 +37,12 @@ type MenuEntry struct {
 type Menu []*MenuEntry
 type Menus map[string]*Menu
 type PageMenus map[string]*MenuEntry
+
+// Url is deprecated. Will be removed in 0.15.
+func (me *MenuEntry) Url() string {
+	helpers.Deprecated("MenuEntry", ".Url", ".URL")
+	return me.URL
+}
 
 func (me *MenuEntry) AddChild(child *MenuEntry) {
 	me.Children = append(me.Children, child)
@@ -53,22 +60,22 @@ func (me *MenuEntry) KeyName() string {
 	return me.Name
 }
 
-func (me *MenuEntry) hopefullyUniqueId() string {
+func (me *MenuEntry) hopefullyUniqueID() string {
 	if me.Identifier != "" {
 		return me.Identifier
-	} else if me.Url != "" {
-		return me.Url
+	} else if me.URL != "" {
+		return me.URL
 	} else {
 		return me.Name
 	}
 }
 
 func (me *MenuEntry) IsEqual(inme *MenuEntry) bool {
-	return me.hopefullyUniqueId() == inme.hopefullyUniqueId() && me.Parent == inme.Parent
+	return me.hopefullyUniqueID() == inme.hopefullyUniqueID() && me.Parent == inme.Parent
 }
 
 func (me *MenuEntry) IsSameResource(inme *MenuEntry) bool {
-	return me.Url != "" && inme.Url != "" && me.Url == inme.Url
+	return me.URL != "" && inme.URL != "" && me.URL == inme.URL
 }
 
 func (me *MenuEntry) MarshallMap(ime map[string]interface{}) {
@@ -76,7 +83,7 @@ func (me *MenuEntry) MarshallMap(ime map[string]interface{}) {
 		loki := strings.ToLower(k)
 		switch loki {
 		case "url":
-			me.Url = cast.ToString(v)
+			me.URL = cast.ToString(v)
 		case "weight":
 			me.Weight = cast.ToInt(v)
 		case "name":

--- a/hugolib/menu_test.go
+++ b/hugolib/menu_test.go
@@ -180,8 +180,8 @@ func doTestPageMenuWithIdentifier(t *testing.T, menuPageSources []source.ByteSou
 	assert.NotNil(t, me1)
 	assert.NotNil(t, me2)
 
-	assert.True(t, strings.Contains(me1.Url, "doc1"))
-	assert.True(t, strings.Contains(me2.Url, "doc2"))
+	assert.True(t, strings.Contains(me1.URL, "doc1"))
+	assert.True(t, strings.Contains(me2.URL, "doc2"))
 
 }
 
@@ -216,8 +216,8 @@ func doTestPageMenuWithDuplicateName(t *testing.T, menuPageSources []source.Byte
 	assert.NotNil(t, me1)
 	assert.NotNil(t, me2)
 
-	assert.True(t, strings.Contains(me1.Url, "doc1"))
-	assert.True(t, strings.Contains(me2.Url, "doc2"))
+	assert.True(t, strings.Contains(me1.URL, "doc1"))
+	assert.True(t, strings.Contains(me2.URL, "doc2"))
 
 }
 
@@ -275,7 +275,7 @@ func TestMenuWithHashInURL(t *testing.T) {
 
 	assert.NotNil(t, me)
 
-	assert.Equal(t, "/Zoo/resource/#anchor", me.Url)
+	assert.Equal(t, "/Zoo/resource/#anchor", me.URL)
 }
 
 // issue #719
@@ -309,7 +309,7 @@ func doTestMenuWithUnicodeURLs(t *testing.T, canonifyURLs, uglyURLs bool) {
 		expected = expectedBase + "/"
 	}
 
-	assert.Equal(t, expected, unicodeRussian.Url, "uglyURLs[%t]", uglyURLs)
+	assert.Equal(t, expected, unicodeRussian.URL, "uglyURLs[%t]", uglyURLs)
 }
 
 func TestTaxonomyNodeMenu(t *testing.T) {
@@ -329,7 +329,7 @@ func TestTaxonomyNodeMenu(t *testing.T) {
 		{"tax", taxRenderInfo{key: "key", singular: "one", plural: "two"},
 			ts.findTestMenuEntryByID("tax", "2"), true, false},
 		{"tax", taxRenderInfo{key: "key", singular: "one", plural: "two"},
-			&MenuEntry{Name: "Somewhere else", Url: "/somewhereelse"}, false, false},
+			&MenuEntry{Name: "Somewhere else", URL: "/somewhereelse"}, false, false},
 	} {
 
 		n, _ := ts.site.newTaxonomyNode(this.taxInfo)
@@ -349,7 +349,7 @@ func TestTaxonomyNodeMenu(t *testing.T) {
 
 	menuEntryXML := ts.findTestMenuEntryByID("tax", "xml")
 
-	if strings.HasSuffix(menuEntryXML.Url, "/") {
+	if strings.HasSuffix(menuEntryXML.URL, "/") {
 		t.Error("RSS menu item should not be padded with trailing slash")
 	}
 }
@@ -359,7 +359,7 @@ func TestHomeNodeMenu(t *testing.T) {
 	defer resetMenuTestState(ts)
 
 	home := ts.site.newHomeNode()
-	homeMenuEntry := &MenuEntry{Name: home.Title, Url: home.Url}
+	homeMenuEntry := &MenuEntry{Name: home.Title, URL: home.URL}
 
 	for i, this := range []struct {
 		menu           string
@@ -369,7 +369,7 @@ func TestHomeNodeMenu(t *testing.T) {
 	}{
 		{"main", homeMenuEntry, true, false},
 		{"doesnotexist", homeMenuEntry, false, false},
-		{"main", &MenuEntry{Name: "Somewhere else", Url: "/somewhereelse"}, false, false},
+		{"main", &MenuEntry{Name: "Somewhere else", URL: "/somewhereelse"}, false, false},
 		{"grandparent", ts.findTestMenuEntryByID("grandparent", "grandparentId"), false, false},
 		{"grandparent", ts.findTestMenuEntryByID("grandparent", "parentId"), false, true},
 		{"grandparent", ts.findTestMenuEntryByID("grandparent", "grandchildId"), true, false},

--- a/hugolib/node.go
+++ b/hugolib/node.go
@@ -17,6 +17,7 @@ import (
 	"html/template"
 	"sync"
 	"time"
+	"github.com/spf13/hugo/helpers"
 )
 
 type Node struct {
@@ -30,7 +31,7 @@ type Node struct {
 	Params      map[string]interface{}
 	Date        time.Time
 	Sitemap     Sitemap
-	UrlPath
+	URLPath
 	paginator     *pager
 	paginatorInit sync.Once
 	scratch       *Scratch
@@ -42,7 +43,7 @@ func (n *Node) Now() time.Time {
 
 func (n *Node) HasMenuCurrent(menuID string, inme *MenuEntry) bool {
 	if inme.HasChildren() {
-		me := MenuEntry{Name: n.Title, Url: n.Url}
+		me := MenuEntry{Name: n.Title, URL: n.URL}
 
 		for _, child := range inme.Children {
 			if me.IsSameResource(child) {
@@ -56,7 +57,7 @@ func (n *Node) HasMenuCurrent(menuID string, inme *MenuEntry) bool {
 
 func (n *Node) IsMenuCurrent(menuID string, inme *MenuEntry) bool {
 
-	me := MenuEntry{Name: n.Title, Url: n.Url}
+	me := MenuEntry{Name: n.Title, URL: n.URL}
 	if !me.IsSameResource(inme) {
 		return false
 	}
@@ -119,11 +120,17 @@ func (n *Node) RelRef(ref string) (string, error) {
 	return n.Site.RelRef(ref, nil)
 }
 
-type UrlPath struct {
-	Url       string
+type URLPath struct {
+	URL       string
 	Permalink template.HTML
 	Slug      string
 	Section   string
+}
+
+// Url is deprecated. Will be removed in 0.15.
+func (n *Node) Url() string {
+	helpers.Deprecated("Node", ".Url", ".URL")
+	return n.URL
 }
 
 // Scratch returns the writable context associated with this Node.

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -341,10 +341,10 @@ func (p *Page) analyzePage() {
 }
 
 func (p *Page) permalink() (*url.URL, error) {
-	baseURL := string(p.Site.BaseUrl)
+	baseURL := string(p.Site.BaseURL)
 	dir := strings.TrimSpace(filepath.ToSlash(p.Source.Dir()))
 	pSlug := strings.TrimSpace(p.Slug)
-	pURL := strings.TrimSpace(p.Url)
+	pURL := strings.TrimSpace(p.URL)
 	var permalink string
 	var err error
 
@@ -420,9 +420,9 @@ func (p *Page) RelPermalink() (string, error) {
 	}
 
 	if viper.GetBool("CanonifyURLs") {
-		// replacements for relpermalink with baseUrl on the form http://myhost.com/sub/ will fail later on
-		// have to return the Url relative from baseUrl
-		relpath, err := helpers.GetRelativePath(link.String(), string(p.Site.BaseUrl))
+		// replacements for relpermalink with baseURL on the form http://myhost.com/sub/ will fail later on
+		// have to return the URL relative from baseURL
+		relpath, err := helpers.GetRelativePath(link.String(), string(p.Site.BaseURL))
 		if err != nil {
 			return "", err
 		}
@@ -455,9 +455,9 @@ func (p *Page) update(f interface{}) error {
 			p.Slug = helpers.URLize(cast.ToString(v))
 		case "url":
 			if url := cast.ToString(v); strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
-				return fmt.Errorf("Only relative urls are supported, %v provided", url)
+				return fmt.Errorf("Only relative URLs are supported, %v provided", url)
 			}
-			p.Url = helpers.URLize(cast.ToString(v))
+			p.URL = helpers.URLize(cast.ToString(v))
 		case "type":
 			p.contentType = cast.ToString(v)
 		case "extension", "ext":
@@ -588,7 +588,7 @@ func (p *Page) Menus() PageMenus {
 		if ms, ok := p.Params["menu"]; ok {
 			link, _ := p.RelPermalink()
 
-			me := MenuEntry{Name: p.LinkTitle(), Weight: p.Weight, Url: link}
+			me := MenuEntry{Name: p.LinkTitle(), Weight: p.Weight, URL: link}
 
 			// Could be the name of the menu to attach it to
 			mname, err := cast.ToStringE(ms)
@@ -618,7 +618,7 @@ func (p *Page) Menus() PageMenus {
 			}
 
 			for name, menu := range menus {
-				menuEntry := MenuEntry{Name: p.LinkTitle(), Url: link, Weight: p.Weight, Menu: name}
+				menuEntry := MenuEntry{Name: p.LinkTitle(), URL: link, Weight: p.Weight, Menu: name}
 				jww.DEBUG.Printf("found menu: %q, in %q\n", name, p.Title)
 
 				ime, err := cast.ToStringMapE(menu)
@@ -785,9 +785,9 @@ func (p *Page) FullFilePath() string {
 
 func (p *Page) TargetPath() (outfile string) {
 
-	// Always use Url if it's specified
-	if len(strings.TrimSpace(p.Url)) > 2 {
-		outfile = strings.TrimSpace(p.Url)
+	// Always use URL if it's specified
+	if len(strings.TrimSpace(p.URL)) > 2 {
+		outfile = strings.TrimSpace(p.URL)
 
 		if strings.HasSuffix(outfile, "/") {
 			outfile = outfile + "index.html"

--- a/hugolib/page_permalink_test.go
+++ b/hugolib/page_permalink_test.go
@@ -35,7 +35,7 @@ func TestPermalink(t *testing.T) {
 		{"x/y/z/boofar.md", "x/y/z/", "http://barnew/boo/", "boofar", "", true, true, "http://barnew/boo/x/y/z/boofar.html", "/x/y/z/boofar.html"},
 		{"x/y/z/boofar.md", "x/y/z/", "http://barnew/boo", "boofar", "", true, true, "http://barnew/boo/x/y/z/boofar.html", "/x/y/z/boofar.html"},
 
-		// test url overrides
+		// test URL overrides
 		{"x/y/z/boofar.md", "x/y/z", "", "", "/z/y/q/", false, false, "/z/y/q/", "/z/y/q/"},
 	}
 
@@ -46,12 +46,12 @@ func TestPermalink(t *testing.T) {
 		viper.Set("canonifyurls", test.canonifyURLs)
 		p := &Page{
 			Node: Node{
-				UrlPath: UrlPath{
+				URLPath: URLPath{
 					Section: "z",
-					Url:     test.url,
+					URL:     test.url,
 				},
 				Site: &SiteInfo{
-					BaseUrl: test.base,
+					BaseURL: test.base,
 				},
 			},
 			Source: Source{File: *source.NewFile(filepath.FromSlash(test.file))},

--- a/hugolib/pagination.go
+++ b/hugolib/pagination.go
@@ -47,9 +47,15 @@ func (p *pager) PageNumber() int {
 	return p.number
 }
 
-// Url returns the url to the current page.
-func (p *pager) Url() template.HTML {
+// URL returns the URL to the current page.
+func (p *pager) URL() template.HTML {
 	return template.HTML(p.paginationURLFactory(p.PageNumber()))
+}
+
+// Url is deprecated. Will be removed in 0.15.
+func (p *pager) Url() template.HTML {
+    helpers.Deprecated("Paginator", ".Url", ".URL")
+    return p.URL()
 }
 
 // Pages returns the elements on this page.
@@ -142,7 +148,7 @@ func (n *Node) Paginator() (*pager, error) {
 			return
 		}
 
-		pagers, err := paginatePages(n.Data["Pages"], n.Url)
+		pagers, err := paginatePages(n.Data["Pages"], n.URL)
 
 		if err != nil {
 			initError = err
@@ -184,7 +190,7 @@ func (n *Node) Paginate(seq interface{}) (*pager, error) {
 		if n.paginator != nil {
 			return
 		}
-		pagers, err := paginatePages(seq, n.Url)
+		pagers, err := paginatePages(seq, n.URL)
 
 		if err != nil {
 			initError = err

--- a/hugolib/pagination_test.go
+++ b/hugolib/pagination_test.go
@@ -43,7 +43,7 @@ func TestPager(t *testing.T) {
 	assert.Equal(t, 5, paginator.TotalPages())
 
 	first := paginatorPages[0]
-	assert.Equal(t, "page/1/", first.Url())
+	assert.Equal(t, "page/1/", first.URL())
 	assert.Equal(t, first, first.First())
 	assert.True(t, first.HasNext())
 	assert.Equal(t, paginatorPages[1], first.Next())
@@ -58,7 +58,7 @@ func TestPager(t *testing.T) {
 	assert.Equal(t, paginatorPages[1], third.Prev())
 
 	last := paginatorPages[4]
-	assert.Equal(t, "page/5/", last.Url())
+	assert.Equal(t, "page/5/", last.URL())
 	assert.Equal(t, last, last.Last())
 	assert.False(t, last.HasNext())
 	assert.Nil(t, last.Next())
@@ -97,7 +97,7 @@ func TestPagerNoPages(t *testing.T) {
 
 }
 
-func TestPaginationUrlFactory(t *testing.T) {
+func TestPaginationURLFactory(t *testing.T) {
 	viper.Set("PaginatePath", "zoo")
 	unicode := newPaginationURLFactory("новости проекта")
 	fooBar := newPaginationURLFactory("foo", "bar")
@@ -197,12 +197,12 @@ func createTestPages(num int) Pages {
 	for i := 0; i < num; i++ {
 		pages[i] = &Page{
 			Node: Node{
-				UrlPath: UrlPath{
+				URLPath: URLPath{
 					Section: "z",
-					Url:     fmt.Sprintf("http://base/x/y/p%d.html", num),
+					URL:     fmt.Sprintf("http://base/x/y/p%d.html", num),
 				},
 				Site: &SiteInfo{
-					BaseUrl: "http://base/",
+					BaseURL: "http://base/",
 				},
 			},
 			Source: Source{File: *source.NewFile(filepath.FromSlash(fmt.Sprintf("/x/y/p%d.md", num)))},

--- a/hugolib/permalinks.go
+++ b/hugolib/permalinks.go
@@ -138,7 +138,7 @@ func pageToPermalinkDate(p *Page, dateField string) (string, error) {
 // pageToPermalinkTitle returns the URL-safe form of the title
 func pageToPermalinkTitle(p *Page, _ string) (string, error) {
 	// Page contains Node which has Title
-	// (also contains UrlPath which has Slug, sometimes)
+	// (also contains URLPath which has Slug, sometimes)
 	return helpers.URLize(p.Title), nil
 }
 
@@ -166,7 +166,7 @@ func pageToPermalinkSlugElseTitle(p *Page, a string) (string, error) {
 }
 
 func pageToPermalinkSection(p *Page, _ string) (string, error) {
-	// Page contains Node contains UrlPath which has Section
+	// Page contains Node contains URLPath which has Section
 	return p.Section(), nil
 }
 

--- a/target/page_test.go
+++ b/target/page_test.go
@@ -62,7 +62,7 @@ func TestPageTranslatorBase(t *testing.T) {
 	}
 }
 
-func TestTranslateUglyUrls(t *testing.T) {
+func TestTranslateUglyURLs(t *testing.T) {
 	tests := []struct {
 		content  string
 		expected string

--- a/tpl/template.go
+++ b/tpl/template.go
@@ -938,7 +938,7 @@ func SafeHTML(text string) template.HTML {
 	return template.HTML(text)
 }
 
-// "safeHtmlAttr" is currently disabled, pending further discussion
+// "safeHTMLAttr" is currently disabled, pending further discussion
 // on its use case.  2015-01-19
 func SafeHTMLAttr(text string) template.HTMLAttr {
 	return template.HTMLAttr(text)
@@ -1308,11 +1308,8 @@ func init() {
 		"isset":       IsSet,
 		"echoParam":   ReturnWhenSet,
 		"safeHTML":    SafeHTML,
-		"safeHtml":    SafeHTML,
 		"safeCSS":     SafeCSS,
-		"safeCss":     SafeCSS,
 		"safeURL":     SafeURL,
-		"safeUrl":     SafeURL,
 		"markdownify": Markdownify,
 		"first":       First,
 		"where":       Where,
@@ -1337,11 +1334,35 @@ func init() {
 		"trim":        Trim,
 		"dateFormat":  DateFormat,
 		"getJSON":     GetJSON,
-		"getJson":     GetJSON,
 		"getCSV":      GetCSV,
-		"getCsv":      GetCSV,
 		"seq":         helpers.Seq,
 		"getenv":      func(varName string) string { return os.Getenv(varName) },
+
+		// "getJson" is deprecated. Will be removed in 0.15.
+		"getJson": func(urlParts ...string) interface{} {
+			helpers.Deprecated("Template", "getJson", "getJSON")
+			return GetJSON(urlParts...)
+		},
+		// "getJson" is deprecated. Will be removed in 0.15.
+		"getCsv": func(sep string, urlParts ...string) [][]string {
+			helpers.Deprecated("Template", "getCsv", "getCSV")
+			return GetCSV(sep, urlParts...)
+		},
+		// "safeHtml" is deprecated. Will be removed in 0.15.
+		"safeHtml": func(text string) template.HTML {
+			helpers.Deprecated("Template", "safeHtml", "safeHTML")
+			return SafeHTML(text)
+		},
+		// "safeCss" is deprecated. Will be removed in 0.15.
+		"safeCss": func(text string) template.CSS {
+			helpers.Deprecated("Template", "safeCss", "safeCSS")
+			return SafeCSS(text)
+		},
+		// "safeUrl" is deprecated. Will be removed in 0.15.
+		"safeUrl": func(text string) template.URL {
+			helpers.Deprecated("Template", "safeUrl", "safeURL")
+			return SafeURL(text)
+		},
 	}
 
 }

--- a/tpl/template_embedded.go
+++ b/tpl/template_embedded.go
@@ -55,13 +55,13 @@ func (t *GoHTMLTemplate) EmbedTemplates() {
     <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
     <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
-    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHtml }}</lastBuildDate>{{ end }}
-    <atom:link href="{{.Url}}" rel="self" type="application/rss+xml" />
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    <atom:link href="{{.URL}}" rel="self" type="application/rss+xml" />
     {{ range first 15 .Data.Pages }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
-      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHtml }}</pubDate>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Content | html }}</description>
@@ -74,7 +74,7 @@ func (t *GoHTMLTemplate) EmbedTemplates() {
   {{ range .Data.Pages }}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Date.IsZero }}
-    <lastmod>{{ safeHtml ( .Date.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+    <lastmod>{{ safeHTML ( .Date.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
     <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
     <priority>{{ .Sitemap.Priority }}</priority>{{ end }}
   </url>
@@ -86,24 +86,24 @@ func (t *GoHTMLTemplate) EmbedTemplates() {
     <ul class="pagination">
         {{ with $pag.First }}
         <li>
-            <a href="{{ .Url }}" aria-label="First"><span aria-hidden="true">&laquo;&laquo;</span></a>
+            <a href="{{ .URL }}" aria-label="First"><span aria-hidden="true">&laquo;&laquo;</span></a>
         </li>
         {{ end }}
         <li
         {{ if not $pag.HasPrev }}class="disabled"{{ end }}>
-        <a href="{{ if $pag.HasPrev }}{{ $pag.Prev.Url }}{{ end }}" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a>
+        <a href="{{ if $pag.HasPrev }}{{ $pag.Prev.URL }}{{ end }}" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a>
         </li>
         {{ range $pag.Pagers }}
         <li
-        {{ if eq . $pag }}class="active"{{ end }}><a href="{{ .Url }}">{{ .PageNumber }}</a></li>
+        {{ if eq . $pag }}class="active"{{ end }}><a href="{{ .URL }}">{{ .PageNumber }}</a></li>
         {{ end }}
         <li
         {{ if not $pag.HasNext }}class="disabled"{{ end }}>
-        <a href="{{ if $pag.HasNext }}{{ $pag.Next.Url }}{{ end }}" aria-label="Next"><span aria-hidden="true">&raquo;</span></a>
+        <a href="{{ if $pag.HasNext }}{{ $pag.Next.URL }}{{ end }}" aria-label="Next"><span aria-hidden="true">&raquo;</span></a>
         </li>
         {{ with $pag.Last }}
         <li>
-            <a href="{{ .Url }}" aria-label="Last"><span aria-hidden="true">&raquo;&raquo;</span></a>
+            <a href="{{ .URL }}" aria-label="Last"><span aria-hidden="true">&raquo;&raquo;</span></a>
         </li>
         {{ end }}
     </ul>
@@ -134,7 +134,7 @@ func (t *GoHTMLTemplate) EmbedTemplates() {
   <meta property="og:image" content="{{ . }}" />
 {{ end }}{{ end }}
 
-{{ if not .Date.IsZero }}<meta property="og:updated_time" content="{{ .Date.Format "2006-01-02T15:04:05-07:00" | safeHtml }}"/>{{ end }}{{ with .Params.audio }}
+{{ if not .Date.IsZero }}<meta property="og:updated_time" content="{{ .Date.Format "2006-01-02T15:04:05-07:00" | safeHTML }}"/>{{ end }}{{ with .Params.audio }}
 <meta property="og:audio" content="{{ . }}" />{{ end }}{{ with .Params.locale }}
 <meta property="og:locale" content="{{ . }}" />{{ end }}{{ with .Site.Params.title }}
 <meta property="og:site_name" content="{{ . }}" />{{ end }}{{ with .Params.videos }}
@@ -193,8 +193,8 @@ func (t *GoHTMLTemplate) EmbedTemplates() {
 <meta itemprop="description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}">
 
 {{if .IsPage}}{{ $ISO8601 := "2006-01-02T15:04:05-07:00" }}{{ if not .PublishDate.IsZero }}
-<meta itemprop="datePublished" content="{{ .PublishDate.Format $ISO8601 | safeHtml }}" />{{ end }}
-{{ if not .Date.IsZero }}<meta itemprop="dateModified" content="{{ .Date.Format $ISO8601 | safeHtml }}" />{{ end }}
+<meta itemprop="datePublished" content="{{ .PublishDate.Format $ISO8601 | safeHTML }}" />{{ end }}
+{{ if not .Date.IsZero }}<meta itemprop="dateModified" content="{{ .Date.Format $ISO8601 | safeHTML }}" />{{ end }}
 <meta itemprop="wordCount" content="{{ .WordCount }}">
 {{ with .Params.images }}{{ range first 6 . }}
   <meta itemprop="image" content="{{ . }}">

--- a/tpl/template_resources.go
+++ b/tpl/template_resources.go
@@ -38,7 +38,7 @@ type remoteLock struct {
 	m map[string]*sync.Mutex
 }
 
-// resLock locks an URL during download
+// URLLock locks an URL during download
 func (l *remoteLock) URLLock(url string) {
 	l.Lock()
 	if _, ok := l.m[url]; !ok {
@@ -48,7 +48,7 @@ func (l *remoteLock) URLLock(url string) {
 	l.m[url].Lock()
 }
 
-// resUnlock unlocks an URL when the download has been finished. Use only in defer calls.
+// URLUnlock unlocks an URL when the download has been finished. Use only in defer calls.
 func (l *remoteLock) URLUnlock(url string) {
 	l.RLock()
 	defer l.RUnlock()
@@ -57,7 +57,7 @@ func (l *remoteLock) URLUnlock(url string) {
 	}
 }
 
-// getFileID returns the cache ID for a string
+// getCacheFileID returns the cache ID for a string
 func getCacheFileID(id string) string {
 	return viper.GetString("CacheDir") + url.QueryEscape(id)
 }
@@ -173,9 +173,9 @@ func resGetResource(url string) ([]byte, error) {
 	return resGetLocal(url, hugofs.SourceFs)
 }
 
-// GetJson expects one or n-parts of a URL to a resource which can either be a local or a remote one.
+// GetJSON expects one or n-parts of a URL to a resource which can either be a local or a remote one.
 // If you provide multiple parts they will be joined together to the final URL.
-// GetJson returns nil or parsed JSON to use in a short code.
+// GetJSON returns nil or parsed JSON to use in a short code.
 func GetJSON(urlParts ...string) interface{} {
 	url := strings.Join(urlParts, "")
 	c, err := resGetResource(url)
@@ -193,7 +193,7 @@ func GetJSON(urlParts ...string) interface{} {
 	return v
 }
 
-// parseCsv parses bytes of csv data into a slice slice string or an error
+// parseCSV parses bytes of CSV data into a slice slice string or an error
 func parseCSV(c []byte, sep string) ([][]string, error) {
 	if len(sep) != 1 {
 		return nil, errors.New("Incorrect length of csv separator: " + sep)
@@ -206,11 +206,11 @@ func parseCSV(c []byte, sep string) ([][]string, error) {
 	return r.ReadAll()
 }
 
-// GetCsv expects a data separator and one or n-parts of a URL to a resource which
+// GetCSV expects a data separator and one or n-parts of a URL to a resource which
 // can either be a local or a remote one.
 // The data separator can be a comma, semi-colon, pipe, etc, but only one character.
 // If you provide multiple parts for the URL they will be joined together to the final URL.
-// GetCsv returns nil or a slice slice to use in a short code.
+// GetCSV returns nil or a slice slice to use in a short code.
 func GetCSV(sep string, urlParts ...string) [][]string {
 	url := strings.Join(urlParts, "")
 	c, err := resGetResource(url)

--- a/tpl/template_test.go
+++ b/tpl/template_test.go
@@ -999,10 +999,10 @@ func TestSafeHTML(t *testing.T) {
 		buf.Reset()
 		err = tmpl.Execute(buf, SafeHTML(this.str))
 		if err != nil {
-			t.Errorf("[%d] execute template with an escaped string value by SafeHtml returns unexpected error: %s", i, err)
+			t.Errorf("[%d] execute template with an escaped string value by SafeHTML returns unexpected error: %s", i, err)
 		}
 		if buf.String() != this.expectWithEscape {
-			t.Errorf("[%d] execute template with an escaped string value by SafeHtml, got %v but expected %v", i, buf.String(), this.expectWithEscape)
+			t.Errorf("[%d] execute template with an escaped string value by SafeHTML, got %v but expected %v", i, buf.String(), this.expectWithEscape)
 		}
 	}
 }
@@ -1034,10 +1034,10 @@ func TestSafeHTMLAttr(t *testing.T) {
 		buf.Reset()
 		err = tmpl.Execute(buf, SafeHTMLAttr(this.str))
 		if err != nil {
-			t.Errorf("[%d] execute template with an escaped string value by SafeHtmlAttr returns unexpected error: %s", i, err)
+			t.Errorf("[%d] execute template with an escaped string value by SafeHTMLAttr returns unexpected error: %s", i, err)
 		}
 		if buf.String() != this.expectWithEscape {
-			t.Errorf("[%d] execute template with an escaped string value by SafeHtmlAttr, got %v but expected %v", i, buf.String(), this.expectWithEscape)
+			t.Errorf("[%d] execute template with an escaped string value by SafeHTMLAttr, got %v but expected %v", i, buf.String(), this.expectWithEscape)
 		}
 	}
 }
@@ -1069,10 +1069,10 @@ func TestSafeCSS(t *testing.T) {
 		buf.Reset()
 		err = tmpl.Execute(buf, SafeCSS(this.str))
 		if err != nil {
-			t.Errorf("[%d] execute template with an escaped string value by SafeCss returns unexpected error: %s", i, err)
+			t.Errorf("[%d] execute template with an escaped string value by SafeCSS returns unexpected error: %s", i, err)
 		}
 		if buf.String() != this.expectWithEscape {
-			t.Errorf("[%d] execute template with an escaped string value by SafeCss, got %v but expected %v", i, buf.String(), this.expectWithEscape)
+			t.Errorf("[%d] execute template with an escaped string value by SafeCSS, got %v but expected %v", i, buf.String(), this.expectWithEscape)
 		}
 	}
 }
@@ -1104,10 +1104,10 @@ func TestSafeURL(t *testing.T) {
 		buf.Reset()
 		err = tmpl.Execute(buf, SafeURL(this.str))
 		if err != nil {
-			t.Errorf("[%d] execute template with an escaped string value by SafeUrl returns unexpected error: %s", i, err)
+			t.Errorf("[%d] execute template with an escaped string value by SafeURL returns unexpected error: %s", i, err)
 		}
 		if buf.String() != this.expectWithEscape {
-			t.Errorf("[%d] execute template with an escaped string value by SafeUrl, got %v but expected %v", i, buf.String(), this.expectWithEscape)
+			t.Errorf("[%d] execute template with an escaped string value by SafeURL, got %v but expected %v", i, buf.String(), this.expectWithEscape)
 		}
 	}
 }

--- a/transform/absurl.go
+++ b/transform/absurl.go
@@ -7,15 +7,15 @@ import (
 var absURLInit sync.Once
 var ar *absURLReplacer
 
-// for performance reasons, we reuse the first baseUrl given
-func initAbsurlReplacer(baseURL string) {
+// for performance reasons, we reuse the first baseURL given
+func initAbsURLReplacer(baseURL string) {
 	absURLInit.Do(func() {
-		ar = newAbsurlReplacer(baseURL)
+		ar = newAbsURLReplacer(baseURL)
 	})
 }
 
 func AbsURL(absURL string) (trs []link, err error) {
-	initAbsurlReplacer(absURL)
+	initAbsURLReplacer(absURL)
 
 	trs = append(trs, func(content []byte) []byte {
 		return ar.replaceInHTML(content)
@@ -24,7 +24,7 @@ func AbsURL(absURL string) (trs []link, err error) {
 }
 
 func AbsURLInXML(absURL string) (trs []link, err error) {
-	initAbsurlReplacer(absURL)
+	initAbsURLReplacer(absURL)
 
 	trs = append(trs, func(content []byte) []byte {
 		return ar.replaceInXML(content)

--- a/transform/absurlreplacer.go
+++ b/transform/absurlreplacer.go
@@ -120,7 +120,7 @@ func checkCandidate(l *contentlexer) {
 		}
 
 		if bytes.HasPrefix(l.content[l.pos:], m.match) {
-			// check for schemaless urls
+			// check for schemaless URLs
 			posAfter := l.pos + len(m.match)
 			if int(posAfter) >= len(l.content) {
 				return
@@ -196,7 +196,7 @@ type absURLReplacer struct {
 	xmlMatchers  []absURLMatcher
 }
 
-func newAbsurlReplacer(baseURL string) *absURLReplacer {
+func newAbsURLReplacer(baseURL string) *absURLReplacer {
 	u, _ := url.Parse(baseURL)
 	base := strings.TrimRight(u.String(), "/")
 


### PR DESCRIPTION
Deal with `Url -> URL` and `BaseUrl -> BaseURL` conversion
while preserving backward compatibility, and marking
relevant lines `deprecated`.

Also fix related initialisms in strings and comments.

Continued effort in fixing #959.