### PR TITLE
Add Bash completion

### DIFF
--- a/commands/genautocomplete.go
+++ b/commands/genautocomplete.go
@@ -1,0 +1,45 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+	jww "github.com/spf13/jwalterweatherman"
+)
+
+var autocompleteTarget string
+
+// bash for now (zsh and others will come)
+var autocompleteType string
+
+var genautocompleteCmd = &cobra.Command{
+	Use:   "genautocomplete",
+	Short: "Generate shell autocompletion script for Hugo",
+	Long: `Generates a shell autocompletion script for Hugo.
+	
+	NOTE: The current version supports Bash only. This should work for *nix systems with Bash installed.
+	
+	By default the file is written directly to /etc/bash_completion.d for convenience and the command may need superuser rights, e.g:
+	
+	sudo hugo genautocomplete
+	
+	Add --completionfile=/path/to/file flag to set alternative file-path and name.
+	
+	Logout and in again to reload the completion scripts or just source them in directly:
+	
+	. /etc/bash_completion
+	`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if autocompleteType != "bash" {
+			jww.FATAL.Fatalln("Only Bash is supported for now")
+		}
+		err := cmd.Root().GenBashCompletionFile(autocompleteTarget)
+		if err != nil {
+			jww.FATAL.Fatalln("Failed to generate shell completion file:", err)
+		}
+	},
+}
+
+func init() {
+	genautocompleteCmd.PersistentFlags().StringVarP(&autocompleteTarget, "completionfile	", "", "/etc/bash_completion.d/hugo.sh", "Autocompletion file")
+	genautocompleteCmd.PersistentFlags().StringVarP(&autocompleteType, "type", "", "bash", "Autocompletion type (currently only bash supported)")
+
+}

--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -76,6 +76,7 @@ func AddCommands() {
 	HugoCmd.AddCommand(newCmd)
 	HugoCmd.AddCommand(listCmd)
 	HugoCmd.AddCommand(undraftCmd)
+	HugoCmd.AddCommand(genautocompleteCmd)
 }
 
 //Initializes flags
@@ -102,6 +103,12 @@ func init() {
 	HugoCmd.Flags().BoolVarP(&BuildWatch, "watch", "w", false, "watch filesystem for changes and recreate as needed")
 	HugoCmd.Flags().BoolVarP(&NoTimes, "noTimes", "", false, "Don't sync modification time of files")
 	hugoCmdV = HugoCmd
+
+	// for Bash autocomplete
+	validConfigFilenames := []string{"json", "js", "yaml", "yml", "toml", "tml"}
+	annotation := make(map[string][]string)
+	annotation[cobra.BashCompFilenameExt] = validConfigFilenames
+	HugoCmd.PersistentFlags().Lookup("config").Annotations = annotation
 
 	// This message will be shown to Windows users if Hugo is opened from explorer.exe
 	cobra.MousetrapHelpText = `


### PR DESCRIPTION
Add a new command, bashcompletion, wich generates a Bash completion script.

The script is by default written to `/etc/bash_completion.d/hugo.sh`; this can be set in `--bashCompletionFile=/some/file`.

Fixes #438