### PR TITLE
Use "hugo new" to indicate the command 

### DIFF
--- a/docs/content/content/types.md
+++ b/docs/content/content/types.md
@@ -11,7 +11,7 @@ weight: 40
 ---
 
 Hugo has full support for different types of content. A content type can have a
-unique set of meta data, template and can be automatically created by the ``hugo new``
+unique set of meta data, template and can be automatically created by the `hugo new`
 command through using content [archetypes](/content/archetypes/).
 
 A good example of when multiple types are needed is to look at [Tumblr](https://www.tumblr.com/). A piece

--- a/docs/content/content/types.md
+++ b/docs/content/content/types.md
@@ -11,7 +11,7 @@ weight: 40
 ---
 
 Hugo has full support for different types of content. A content type can have a
-unique set of meta data, template and can be automatically created by the new
+unique set of meta data, template and can be automatically created by the ``hugo new``
 command through using content [archetypes](/content/archetypes/).
 
 A good example of when multiple types are needed is to look at [Tumblr](https://www.tumblr.com/). A piece


### PR DESCRIPTION
(Dipping a toe in, and noticing there really are not that many weak areas in the docs. Great job. )

Noticed that content/types.md just had "new" instead of hugo new in backticks. 
I thought it is better to make it consistent with other areas with the same. 