### PR TITLE
Edits to templates/404.md

### DIFF
--- a/docs/content/templates/404.md
+++ b/docs/content/templates/404.md
@@ -14,9 +14,9 @@ weight: 100
 ---
 
 When using Hugo with [GitHub Pages](http://pages.github.com/), you can provide
-your own template for a [custom 404 error page](https://help.github.com/articles/custom-404-pages/) by creating a 404.html file in the root.
+your own template for a [custom 404 error page](https://help.github.com/articles/custom-404-pages/) by creating a 404.html template file in your `/layouts` folder. When Hugo generates your site, the `404.html` file will be placed in the root.
 
-404 pages are of the type "node" and have all the [node
+404 pages are of the type **"node"** and have all the [node
 variables](/layout/variables/) available to use in the templates.
 
 In addition to the standard node variables, the 404 page has access to
@@ -39,4 +39,13 @@ This is a basic example of a 404.html template:
     </section>
 
     {{ partial "footer.html" . }}
+
+### Automatic Loading
+
+Your 404.html file can be set to load automatically when a visitor enters a mistaken URL path, dependent upon the web serving environment you are using. For example: 
+
+* _Github Pages_ - it's automatic. 
+* _Apache_ - one way is to specify `ErrorDocument 404 /404.html` in an `.htaccess` file in the root of your site.
+* _Nginx_ - you might specify `error_page   404  =  /404.html;` in your `nginx.conf` file. 
+* _Amazon AWS S3_ - when setting a bucket up for static web serving, you can specify the error file.
 


### PR DESCRIPTION
Added bit about how the 404.html page has to be set to load automatically - auto on Github but needs config on other web servers.

Also tweaked the text a little to emphasize it's a node type, and explain a little more about where the 404 template should be saved.