### PR TITLE
Update test logs for uniformity and consistency

### DIFF
--- a/helpers/general_test.go
+++ b/helpers/general_test.go
@@ -27,7 +27,7 @@ func TestGuessType(t *testing.T) {
 	} {
 		result := GuessType(this.in)
 		if result != this.expect {
-			t.Errorf("[%d] GuessType guessed wrong, expected %s, got %s", i, this.expect, result)
+			t.Errorf("[%d] got %s but expected %s", i, result, this.expect)
 		}
 	}
 }
@@ -108,7 +108,7 @@ func TestReaderContains(t *testing.T) {
 	for i, this := range append(containsBenchTestData, containsAdditionalTestData...) {
 		result := ReaderContains(StringToReader(this.v1), this.v2)
 		if result != this.expect {
-			t.Errorf("[%d] Got %t but expected %t", i, result, this.expect)
+			t.Errorf("[%d] got %t but expected %t", i, result, this.expect)
 		}
 	}
 
@@ -122,7 +122,7 @@ func BenchmarkReaderContains(b *testing.B) {
 		for i, this := range containsBenchTestData {
 			result := ReaderContains(StringToReader(this.v1), this.v2)
 			if result != this.expect {
-				b.Errorf("[%d] Got %t but expected %t", i, result, this.expect)
+				b.Errorf("[%d] got %t but expected %t", i, result, this.expect)
 			}
 		}
 	}
@@ -139,7 +139,7 @@ func _BenchmarkReaderContains(b *testing.B) {
 			}
 			result := bytes.Contains(bs, this.v2)
 			if result != this.expect {
-				b.Errorf("[%d] Got %t but expected %t", i, result, this.expect)
+				b.Errorf("[%d] got %t but expected %t", i, result, this.expect)
 			}
 		}
 	}
@@ -166,10 +166,10 @@ func TestInStringArrayCaseSensitive(t *testing.T) {
 		{"Albert", true},
 		{"ALBERT", false},
 	}
-	for _, in := range data {
+	for i, in := range data {
 		output := InStringArray(array, in.input)
 		if output != in.expected {
-			t.Errorf("TestInStringArrayCase failed. Expected %t. Got %t.", in.expected, output)
+			t.Errorf("[%d] got %t but expected %t", i, output, in.expected)
 		}
 	}
 }

--- a/hugolib/pagination_test.go
+++ b/hugolib/pagination_test.go
@@ -300,7 +300,7 @@ func TestProbablyEqualPageLists(t *testing.T) {
 		result := probablyEqualPageLists(this.v1, this.v2)
 
 		if result != this.expect {
-			t.Errorf("[%d] Got %t but expected %t", i, result, this.expect)
+			t.Errorf("[%d] got %t but expected %t", i, result, this.expect)
 
 		}
 	}

--- a/hugolib/path_separators_test.go
+++ b/hugolib/path_separators_test.go
@@ -34,13 +34,13 @@ func TestNewPageWithFilePath(t *testing.T) {
 		{filepath.Join("content", "dub", "sub", "foobar.html"), "dub", L("dub/single.html", "_default/single.html")},
 	}
 
