### PR TITLE
Allow forward slashes in Hugo new on Windows

### DIFF
--- a/commands/new.go
+++ b/commands/new.go
@@ -92,10 +92,7 @@ func NewContent(cmd *cobra.Command, args []string) {
 
 	var kind string
 
-	// assume the first directory is the section (kind)
-	if strings.Contains(createpath[1:], helpers.FilePathSeparator) {
-		kind = helpers.GuessSection(createpath)
-	}
+	createpath, kind = newContentPathSection(createpath)
 
 	if contentType != "" {
 		kind = contentType
@@ -249,6 +246,19 @@ min_version = 0.13
 	}
 
 	return nil
+}
+
+func newContentPathSection(path string) (string, string) {
+	// Forward slashes is used in all examples. Convert if needed.
+	// Issue #1133
+	createpath := strings.Replace(path, "/", helpers.FilePathSeparator, -1)
+	var section string
+	// assume the first directory is the section (kind)
+	if strings.Contains(createpath[1:], helpers.FilePathSeparator) {
+		section = helpers.GuessSection(createpath)
+	}
+
+	return createpath, section
 }
 
 func createConfig(inpath string, kind string) (err error) {

--- a/commands/new_test.go
+++ b/commands/new_test.go
@@ -1,0 +1,14 @@
+package commands
+
+import (
+	"github.com/stretchr/testify/assert"
+	"path/filepath"
+	"testing"
+)
+
+// Issue #1133
+func TestNewContentPathSectionWithForwardSlashes(t *testing.T) {
+	p, s := newContentPathSection("/post/new.md")
+	assert.Equal(t, filepath.FromSlash("/post/new.md"), p)
+	assert.Equal(t, "post", s)
+}


### PR DESCRIPTION
Fixes  #1133