### PR TITLE
added RSSUri to specify the name of the RSS file

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -152,6 +152,7 @@ func InitializeConfig() {
 	viper.SetDefault("Paginate", 10)
 	viper.SetDefault("PaginatePath", "page")
 	viper.SetDefault("Blackfriday", helpers.NewBlackfriday())
+	viper.SetDefault("RSSUri", "index.xml")
 
 	if hugoCmdV.PersistentFlags().Lookup("buildDrafts").Changed {
 		viper.Set("BuildDrafts", Draft)

--- a/hugolib/rss_test.go
+++ b/hugolib/rss_test.go
@@ -34,6 +34,7 @@ const RSS_TEMPLATE = `<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom
 
 func TestRSSOutput(t *testing.T) {
 	viper.Set("baseurl", "http://auth/bub/")
+	viper.Set("RSSUri", "index.xml")
 
 	hugofs.DestinationFS = new(afero.MemMapFs)
 	s := &Site{

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1251,7 +1251,7 @@ func (s *Site) RenderHomePage() error {
 
 	if !viper.GetBool("DisableRSS") {
 		// XML Feed
-		n.URL = s.permalinkStr("index.xml")
+		n.URL = s.permalinkStr(viper.GetString("RSSUri"))
 		n.Title = ""
 		high := 50
 		if len(s.Pages) < high {
@@ -1264,7 +1264,7 @@ func (s *Site) RenderHomePage() error {
 
 		rssLayouts := []string{"rss.xml", "_default/rss.xml", "_internal/_default/rss.xml"}
 
-		if err := s.renderAndWriteXML("homepage rss", "index.xml", n, s.appendThemeTemplates(rssLayouts)...); err != nil {
+		if err := s.renderAndWriteXML("homepage rss", viper.GetString("RSSUri"), n, s.appendThemeTemplates(rssLayouts)...); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This is useful when migrating a site from another system like drupal that uses a different name for the RSS xml files.