### PR TITLE
Adds "getenv" as an alias to os.Getenv

### DIFF
--- a/tpl/template.go
+++ b/tpl/template.go
@@ -1341,6 +1341,7 @@ func init() {
 		"getCSV":      GetCSV,
 		"getCsv":      GetCSV,
 		"seq":         helpers.Seq,
+		"getenv":      func(varName string) string { return os.Getenv(varName) },
 	}
 
 }


### PR DESCRIPTION
Fixes #977 by adding a wrapper for the os.Getenv function. The
wrapper takes as input a string that is assumed to be an exported
variable name.