### PR TITLE
Log directories being watched when server is run

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -98,7 +98,14 @@ func server(cmd *cobra.Command, args []string) {
 
 	// Watch runs its own server as part of the routine
 	if serverWatch {
-		jww.FEEDBACK.Println("Watching for changes in", helpers.AbsPathify(viper.GetString("ContentDir")))
+		watched := getDirList()
+		workingDir := helpers.AbsPathify(viper.GetString("WorkingDir"))
+		for i, dir := range watched {
+			watched[i], _ = helpers.GetRelativePath(dir, workingDir)
+		}
+		unique := strings.Join(helpers.RemoveSubpaths(watched), ",")
+
+		jww.FEEDBACK.Printf("Watching for changes in %s/{%s}\n", workingDir, unique)
 		err := NewWatcher(serverPort)
 		if err != nil {
 			fmt.Println(err)

--- a/helpers/path.go
+++ b/helpers/path.go
@@ -365,6 +365,39 @@ func PrettiyPath(in string, b FilepathPathBridge) string {
 	return b.Join(b.Dir(in), name, "index"+ext)
 }
 
+// RemoveSubpaths takes a list of paths and removes everything that
+// contains another path in the list as a prefix. Ignores any empty
+// strings. Used mostly for logging.
+//
+// e.g. ["hello/world", "hello", "foo/bar", ""] -> ["hello", "foo/bar"]
+func RemoveSubpaths(paths []string) []string {
+	a := make([]string, 0)
+	for _, cur := range paths {
+		// ignore trivial case
+		if cur == "" {
+			continue
+		}
+
+		isDupe := false
+		for i, old := range a {
+			if strings.HasPrefix(cur, old) {
+				isDupe = true
+				break
+			} else if strings.HasPrefix(old, cur) {
+				a[i] = cur
+				isDupe = true
+				break
+			}
+		}
+
+		if !isDupe {
+			a = append(a, cur)
+		}
+	}
+
+	return a
+}
+
 // FindCWD returns the current working directory from where the Hugo
 // executable is run.
 func FindCWD() (string, error) {

--- a/helpers/path_test.go
+++ b/helpers/path_test.go
@@ -2,10 +2,10 @@ package helpers
 
 import (
 	"fmt"
-	"github.com/spf13/viper"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/spf13/afero"
+	"github.com/spf13/viper"
 )
 
 func TestMakePath(t *testing.T) {
@@ -543,6 +544,14 @@ func TestPathPrep(t *testing.T) {
 
 func TestPrettifyPath(t *testing.T) {
 
+}
+
+func TestRemoveSubpaths(t *testing.T) {
+	got := RemoveSubpaths([]string{"hello", "hello/world", "foo/bar", ""})
+	expect := []string{"hello", "foo/bar"}
+	if !reflect.DeepEqual(got, expect) {
+		t.Errorf("Test %d failed. Expected %q but got %q", expect, got)
+	}
 }
 
 func TestFindCWD(t *testing.T) {


### PR DESCRIPTION
Fixes #1030. Previously hugo only listed the content directory 
as being watched. Now we list all files being watched according to
`commands.getDirList()`. We also introduce a RemoveSubpaths
function and test in the helpers module to reduce noise in the command
line output by not showing subdirectories of ones already being watched.

For example, instead of:
`Watching for changes in $HOME/blog/content`
We get:
`Watching for changes in
$HOME/blog/{data,content,layouts,static,themes/my-theme}`