### PR TITLE
Go template primer - add index

### DIFF
--- a/docs/content/templates/go-templates.md
+++ b/docs/content/templates/go-templates.md
@@ -144,6 +144,10 @@ range.
         {{ $element }}
     {{ end }}
 
+The `index` function is a [Go][] built-in, and you can read about it [here][gostdlibpkgtexttemplate]. `index`:
+
+> ...returns the result of indexing its first argument by the following arguments. Thus "index x 1 2 3" is, in Go syntax, `x[1][2][3]`. Each indexed item must be a map, slice, or array.
+
 ### Conditionals
 
 `if`, `else`, `with`, `or` & `and` provide the framework for handling conditional
@@ -383,10 +387,6 @@ so, such as in this example:
 </nav>
 ```
 
-
-[go]: http://golang.org/
-[gohtmltemplate]: http://golang.org/pkg/html/template/
-
 # Template example: Show only upcoming events
 
 Go allows you to do more than what's shown here.  Using Hugo's
@@ -406,3 +406,7 @@ the future:
         </li>
       {{ end }}
     {{ end }}
+
+[go]: http://golang.org/
+[gohtmltemplate]: http://golang.org/pkg/html/template/
+[gostdlibpkgtexttemplate]: http://golang.org/pkg/text/template/

--- a/docs/content/templates/partials.md
+++ b/docs/content/templates/partials.md
@@ -13,7 +13,7 @@ weight: 80
 
 In practice, it's very convenient to split out common template portions into a
 partial template that can be included anywhere. As you create the rest of your
-templates, you will include templates from the /layout/partials directory.
+templates, you will include templates from the /layout/partials directory, or from arbitrary subdirectories like /layout/partials/post/tag.
 
 Partials are especially important for themes as it gives users an opportunity
 to overwrite just a small part of your theme, while maintaining future compatibility.
@@ -99,5 +99,11 @@ This footer template is used for [spf13.com](http://spf13.com/):
     </body>
     </html>
 
-**For examples of referencing these templates, see [single content
+To reference a partial template stored in a subfolder, e.g. `/layout/partials/post/tag/list.html`, call it this way: 
+
+     {{ partial "post/tag/list" . }}
+
+Note that the subdirectories you create under /layout/partials can be named whatever you like. 
+
+**For more examples of referencing these templates, see [single content
 templates](/templates/content/), [list templates](/templates/list/) and [homepage templates](/templates/homepage/).**


### PR DESCRIPTION
Related to @bjornerik 's answer in this discussion: http://discuss.gohugo.io/t/inserting-data-from-data-file-into-content-file-newbie-question/1002/3 ... I figured I'd make myself useful and add the reference to the index function, on the go template primer page. 

Also, I moved the reference links to the bottom. 

A general comment: as good as these docs are, the primer at this point makes some assumptions about audience knowledge, so some might find it lacking. Once I understand better, I might make some more clarifying edits. 