### PR TITLE
Add template debugging functions

### DIFF
--- a/docs/content/templates/functions.md
+++ b/docs/content/templates/functions.md
@@ -44,6 +44,90 @@ e.g.
 
     {{ if eq .Section "blog" }}current{{ end }}
 
+### inspect
+Return a string containing the default representation of a value.
+Takes one parameter which may be any variable or text/numeric constant.
+
+This function supports debugging templates. The output is similar to `{{ printf "%#v" $variable }}`.
+
+<table class="table table-bordered">
+<thead>
+<tr>
+<th>Description</th>
+<th>Example</th>
+<th>Result</th>
+</tr>
+</thead>
+
+<tbody>
+
+<tr>
+<td>Value of a numeric constant</td>
+<td><code>{{ inspect 0 }}</code></td>
+<td><code>0</code></td>
+</tr>
+
+<tr>
+<td>Value of a string constant</td>
+<td><code>{{ inspect "Hello, World!" }}</code></td>
+<td><code>&amp;#34;Hello, World!&amp;#34</code></td>
+</tr>
+
+<tr>
+<td>Value of a variable</td>
+<td><code>{{ $foo := "bar" }}</code><br /><code>{{ inspect $foo }}</code></td>
+<td><code>&amp;#34;bar&amp;#34</code></td>
+</tr>
+
+</tbody>
+</table>
+
+
+### typeOf
+Return a string containing the type of a value.
+Takes one parameter which may be any variable or text/numeric constant.
+
+This function supports debugging templates.
+
+<table class="table table-bordered">
+<thead>
+<tr>
+<th>Description</th>
+<th>Example</th>
+<th>Result</th>
+</tr>
+</thead>
+
+<tbody>
+
+<tr>
+<td>Value of a numeric constant</td>
+<td><code>{{ typeOf 0 }}</code></td>
+<td><code>int</code></td>
+</tr>
+
+<tr>
+<td>Value of a numeric constant</td>
+<td><code>{{ typeOf 0.0 }}</code></td>
+<td><code>float64</code></td>
+</tr>
+
+<tr>
+<td>Value of a string constant</td>
+<td><code>{{ typeOf "bar" }}</code></td>
+<td><code>string</code></td>
+</tr>
+
+<tr>
+<td>Value of a variable</td>
+<td><code>{{ $foo := "bar" }}</code><br /><code>{{ typeOf $foo }}</code></td>
+<td><code>string</code></td>
+</tr>
+
+</tbody>
+</table>
+
+
 ### first
 Slices an array to only the first X elements.
 

--- a/tpl/template.go
+++ b/tpl/template.go
@@ -901,6 +901,23 @@ func IsSet(a interface{}, key interface{}) bool {
 	return false
 }
 
+func Inspect(v interface{}) string {
+	//return reflect.ValueOf(v).String()
+	av := reflect.ValueOf(v)
+	return fmt.Sprintf("%#v", av.Interface())
+}
+
+func InspectTypeOf(v interface{}) string {
+	var t = reflect.TypeOf(v).Name()
+	if t == "" {
+		t = reflect.TypeOf(v).String() 
+		if t == "" {
+			t = "*no-type*"
+		}
+	}
+	return t
+}
+
 func ReturnWhenSet(a, k interface{}) interface{} {
 	av, isNil := indirect(reflect.ValueOf(a))
 	if isNil {
@@ -1454,6 +1471,8 @@ func init() {
 		"intersect":   Intersect,
 		"isSet":       IsSet,
 		"isset":       IsSet,
+		"inspect":     Inspect,
+		"typeOf":      InspectTypeOf,
 		"echoParam":   ReturnWhenSet,
 		"safeHTML":    SafeHTML,
 		"safeCSS":     SafeCSS,

--- a/tpl/template_test.go
+++ b/tpl/template_test.go
@@ -1220,3 +1220,51 @@ func TestSafeURL(t *testing.T) {
 		}
 	}
 }
+
+func TestInspect(t *testing.T) {
+	for i, this := range []struct {
+		v      interface{}
+		expect interface{}
+	}{
+		{0, "0"},
+		{1, "1"},
+		{-1, "-1"},
+		{0.0, "0"},
+		{1.0, "1"},
+		{-1.0, "-1"},
+		{0.1, "0.1"},
+		{1.1, "1.1"},
+		{-1.1, "-1.1"},
+		{"text", "\"text\""},
+	} {
+		result := Inspect(this.v)
+		if !reflect.DeepEqual(result, this.expect) {
+			t.Errorf("[%d] inspect got %v but expected %v", i, result, this.expect)
+		}
+	}
+}
+
+func TestInspectTypeOf(t *testing.T) {
+	for i, this := range []struct {
+		v      interface{}
+		expect interface{}
+	}{
+		{0, "int"},
+		{1, "int"},
+		{-1, "int"},
+		{0.0, "float64"},
+		{1.0, "float64"},
+		{-1.0, "float64"},
+		{0.1, "float64"},
+		{1.1, "float64"},
+		{-1.1, "float64"},
+		{"text", "string"},
+		{"$foo", "string"},
+		//{".", "*hugolib.Node"},
+	} {
+		result := InspectTypeOf(this.v)
+		if !reflect.DeepEqual(result, this.expect) {
+			t.Errorf("[%d] typeOf got %v but expected %v", i, result, this.expect)
+		}
+	}
+}


### PR DESCRIPTION
Template developers frequently need to show variable values while 
debugging templates. Issue #1009 requests better support for this.

The `printf "%#v"` idiom is powerful but requires some knowledge
of Hugo's internal representation of Go value types. Not all
template designers will have that knowledge. The two functions
`inspect` and `typeOf` provide a path towards easier to use and
understand printing of variables and values.

The `inspect` function replaces the `printf` call. This version
relies on the default `string` conversion for the result. This
provides a path towards pretty-printing variables and values.

Templates may use `typeOf` to determine the best formatting
for variables and values.