### PR TITLE
Return error on wrong use of the Paginator

### DIFF
--- a/hugolib/pagination.go
+++ b/hugolib/pagination.go
@@ -22,6 +22,7 @@ import (
 	"html/template"
 	"math"
 	"path"
+	"reflect"
 )
 
 type pager struct {
@@ -37,8 +38,10 @@ type paginator struct {
 	paginatedPages []Pages
 	pagers
 	paginationURLFactory
-	total int
-	size  int
+	total   int
+	size    int
+	source  interface{}
+	options []interface{}
 }
 
 type paginationURLFactory func(int) string
@@ -164,6 +167,8 @@ func (n *Node) Paginator(options ...interface{}) (*pager, error) {
 		if len(pagers) > 0 {
 			// the rest of the nodes will be created later
 			n.paginator = pagers[0]
+			n.paginator.source = "paginator"
+			n.paginator.options = options
 			n.Site.addToPaginationPageCount(uint64(n.paginator.TotalPages()))
 		}
 
@@ -212,6 +217,8 @@ func (n *Node) Paginate(seq interface{}, options ...interface{}) (*pager, error)
 		if len(pagers) > 0 {
 			// the rest of the nodes will be created later
 			n.paginator = pagers[0]
+			n.paginator.source = seq
+			n.paginator.options = options
 			n.Site.addToPaginationPageCount(uint64(n.paginator.TotalPages()))
 		}
 
@@ -219,6 +226,14 @@ func (n *Node) Paginate(seq interface{}, options ...interface{}) (*pager, error)
 
 	if initError != nil {
 		return nil, initError
+	}
+
+	if n.paginator.source == "paginator" {
+		return nil, errors.New("a Paginator was previously built for this Node without filters; look for earlier .Paginator usage")
+	} else {
+		if !reflect.DeepEqual(options, n.paginator.options) || !probablyEqualPageLists(n.paginator.source, seq) {
+			return nil, errors.New("invoked multiple times with different arguments")
+		}
 	}
 
 	return n.paginator, nil
@@ -248,18 +263,9 @@ func paginatePages(seq interface{}, pagerSize int, section string) (pagers, erro
 		return nil, errors.New("'paginate' configuration setting must be positive to paginate")
 	}
 
-	var pages Pages
-	switch seq.(type) {
-	case Pages:
-		pages = seq.(Pages)
-	case *Pages:
-		pages = *(seq.(*Pages))
-	case WeightedPages:
-		pages = (seq.(WeightedPages)).Pages()
-	case PageGroup:
-		pages = (seq.(PageGroup)).Pages
-	default:
-		return nil, errors.New(fmt.Sprintf("unsupported type in paginate, got %T", seq))
+	pages, err := toPages(seq)
+	if err != nil {
+		return nil, err
 	}
 
 	urlFactory := newPaginationURLFactory(section)
@@ -267,6 +273,54 @@ func paginatePages(seq interface{}, pagerSize int, section string) (pagers, erro
 	pagers := paginator.Pagers()
 
 	return pagers, nil
+}
+
+func toPages(seq interface{}) (Pages, error) {
+	switch seq.(type) {
+	case Pages:
+		return seq.(Pages), nil
+	case *Pages:
+		return *(seq.(*Pages)), nil
+	case WeightedPages:
+		return (seq.(WeightedPages)).Pages(), nil
+	case PageGroup:
+		return (seq.(PageGroup)).Pages, nil
+	default:
+		return nil, errors.New(fmt.Sprintf("unsupported type in paginate, got %T", seq))
+	}
+}
+
+// probablyEqual checks page lists for probable equality.
+// It may return false positives.
+// The motivation behind this is to avoid potential costly reflect.DeepEqual
+// when "probably" is good enough.
+func probablyEqualPageLists(a1 interface{}, a2 interface{}) bool {
+
+	if a1 == nil || a2 == nil {
+		return a1 == a2
+	}
+
+	p1, err1 := toPages(a1)
+	p2, err2 := toPages(a2)
+
+	// probably the same wrong type
+	if err1 != nil && err2 != nil {
+		return true
+	}
+
+	if err1 != nil || err2 != nil {
+		return false
+	}
+
+	if len(p1) != len(p2) {
+		return false
+	}
+
+	if len(p1) == 0 {
+		return true
+	}
+
+	return p1[0] == p2[0]
 }
 
 func newPaginator(pages Pages, size int, urlFactory paginationURLFactory) (*paginator, error) {

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -48,6 +48,8 @@ var _ = transform.AbsURL
 
 var DefaultTimer *nitro.B
 
+var distinctErrorLogger = helpers.NewDistinctErrorLogger()
+
 // Site contains all the information relevant for constructing a static
 // site.  The basic flow of information is as follows:
 //
@@ -1086,7 +1088,7 @@ func taxonomyRenderer(s *Site, taxes <-chan taxRenderInfo, results chan<- error,
 				}
 				pageNumber := i + 1
 				htmlBase := fmt.Sprintf("/%s/%s/%d", base, paginatePath, pageNumber)
-				if err := s.renderAndWritePage(fmt.Sprintf("taxononomy_%s_%d", t.singular, pageNumber), htmlBase, taxonomyPagerNode, layouts...); err != nil {
+				if err := s.renderAndWritePage(fmt.Sprintf("taxononomy %s", t.singular), htmlBase, taxonomyPagerNode, layouts...); err != nil {
 					results <- err
 					continue
 				}
@@ -1155,7 +1157,7 @@ func (s *Site) RenderSectionLists() error {
 
 		n := s.newSectionListNode(section, data)
 
-		if err := s.renderAndWritePage(fmt.Sprintf("section%s_%d", section, 1), fmt.Sprintf("/%s", section), n, s.appendThemeTemplates(layouts)...); err != nil {
+		if err := s.renderAndWritePage(fmt.Sprintf("section %s", section), fmt.Sprintf("/%s", section), n, s.appendThemeTemplates(layouts)...); err != nil {
 			return err
 		}
 
@@ -1181,7 +1183,7 @@ func (s *Site) RenderSectionLists() error {
 				}
 				pageNumber := i + 1
 				htmlBase := fmt.Sprintf("/%s/%s/%d", section, paginatePath, pageNumber)
-				if err := s.renderAndWritePage(fmt.Sprintf("section_%s_%d", section, pageNumber), filepath.FromSlash(htmlBase), sectionPagerNode, layouts...); err != nil {
+				if err := s.renderAndWritePage(fmt.Sprintf("section %s", section), filepath.FromSlash(htmlBase), sectionPagerNode, layouts...); err != nil {
 					return err
 				}
 			}
@@ -1238,7 +1240,7 @@ func (s *Site) RenderHomePage() error {
 			}
 			pageNumber := i + 1
 			htmlBase := fmt.Sprintf("/%s/%d", paginatePath, pageNumber)
-			if err := s.renderAndWritePage(fmt.Sprintf("homepage_%d", pageNumber), filepath.FromSlash(htmlBase), homePagerNode, layouts...); err != nil {
+			if err := s.renderAndWritePage(fmt.Sprintf("homepage"), filepath.FromSlash(htmlBase), homePagerNode, layouts...); err != nil {
 				return err
 			}
 		}
@@ -1424,7 +1426,7 @@ func (s *Site) render(name string, d interface{}, renderBuffer *bytes.Buffer, la
 
 	if err := s.renderThing(d, layout, renderBuffer); err != nil {
 		// Behavior here should be dependent on if running in server or watch mode.
-		jww.ERROR.Println(fmt.Errorf("Error while rendering %s: %v", name, err))
+		distinctErrorLogger.Printf("Error while rendering %s: %v", name, err)
 		if !s.Running() {
 			os.Exit(-1)
 		}


### PR DESCRIPTION
`Paginate`now returns error when

1) `.Paginate` is called after `.Paginator`
2) `.Paginate` is repeatedly called with different arguments

This should help remove some confusion.

This commit also introduces `DistinctErrorLogger` to prevent spamming the log for duplicate rendering errors from the pagers.

Fixes #993