### PR TITLE
Write to rotating ContentReWriter in transformer chain

### DIFF
--- a/transform/absurl.go
+++ b/transform/absurl.go
@@ -17,8 +17,8 @@ func initAbsURLReplacer(baseURL string) {
 func AbsURL(absURL string) (trs []link, err error) {
 	initAbsURLReplacer(absURL)
 
-	trs = append(trs, func(content []byte) []byte {
-		return ar.replaceInHTML(content)
+	trs = append(trs, func(rw ContentReWriter) {
+		ar.replaceInHTML(rw)
 	})
 	return
 }
@@ -26,8 +26,8 @@ func AbsURL(absURL string) (trs []link, err error) {
 func AbsURLInXML(absURL string) (trs []link, err error) {
 	initAbsURLReplacer(absURL)
 
-	trs = append(trs, func(content []byte) []byte {
-		return ar.replaceInXML(content)
+	trs = append(trs, func(rw ContentReWriter) {
+		ar.replaceInXML(rw)
 	})
 	return
 }

--- a/transform/chain.go
+++ b/transform/chain.go
@@ -1,12 +1,12 @@
 package transform
 
 import (
-	"io"
-
+	"bytes"
 	bp "github.com/spf13/hugo/bufferpool"
+	"io"
 )
 
-type trans func([]byte) []byte
+type trans func(rw ContentReWriter)
 
 type link trans
 
@@ -20,17 +20,62 @@ func NewEmptyTransforms() []link {
 	return make([]link, 0, 20)
 }
 
-func (c *chain) Apply(w io.Writer, r io.Reader) (err error) {
-	buffer := bp.GetBuffer()
-	defer bp.PutBuffer(buffer)
+// ContentReWriter is an interface that enables rotation
+// of pooled buffers in the transformer chain.
+type ContentReWriter interface {
+	Content() []byte
+	io.Writer
+}
 
-	buffer.ReadFrom(r)
-	b := buffer.Bytes()
-	for _, tr := range *c {
-		b = tr(b)
+// Implements ContentReWriter
+// Content is read from the from-buffer,
+// and rewritten to to the to-buffer.
+type fromToBuffer struct {
+	from *bytes.Buffer
+	to   *bytes.Buffer
+}
+
+func (ft fromToBuffer) Write(p []byte) (n int, err error) {
+	return ft.to.Write(p)
+}
+
+func (ft fromToBuffer) Content() []byte {
+	return ft.from.Bytes()
+}
+
+func (c *chain) Apply(w io.Writer, r io.Reader) error {
+
+	b1 := bp.GetBuffer()
+	defer bp.PutBuffer(b1)
+
+	b1.ReadFrom(r)
+
+	if len(*c) == 0 {
+		b1.WriteTo(w)
+		return nil
 	}
-	buffer.Reset()
-	buffer.Write(b)
-	buffer.WriteTo(w)
-	return
+
+	b2 := bp.GetBuffer()
+	defer bp.PutBuffer(b2)
+
+	fb := &fromToBuffer{from: b1, to: b2}
+
+	for i, tr := range *c {
+		if i > 0 {
+			if fb.from == b1 {
+				fb.from = b2
+				fb.to = b1
+				fb.to.Reset()
+			} else {
+				fb.from = b1
+				fb.to = b2
+				fb.to.Reset()
+			}
+		}
+
+		tr(fb)
+	}
+
+	fb.to.WriteTo(w)
+	return nil
 }

--- a/transform/livereloadinject.go
+++ b/transform/livereloadinject.go
@@ -2,29 +2,22 @@ package transform
 
 import (
 	"bytes"
-	jww "github.com/spf13/jwalterweatherman"
 	"github.com/spf13/viper"
 )
 
-func LiveReloadInject(content []byte) (injected []byte) {
-	defer func() {
-		if r := recover(); r != nil {
-			jww.ERROR.Println("Recovered in LiveReloadInject", r)
-			injected = content
-		}
-	}()
+func LiveReloadInject(rw ContentReWriter) {
 	match := []byte("</body>")
 	port := viper.GetString("port")
 	replace := []byte(`<script>document.write('<script src="http://'
         + (location.host || 'localhost').split(':')[0]
 		+ ':` + port + `/livereload.js?mindelay=10"></'
         + 'script>')</script></body>`)
-	newcontent := bytes.Replace(content, match, replace, -1)
+	newcontent := bytes.Replace(rw.Content(), match, replace, -1)
 
-	if len(newcontent) == len(content) {
+	if len(newcontent) == len(rw.Content()) {
 		match := []byte("</BODY>")
-		newcontent = bytes.Replace(content, match, replace, -1)
+		newcontent = bytes.Replace(rw.Content(), match, replace, -1)
 	}
 
-	return newcontent
+	rw.Write(newcontent)
 }


### PR DESCRIPTION
This commit adds the interface ContentReWriter in the tranformer chain.

This is backed by two pooled byte buffers, alternating between being the reader or the writer.

This keeps the performance characteristic of the old implementation, but in a thread safe way.

Fixes #911

Benchmark old vs new:

```
benchmark              old ns/op     new ns/op     delta
BenchmarkAbsURL        17614         17384         -1.31%
BenchmarkXMLAbsURL     9431          9248          -1.94%

benchmark              old allocs     new allocs     delta
BenchmarkAbsURL        24             28             +16.67%
BenchmarkXMLAbsURL     12             14             +16.67%

benchmark              old bytes     new bytes     delta
BenchmarkAbsURL        3295          3424          +3.92%
BenchmarkXMLAbsURL     1954          1987          +1.69%
```