### PR TITLE
Added 2 string template functions

### DIFF
--- a/tpl/template.go
+++ b/tpl/template.go
@@ -188,6 +188,22 @@ func compareGetFloat(a interface{}, b interface{}) (float64, float64) {
 	return left, right
 }
 
+func Substr(a interface{}, pos, length int) (string, error) {
+	aStr, err := cast.ToStringE(a)
+	if err != nil {
+		return "", err
+	}
+	return aStr[pos:length], nil
+}
+
+func Split(a interface{}, delimiter string) ([]string, error) {
+	aStr, err := cast.ToStringE(a)
+	if err != nil {
+		return []string{}, err
+	}
+	return strings.Split(aStr, delimiter), nil
+}
+
 func Intersect(l1, l2 interface{}) (interface{}, error) {
 	if l1 == nil || l2 == nil {
 		return make([]interface{}, 0), nil
@@ -1308,6 +1324,8 @@ func init() {
 		"lt":          Lt,
 		"le":          Le,
 		"in":          In,
+		"substr":      Substr,
+		"split":       Split,
 		"intersect":   Intersect,
 		"isSet":       IsSet,
 		"isset":       IsSet,

--- a/tpl/template.go
+++ b/tpl/template.go
@@ -188,12 +188,12 @@ func compareGetFloat(a interface{}, b interface{}) (float64, float64) {
 	return left, right
 }
 
-func Substr(a interface{}, pos, length int) (string, error) {
+func Slice(a interface{}, start, end int) (string, error) {
 	aStr, err := cast.ToStringE(a)
 	if err != nil {
 		return "", err
 	}
-	return aStr[pos:length], nil
+	return aStr[start:end], nil
 }
 
 func Split(a interface{}, delimiter string) ([]string, error) {
@@ -1324,7 +1324,7 @@ func init() {
 		"lt":          Lt,
 		"le":          Le,
 		"in":          In,
-		"substr":      Substr,
+		"slice":       Slice,
 		"split":       Split,
 		"intersect":   Intersect,
 		"isSet":       IsSet,

--- a/tpl/template_test.go
+++ b/tpl/template_test.go
@@ -276,7 +276,7 @@ func TestIn(t *testing.T) {
 	}
 }
 
-func TestSubstr(t *testing.T) {
+func TestSlice(t *testing.T) {
 	for i, this := range []struct {
 		v1     interface{}
 		v2     int
@@ -289,11 +289,11 @@ func TestSubstr(t *testing.T) {
 		{123, 1, 3, "23"},
 		{tstNoStringer{}, 0, 1, false},
 	} {
-		result, err := Substr(this.v1, this.v2, this.v3)
+		result, err := Slice(this.v1, this.v2, this.v3)
 
 		if b, ok := this.expect.(bool); ok && !b {
 			if err == nil {
-				t.Errorf("[%d] Substr didn't return an expected error", i)
+				t.Errorf("[%d] Slice didn't return an expected error", i)
 			}
 		} else {
 			if err != nil {

--- a/tpl/template_test.go
+++ b/tpl/template_test.go
@@ -276,6 +276,63 @@ func TestIn(t *testing.T) {
 	}
 }
 
+func TestSubstr(t *testing.T) {
+	for i, this := range []struct {
+		v1 interface{}
+		v2 int
+		v3 int
+		expect string
+	}{
+		{"abc", 1, 2, "b"},
+		{"abc", 1, 3, "bc"},
+		{"abc", 0, 1, "a"},
+	} {
+		result, err := Substr(this.v1, this.v2, this.v3)
+
+		if err != nil {
+			t.Errorf("[%d] failed: %s", i, err)
+			continue
+		}
+
+		if result != this.expect {
+			t.Errorf("[%d] Got %v but expected %v", i, result, this.expect)
+		}
+	}
+
+	_, err := Substr(tstNoStringer{}, 0, 1)
+	if err == nil {
+		t.Error("Expected error for non-string-convertable variable")
+	}
+}
+
+func TestSplit(t *testing.T) {
+	for i, this := range []struct {
+		v1 interface{}
+		v2 string
+		expect []string
+	}{
+		{"a, b", ", ", []string{"a", "b"}},
+		{"a & b & c", " & ", []string{"a", "b", "c"}},
+		{"http://exmaple.com", "http://", []string{"", "exmaple.com"}},
+	} {
+		result, err := Split(this.v1, this.v2)
+
+		if err != nil {
+			t.Errorf("[%d] failed: %s", i, err)
+			continue
+		}
+
+		if !reflect.DeepEqual(result, this.expect) {
+			t.Errorf("[%d] Got %s but expected %s", i, result, this.expect)
+		}
+	}
+
+	_, err := Split(tstNoStringer{}, ",")
+	if err == nil {
+		t.Error("Expected error for non-string-convertable variable")
+	}
+}
+
 func TestIntersect(t *testing.T) {
 	for i, this := range []struct {
 		sequence1 interface{}


### PR DESCRIPTION
Added the following string template functions in "tpl/template.go":

1. Substr
Slice a string based on a specified range. e.g {{ substr "abc" 1 2 }} will return "b".

2. Split
Split a string based on a specified delimiter. e.g {{ split "a,b,c"  "," }} will return [a b c].

This is my first commit to Hugo. I've tried to follow the contributor guide. However, please feel free to let me know if I've missed anything. Cheers