### PR TITLE
Add support for URLs relative to context root

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -139,6 +139,7 @@ func InitializeConfig() {
 	viper.SetDefault("Verbose", false)
 	viper.SetDefault("IgnoreCache", false)
 	viper.SetDefault("CanonifyURLs", false)
+	viper.SetDefault("RelativeURLs", false)
 	viper.SetDefault("Taxonomies", map[string]string{"tag": "tags", "category": "categories"})
 	viper.SetDefault("Permalinks", make(hugolib.PermalinkOverrides, 0))
 	viper.SetDefault("Sitemap", hugolib.Sitemap{Priority: -1})

--- a/helpers/path.go
+++ b/helpers/path.go
@@ -232,6 +232,41 @@ func MakePathRelative(inPath string, possibleDirectories ...string) (string, err
 	return inPath, errors.New("Can't extract relative path, unknown prefix")
 }
 
+// Should be good enough for Hugo.
+var isFileRe = regexp.MustCompile(".*\\..{1,6}$")
+
+// Expects a relative path starting after the content directory.
+func GetDottedRelativePath(inPath string) string {
+	inPath = filepath.Clean(filepath.FromSlash(inPath))
+	if inPath == "." {
+		return "./"
+	}
+	isFile := isFileRe.MatchString(inPath)
+	if !isFile {
+		if !strings.HasSuffix(inPath, FilePathSeparator) {
+			inPath += FilePathSeparator
+		}
+	}
+	if !strings.HasPrefix(inPath, FilePathSeparator) {
+		inPath = FilePathSeparator + inPath
+	}
+	dir, _ := filepath.Split(inPath)
+
+	sectionCount := strings.Count(dir, FilePathSeparator)
+
+	if sectionCount == 0 || dir == FilePathSeparator {
+		return "./"
+	}
+
+	var dottedPath string
+
+	for i := 1; i < sectionCount; i++ {
+		dottedPath += "../"
+	}
+
+	return dottedPath
+}
+
 // Filename takes a path, strips out the extension,
 // and returns the name of the file.
 func Filename(in string) (name string) {

--- a/helpers/path_test.go
+++ b/helpers/path_test.go
@@ -112,6 +112,45 @@ func TestMakePathRelative(t *testing.T) {
 	}
 }
 
+func TestGetDottedRelativePath(t *testing.T) {
+	// on Windows this will receive both kinds, both country and western ...
+	for _, f := range []func(string) string{filepath.FromSlash, func(s string) string { return s }} {
+		doTestGetDottedRelativePath(f, t)
+	}
+
+}
+
+func doTestGetDottedRelativePath(urlFixer func(string) string, t *testing.T) {
+	type test struct {
+		input, expected string
+	}
+	data := []test{
+		{"", "./"},
+		{urlFixer("/"), "./"},
+		{urlFixer("post"), "../"},
+		{urlFixer("/post"), "../"},
+		{urlFixer("post/"), "../"},
+		{urlFixer("tags/foo.html"), "../"},
+		{urlFixer("/tags/foo.html"), "../"},
+		{urlFixer("/post/"), "../"},
+		{urlFixer("////post/////"), "../"},
+		{urlFixer("/foo/bar/index.html"), "../../"},
+		{urlFixer("/foo/bar/foo/"), "../../../"},
+		{urlFixer("/foo/bar/foo"), "../../../"},
+		{urlFixer("foo/bar/foo/"), "../../../"},
+		{urlFixer("foo/bar/foo/bar"), "../../../../"},
+		{"404.html", "./"},
+		{"404.xml", "./"},
+		{"/404.html", "./"},
+	}
+	for i, d := range data {
+		output := GetDottedRelativePath(d.input)
+		if d.expected != output {
+			t.Errorf("Test %d failed. Expected %q got %q", i, d.expected, output)
+		}
+	}
+}
+
 func TestMakeTitle(t *testing.T) {
 	type test struct {
 		input, expected string

--- a/target/file.go
+++ b/target/file.go
@@ -16,6 +16,11 @@ type Translator interface {
 	Translate(string) (string, error)
 }
 
+// TODO(bep) consider other ways to solve this.
+type OptionalTranslator interface {
+	TranslateRelative(string) (string, error)
+}
+
 type Output interface {
 	Publisher
 	Translator

--- a/target/page.go
+++ b/target/page.go
@@ -32,10 +32,18 @@ func (pp *PagePub) Publish(path string, r io.Reader) (err error) {
 }
 
 func (pp *PagePub) Translate(src string) (dest string, err error) {
+	dir, err := pp.TranslateRelative(src)
+	if err != nil {
+		return dir, err
+	}
+	if pp.PublishDir != "" {
+		dir = filepath.Join(pp.PublishDir, dir)
+	}
+	return dir, nil
+}
+
+func (pp *PagePub) TranslateRelative(src string) (dest string, err error) {
 	if src == helpers.FilePathSeparator {
-		if pp.PublishDir != "" {
-			return filepath.Join(pp.PublishDir, "index.html"), nil
-		}
 		return "index.html", nil
 	}
 
@@ -43,9 +51,6 @@ func (pp *PagePub) Translate(src string) (dest string, err error) {
 	isRoot := dir == ""
 	ext := pp.extension(filepath.Ext(file))
 	name := filename(file)
-	if pp.PublishDir != "" {
-		dir = filepath.Join(pp.PublishDir, dir)
-	}
 
 	if pp.UglyURLs || file == "index.html" || (isRoot && file == "404.html") {
 		return filepath.Join(dir, fmt.Sprintf("%s%s", name, ext)), nil

--- a/transform/absurl.go
+++ b/transform/absurl.go
@@ -1,58 +1,11 @@
 package transform
 
-import (
-	"github.com/spf13/viper"
-	"sync"
-)
+var ar *absURLReplacer = newAbsURLReplacer()
 
-// to be used in tests; the live site will get its value from Viper.
-var AbsBaseUrl string
-
-var absURLInit sync.Once
-var ar *absURLReplacer
-
-func AbsURL() (trs []link, err error) {
-	initAbsURLReplacer()
-	return absURLFromReplacer(ar)
+var AbsURL = func(ct contentTransformer) {
+	ar.replaceInHTML(ct)
 }
 
-func absURLFromURL(URL string) (trs []link, err error) {
-	return absURLFromReplacer(newAbsURLReplacer(URL))
-}
-
-func absURLFromReplacer(ar *absURLReplacer) (trs []link, err error) {
-	trs = append(trs, func(ct contentTransformer) {
-		ar.replaceInHTML(ct)
-	})
-	return
-}
-
-func AbsURLInXML() (trs []link, err error) {
-	initAbsURLReplacer()
-	return absURLInXMLFromReplacer(ar)
-}
-
-func absURLInXMLFromURL(URL string) (trs []link, err error) {
-	return absURLInXMLFromReplacer(newAbsURLReplacer(URL))
-}
-
-func absURLInXMLFromReplacer(ar *absURLReplacer) (trs []link, err error) {
-	trs = append(trs, func(ct contentTransformer) {
-		ar.replaceInXML(ct)
-	})
-	return
-}
-
-func initAbsURLReplacer() {
-	absURLInit.Do(func() {
-		var url string
-
-		if AbsBaseUrl != "" {
-			url = AbsBaseUrl
-		} else {
-			url = viper.GetString("BaseURL")
-		}
-
-		ar = newAbsURLReplacer(url)
-	})
+var AbsURLInXML = func(ct contentTransformer) {
+	ar.replaceInXML(ct)
 }

--- a/transform/chain.go
+++ b/transform/chain.go
@@ -23,6 +23,7 @@ func NewEmptyTransforms() []link {
 // contentTransformer is an interface that enables rotation  of pooled buffers
 // in the transformer chain.
 type contentTransformer interface {
+	Path() []byte
 	Content() []byte
 	io.Writer
 }
@@ -30,8 +31,13 @@ type contentTransformer interface {
 // Implements contentTransformer
 // Content is read from the from-buffer and rewritten to to the to-buffer.
 type fromToBuffer struct {
+	path []byte
 	from *bytes.Buffer
 	to   *bytes.Buffer
+}
+
+func (ft fromToBuffer) Path() []byte {
+	return ft.path
 }
 
 func (ft fromToBuffer) Write(p []byte) (n int, err error) {
@@ -42,7 +48,7 @@ func (ft fromToBuffer) Content() []byte {
 	return ft.from.Bytes()
 }
 
-func (c *chain) Apply(w io.Writer, r io.Reader) error {
+func (c *chain) Apply(w io.Writer, r io.Reader, p []byte) error {
 
 	b1 := bp.GetBuffer()
 	defer bp.PutBuffer(b1)
@@ -57,7 +63,7 @@ func (c *chain) Apply(w io.Writer, r io.Reader) error {
 	b2 := bp.GetBuffer()
 	defer bp.PutBuffer(b2)
 
-	fb := &fromToBuffer{from: b1, to: b2}
+	fb := &fromToBuffer{path: p, from: b1, to: b2}
 
 	for i, tr := range *c {
 		if i > 0 {


### PR DESCRIPTION
 Add support for URLs relative to context root

Setting `RelativeURLs` to `true` will make all relative URLs in the site *really* relative.

And will do so with speed.

So:

In `/post/myblogpost.html`:

`/mycss.css` becomes `../mycss.css`

The same in `/index.html` will become:

`./mycss.css` etc.

Note that absolute URLs will not be touched (either external resources, or URLs constructed with `BaseURL`).

The speediness is about the same as before:

```
benchmark                    old ns/op     new ns/op     delta
BenchmarkAbsURL              17462         18164         +4.02%
BenchmarkAbsURLSrcset        18842         19632         +4.19%
BenchmarkXMLAbsURLSrcset     18643         19313         +3.59%
BenchmarkXMLAbsURL           9283          9656          +4.02%

benchmark                    old allocs     new allocs     delta
BenchmarkAbsURL              24             28             +16.67%
BenchmarkAbsURLSrcset        29             32             +10.34%
BenchmarkXMLAbsURLSrcset     27             30             +11.11%
BenchmarkXMLAbsURL           12             14             +16.67%

benchmark                    old bytes     new bytes     delta
BenchmarkAbsURL              3154          3404          +7.93%
BenchmarkAbsURLSrcset        2376          2573          +8.29%
BenchmarkXMLAbsURLSrcset     2569          2763          +7.55%
BenchmarkXMLAbsURL           1888          1998          +5.83%

```

Fixes #1104
Fixes #622