### PR TITLE
Add ability to specify the name of the RSS file.

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -152,6 +152,7 @@ func InitializeConfig() {
 	viper.SetDefault("Paginate", 10)
 	viper.SetDefault("PaginatePath", "page")
 	viper.SetDefault("Blackfriday", helpers.NewBlackfriday())
+	viper.SetDefault("RSSUri", "index.xml")
 
 	if hugoCmdV.PersistentFlags().Lookup("buildDrafts").Changed {
 		viper.Set("BuildDrafts", Draft)

--- a/hugolib/rss_test.go
+++ b/hugolib/rss_test.go
@@ -34,6 +34,7 @@ const RSS_TEMPLATE = `<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom
 
 func TestRSSOutput(t *testing.T) {
 	viper.Set("baseurl", "http://auth/bub/")
+	viper.Set("RSSUri", "index.xml")
 
 	hugofs.DestinationFS = new(afero.MemMapFs)
 	s := &Site{

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1251,7 +1251,7 @@ func (s *Site) RenderHomePage() error {
 
 	if !viper.GetBool("DisableRSS") {
 		// XML Feed
-		n.URL = s.permalinkStr("index.xml")
+		n.URL = s.permalinkStr(viper.GetString("RSSUri"))
 		n.Title = ""
 		high := 50
 		if len(s.Pages) < high {
@@ -1264,7 +1264,7 @@ func (s *Site) RenderHomePage() error {
 
 		rssLayouts := []string{"rss.xml", "_default/rss.xml", "_internal/_default/rss.xml"}
 
-		if err := s.renderAndWriteXML("homepage rss", "index.xml", n, s.appendThemeTemplates(rssLayouts)...); err != nil {
+		if err := s.renderAndWriteXML("homepage rss", viper.GetString("RSSUri"), n, s.appendThemeTemplates(rssLayouts)...); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
I made this change to my fork in order to allow setting the name of the RSS file generated for the homepage.  I am migrating a site from Drupal to Hugo and drupal named the RSS feeds as /rss.xml.

However, this does not appear to be working.  I have compiled my changes and put the resulting executable in my /usr/local/bin and I have verified that it is being used by using "hugo version" but the generated site still has the RSS file in /index.xml.

Is there someplace else that needs to be changed to create this option?

Thanks!