-	for _, el := range toCheck {
+	for i, el := range toCheck {
 		p, err := NewPageFrom(strings.NewReader(SIMPLE_PAGE_YAML), el.input)
 		if err != nil {
-			t.Errorf("Reading from SIMPLE_PAGE_YAML resulted in an error: %s", err)
+			t.Errorf("[%d] Reading from SIMPLE_PAGE_YAML resulted in an error: %s", i, err)
 		}
 		if p.Section() != el.section {
-			t.Errorf("Section not set to %s for page %s. Got: %s", el.section, el.input, p.Section())
+			t.Errorf("[%d] Section incorrect page %s. got %s but expected %s", i, el.input, p.Section(), el.section)
 		}
 
 		for _, y := range el.layout {
@@ -48,7 +48,7 @@ func TestNewPageWithFilePath(t *testing.T) {
 		}
 
 		if !listEqual(p.Layout(), el.layout) {
-			t.Errorf("Layout incorrect. Expected: '%s', Got: '%s'", el.layout, p.Layout())
+			t.Errorf("[%d] Layout incorrect. got '%s' but expected '%s'", i, p.Layout(), el.layout)
 		}
 	}
 }

--- a/hugolib/path_separators_windows_test.go
+++ b/hugolib/path_separators_windows_test.go
@@ -13,6 +13,6 @@ const (
 func TestTemplatePathSeparator(t *testing.T) {
 	tmpl := new(tpl.GoHTMLTemplate)
 	if name := tmpl.GenerateTemplateNameFrom(win_base, win_path); name != "sub1/index.html" {
-		t.Fatalf("Template name incorrect.  Expected: %s, Got: %s", "sub1/index.html", name)
+		t.Fatalf("Template name incorrect. got %s but expected %s", name, "sub1/index.html")
 	}
 }

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -23,7 +23,7 @@ func CheckShortCodeMatch(t *testing.T, input, expected string, template tpl.Temp
 	output := ShortcodesHandle(input, p, template)
 
 	if output != expected {
-		t.Fatalf("Shortcode render didn't match. Expected: %q, Got: %q", expected, output)
+		t.Fatalf("Shortcode render didn't match. got %q but exxpected %q", output, expected)
 	}
 }
 
@@ -227,8 +227,8 @@ func TestExtractShortcodes(t *testing.T) {
 			} else {
 				r, _ := regexp.Compile(this.expectErrorMsg)
 				if !r.MatchString(err.Error()) {
-					t.Fatalf("[%d] %s: ExtractShortcodes didn't return an expected error message, expected %s got %s",
-						i, this.name, this.expectErrorMsg, err.Error())
+					t.Fatalf("[%d] %s: ExtractShortcodes didn't return an expected error message, got %s but expected %s",
+						i, this.name, err.Error(), this.expectErrorMsg)
 				}
 			}
 			continue
@@ -256,7 +256,7 @@ func TestExtractShortcodes(t *testing.T) {
 		}
 
 		if !r.MatchString(content) {
-			t.Fatalf("[%d] %s: Shortcode extract didn't match. Expected: %q, Got: %q", i, this.name, expected, content)
+			t.Fatalf("[%d] %s: Shortcode extract didn't match. got %q but expected %q", i, this.name, content, expected)
 		}
 
 		for placeHolder, sc := range shortCodes {
@@ -272,7 +272,7 @@ func TestExtractShortcodes(t *testing.T) {
 		if this.expectShortCodes != "" {
 			shortCodesAsStr := fmt.Sprintf("map%q", collectAndShortShortcodes(shortCodes))
 			if !strings.Contains(shortCodesAsStr, this.expectShortCodes) {
-				t.Fatalf("[%d] %s: Short codes not as expected, got %s - expected to contain %s", i, this.name, shortCodesAsStr, this.expectShortCodes)
+				t.Fatalf("[%d] %s: Short codes not as expected, got %s but expected %s", i, this.name, shortCodesAsStr, this.expectShortCodes)
 			}
 		}
 	}

--- a/parser/frontmatter_test.go
+++ b/parser/frontmatter_test.go
@@ -19,7 +19,7 @@ func TestFormatToLeadRune(t *testing.T) {
 		result := FormatToLeadRune(this.kind)
 
 		if result != this.expect {
-			t.Errorf("[%d] Got %q but expected %q", i, result, this.expect)
+			t.Errorf("[%d] got %q but expected %q", i, result, this.expect)
 		}
 	}
 }

--- a/tpl/template_funcs_test.go
+++ b/tpl/template_funcs_test.go
@@ -271,7 +271,7 @@ func TestIn(t *testing.T) {
 		result := In(this.v1, this.v2)
 
 		if result != this.expect {
-			t.Errorf("[%d] Got %v but expected %v", i, result, this.expect)
+			t.Errorf("[%d] got %v but expected %v", i, result, this.expect)
 		}
 	}
 }
@@ -305,7 +305,7 @@ func TestSlicestr(t *testing.T) {
 				continue
 			}
 			if !reflect.DeepEqual(result, this.expect) {
-				t.Errorf("[%d] Got %s but expected %s", i, result, this.expect)
+				t.Errorf("[%d] got %s but expected %s", i, result, this.expect)
 			}
 		}
 	}
@@ -345,7 +345,7 @@ func TestSubstr(t *testing.T) {
 				continue
 			}
 			if !reflect.DeepEqual(result, this.expect) {
-				t.Errorf("[%d] Got %s but expected %s", i, result, this.expect)
+				t.Errorf("[%d] got %s but expected %s", i, result, this.expect)
 			}
 		}
 	}
@@ -375,7 +375,7 @@ func TestSplit(t *testing.T) {
 				continue
 			}
 			if !reflect.DeepEqual(result, this.expect) {
-				t.Errorf("[%d] Got %s but expected %s", i, result, this.expect)
+				t.Errorf("[%d] got %s but expected %s", i, result, this.expect)
 			}
 		}
 	}
@@ -408,20 +408,20 @@ func TestIntersect(t *testing.T) {
 			continue
 		}
 		if !reflect.DeepEqual(results, this.expect) {
-			t.Errorf("[%d] Got %v but expected %v", i, results, this.expect)
+			t.Errorf("[%d] got %v but expected %v", i, results, this.expect)
 		}
 	}
 
 	_, err1 := Intersect("not an array or slice", []string{"a"})
 
 	if err1 == nil {
-		t.Error("Excpected error for non array as first arg")
+		t.Error("Expected error for non array as first arg")
 	}
 
 	_, err2 := Intersect([]string{"a"}, "not an array or slice")
 
 	if err2 == nil {
-		t.Error("Excpected error for non array as second arg")
+		t.Error("Expected error for non array as second arg")
 	}
 }
 
@@ -1220,3 +1220,4 @@ func TestSafeURL(t *testing.T) {
 		}
 	}
 }
+


### PR DESCRIPTION
Many minor fixes to make test logs more consistent and correct a
mispelling.

Standardize on "[%i] got X but expected Y" for log messages. Using
a consistent layout makes it easier to read the test results. This
was mostly changing "Got" to "got". Swapped the order of values on
several calls to bring them in line with the convention.

A few log messages had a sequence number added to identify the
exact scenario that failed. Otherwise, there would be no way to
ascertain which failed When there are many scenarios.

Correct spelling of "expected."

Fixes #1028