### PR TITLE
Fix a bug in IsMenuCurrent when baseUrl is not at the root path

### DIFF
--- a/hugolib/node.go
+++ b/hugolib/node.go
@@ -18,6 +18,7 @@ import (
 	"html/template"
 	"sync"
 	"time"
+    "strings"
 )
 
 type Node struct {
@@ -56,8 +57,20 @@ func (n *Node) HasMenuCurrent(menuID string, inme *MenuEntry) bool {
 }
 
 func (n *Node) IsMenuCurrent(menuID string, inme *MenuEntry) bool {
+    s := n.Site
 
 	me := MenuEntry{Name: n.Title, URL: n.URL}
+
+	if strings.HasPrefix(me.URL, "/") {
+		// make it match the nodes
+		menuEntryURL := me.URL
+		menuEntryURL = helpers.URLizeAndPrep(menuEntryURL)
+		if !s.canonifyURLs {
+		    menuEntryURL = helpers.AddContextRoot(string(s.BaseURL), menuEntryURL)
+		}
+		me.URL = menuEntryURL
+	}
+
 	if !me.IsSameResource(inme) {
 		return false
 	}


### PR DESCRIPTION
I'm having a problem on my site where my Site.baseUrl points does not point to the root path (eg. http://localhost/mysite/)

In this case, when IsMenuCurrent does not appear to work correctly.  I think menu.go:IsSameResource should really have something that can compare with a prepended Site.baseURL, similar to site.go:getMenusFromConfig.  However, I couldn't see an easy way to do that.  Instead, I opted to modify node.go:IsMenuCurrent to do a similar prepend.

However, I don't think this will catch other bugs in HasMenuCurrent or any other menu access points.