### PR TITLE
Add support for Ace base and inner templates

### DIFF
--- a/hugofs/fs.go
+++ b/hugofs/fs.go
@@ -17,5 +17,6 @@ import "github.com/spf13/afero"
 
 var SourceFs afero.Fs = new(afero.OsFs)
 var DestinationFS afero.Fs = new(afero.OsFs)
+var OsFs afero.Fs = new(afero.OsFs)
 
 //var DestinationFS afero.Fs = new(afero.MemMapFs)


### PR DESCRIPTION
See the [Ace docs](https://github.com/yosssi/ace/tree/master/examples/base_inner_template) for usage examples.
 
The base template will be chosen as in the examples below.

```
layouts/_default/single.ace
layouts/_default/list.ace
layouts/_default/baseof.ace
index.ace
```

In all of the above cases, the base template in `_default` will be used.

```
layouts/_default/single.ace
layouts/_default/list.ace
layouts/_default/baseof.ace
layouts/blog/list.ace
layouts/blog/baseof.ace
index.ace
baseof.ace
```

In the example above the front page and the list template in the blog section have their own base template.

Also see http://discuss.gohugo.io/t/inheritance-with-ace-templates/677/2

Fixes #994
Fixes #511