### PR TITLE
Fix #1166 Add 1x retry with 2sec sleep time. (+Tests)

### DIFF
--- a/tpl/template_resources.go
+++ b/tpl/template_resources.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/hugo/helpers"
@@ -31,7 +32,11 @@ import (
 	"github.com/spf13/viper"
 )
 
-var remoteURLLock = &remoteLock{m: make(map[string]*sync.Mutex)}
+var (
+	remoteURLLock = &remoteLock{m: make(map[string]*sync.Mutex)}
+	resSleep      = time.Second * 2 // if JSON decoding failed sleep for n seconds before retrying
+	resRetries    = 1               // number of retries to load the JSON from URL or local file system
+)
 
 type remoteLock struct {
 	sync.RWMutex
@@ -90,13 +95,21 @@ func resWriteCache(id string, c []byte, fs afero.Fs) error {
 	fID := getCacheFileID(id)
 	f, err := fs.Create(fID)
 	if err != nil {
-		return err
+		return errors.New("Error: " + err.Error() + ". Failed to create file: " + fID)
 	}
+	defer f.Close()
 	n, err := f.Write(c)
 	if n == 0 {
 		return errors.New("No bytes written to file: " + fID)
 	}
-	return err
+	if err != nil {
+		return errors.New("Error: " + err.Error() + ". Failed to write to file: " + fID)
+	}
+	return nil
+}
+
+func resDeleteCache(id string, fs afero.Fs) error {
+	return fs.Remove(getCacheFileID(id))
 }
 
 // resGetRemote loads the content of a remote file. This method is thread safe.
@@ -177,18 +190,25 @@ func resGetResource(url string) ([]byte, error) {
 // If you provide multiple parts they will be joined together to the final URL.
 // GetJSON returns nil or parsed JSON to use in a short code.
 func GetJSON(urlParts ...string) interface{} {
-	url := strings.Join(urlParts, "")
-	c, err := resGetResource(url)
-	if err != nil {
-		jww.ERROR.Printf("Failed to get json resource %s with error message %s", url, err)
-		return nil
-	}
-
 	var v interface{}
-	err = json.Unmarshal(c, &v)
-	if err != nil {
-		jww.ERROR.Printf("Cannot read json from resource %s with error message %s", url, err)
-		return nil
+	url := strings.Join(urlParts, "")
+
+	for i := 0; i <= resRetries; i++ {
+		c, err := resGetResource(url)
+		if err != nil {
+			jww.ERROR.Printf("Failed to get json resource %s with error message %s", url, err)
+			return nil
+		}
+
+		err = json.Unmarshal(c, &v)
+		if err != nil {
+			jww.ERROR.Printf("Cannot read json from resource %s with error message %s", url, err)
+			jww.ERROR.Printf("Retry #%d for %s and sleeping for %s", i, url, resSleep)
+			time.Sleep(resSleep)
+			resDeleteCache(url, hugofs.SourceFs)
+			continue
+		}
+		break
 	}
 	return v
 }
@@ -212,16 +232,34 @@ func parseCSV(c []byte, sep string) ([][]string, error) {
 // If you provide multiple parts for the URL they will be joined together to the final URL.
 // GetCSV returns nil or a slice slice to use in a short code.
 func GetCSV(sep string, urlParts ...string) [][]string {
+	var d [][]string
 	url := strings.Join(urlParts, "")
-	c, err := resGetResource(url)
-	if err != nil {
-		jww.ERROR.Printf("Failed to get csv resource %s with error message %s", url, err)
-		return nil
+
+	var clearCacheSleep = func(i int, u string) {
+		jww.ERROR.Printf("Retry #%d for %s and sleeping for %s", i, url, resSleep)
+		time.Sleep(resSleep)
+		resDeleteCache(url, hugofs.SourceFs)
 	}
-	d, err := parseCSV(c, sep)
-	if err != nil {
-		jww.ERROR.Printf("Failed to read csv resource %s with error message %s", url, err)
-		return nil
+
+	for i := 0; i <= resRetries; i++ {
+		c, err := resGetResource(url)
+
+		if err == nil && false == bytes.Contains(c, []byte(sep)) {
+			err = errors.New("Cannot find separator " + sep + " in CSV.")
+		}
+
+		if err != nil {
+			jww.ERROR.Printf("Failed to read csv resource %s with error message %s", url, err)
+			clearCacheSleep(i, url)
+			continue
+		}
+
+		if d, err = parseCSV(c, sep); err != nil {
+			jww.ERROR.Printf("Failed to parse csv file %s with error message %s", url, err)
+			clearCacheSleep(i, url)
+			continue
+		}
+		break
 	}
 	return d
 }


### PR DESCRIPTION
The retry gets triggered when the parsing of the content fails.
JSON unmarshal fails due to invalid JSON -> retry
CSV cannot find separator -> retry
CSV failed to parse -> retry

HTTP Response from host gets not checked nor there is a timeout
configured for the default http client.

If I should check for the returned HTTP status code ( != 200 ) then I need another client library ... which is one more dependency for hugo ... let me know.