### PR TITLE
Update embedded rss.xml code in the docs

### DIFF
--- a/docs/content/templates/rss.md
+++ b/docs/content/templates/rss.md
@@ -75,19 +75,22 @@ This is the RSS template that ships with Hugo. It adheres to the
 
     <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
       <channel>
-          <title>{{ .Title }} on {{ .Site.Title }} </title>
-          <generator uri="https://gohugo.io">Hugo</generator>
+        <title>{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}</title>
         <link>{{ .Permalink }}</link>
-        {{ with .Site.LanguageCode }}<language>{{.}}</language>{{end}}
-        {{ with .Site.Author.name }}<author>{{.}}</author>{{end}}
-        {{ with .Site.Copyright }}<copyright>{{.}}</copyright>{{end}}
-        <updated>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 MST" }}</updated>
+        <description>Recent content {{ with .Title }}in {{.}} {{ end }}on {{ .Site.Title }}</description>
+        <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+        <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
+        <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
+        <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+        <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
+        <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+        <atom:link href="{{.URL}}" rel="self" type="application/rss+xml" />
         {{ range first 15 .Data.Pages }}
         <item>
           <title>{{ .Title }}</title>
           <link>{{ .Permalink }}</link>
-          <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 MST" }}</pubDate>
-          {{with .Site.Author.name}}<author>{{.}}</author>{{end}}
+          <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+          {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
           <guid>{{ .Permalink }}</guid>
           <description>{{ .Content | html }}</description>
         </item>


### PR DESCRIPTION
Nothing special. I just copied the code for `rss.xml` from `tpl/template_embedded.go` to the _RSS (feed) Templates_ page, because it was a bit outdated there.