### PR TITLE
Add `after` template function to complement `first`

### DIFF
--- a/docs/content/templates/functions.md
+++ b/docs/content/templates/functions.md
@@ -76,10 +76,23 @@ e.g.
         {{ .Render "summary" }}
     {{ end }}
 
+### last
+Slices an array to only the last X elements.
+
+Works on [lists](/templates/list/), [taxonomies](/taxonomies/displaying/), [terms](/templates/terms/), [groups](/templates/list/)
+
+e.g.
+
+    {{ range last 10 .Data.Pages }}
+        {{ .Render "summary" }}
+    {{ end }}
+
 ### after
 Slices an array to only the items after the Xth item. Use this in 
 combination with `first` use both halves of an array split a item
 X.
+
+Works on [lists](/templates/list/), [taxonomies](/taxonomies/displaying/), [terms](/templates/terms/), [groups](/templates/list/)
 
 e.g.
 

--- a/docs/content/templates/functions.md
+++ b/docs/content/templates/functions.md
@@ -76,6 +76,16 @@ e.g.
         {{ .Render "summary" }}
     {{ end }}
 
+### after
+Slices an array to only the items after the Xth item. Use this in 
+combination with `first` use both halves of an array split a item
+X.
+
+e.g.
+
+    {{ range after 10 .Data.Pages }}
+        {{ .Render "title" }}
+    {{ end }}
 
 ### getenv
 Returns the value of an environment variable.

--- a/tpl/template_funcs.go
+++ b/tpl/template_funcs.go
@@ -390,19 +390,19 @@ func First(limit interface{}, seq interface{}) (interface{}, error) {
 
 // After is exposed to templates, to iterate over all the items after N in a
 // rangeable list. It's meant to accompany First
-func After(limit interface{}, seq interface{}) (interface{}, error) {
+func After(index interface{}, seq interface{}) (interface{}, error) {
 
-	if limit == nil || seq == nil {
+	if index == nil || seq == nil {
 		return nil, errors.New("both limit and seq must be provided")
 	}
 
-	limitv, err := cast.ToIntE(limit)
+	indexv, err := cast.ToIntE(index)
 
 	if err != nil {
 		return nil, err
 	}
 
-	if limitv < 1 {
+	if indexv < 1 {
 		return nil, errors.New("can't return negative/empty count of items from sequence")
 	}
 
@@ -418,10 +418,10 @@ func After(limit interface{}, seq interface{}) (interface{}, error) {
 	default:
 		return nil, errors.New("can't iterate over " + reflect.ValueOf(seq).Type().String())
 	}
-	if limitv >= seqv.Len() {
+	if indexv >= seqv.Len() {
 		return nil, errors.New("no items left")
 	}
-	return seqv.Slice(limitv, seqv.Len()).Interface(), nil
+	return seqv.Slice(indexv, seqv.Len()).Interface(), nil
 }
 
 var (

--- a/tpl/template_funcs_test.go
+++ b/tpl/template_funcs_test.go
@@ -253,6 +253,40 @@ func TestFirst(t *testing.T) {
 	}
 }
 
+func TestLast(t *testing.T) {
+	for i, this := range []struct {
+		count    interface{}
+		sequence interface{}
+		expect   interface{}
+	}{
+		{int(2), []string{"a", "b", "c"}, []string{"b", "c"}},
+		{int32(3), []string{"a", "b"}, []string{"a", "b"}},
+		{int64(2), []int{100, 200, 300}, []int{200, 300}},
+		{100, []int{100, 200}, []int{100, 200}},
+		{"1", []int{100, 200, 300}, []int{300}},
+		{int64(-1), []int{100, 200, 300}, false},
+		{"noint", []int{100, 200, 300}, false},
+		{1, nil, false},
+		{nil, []int{100}, false},
+		{1, t, false},
+	} {
+		results, err := Last(this.count, this.sequence)
+		if b, ok := this.expect.(bool); ok && !b {
+			if err == nil {
+				t.Errorf("[%d] First didn't return an expected error", i)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("[%d] failed: %s", i, err)
+				continue
+			}
+			if !reflect.DeepEqual(results, this.expect) {
+				t.Errorf("[%d] First %d items, got %v but expected %v", i, this.count, results, this.expect)
+			}
+		}
+	}
+}
+
 func TestAfter(t *testing.T) {
 	for i, this := range []struct {
 		count    interface{}

--- a/tpl/template_funcs_test.go
+++ b/tpl/template_funcs_test.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"html/template"
 	"path"
 	"reflect"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type tstNoStringer struct {
@@ -236,6 +237,40 @@ func TestFirst(t *testing.T) {
 		{1, t, false},
 	} {
 		results, err := First(this.count, this.sequence)
+		if b, ok := this.expect.(bool); ok && !b {
+			if err == nil {
+				t.Errorf("[%d] First didn't return an expected error", i)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("[%d] failed: %s", i, err)
+				continue
+			}
+			if !reflect.DeepEqual(results, this.expect) {
+				t.Errorf("[%d] First %d items, got %v but expected %v", i, this.count, results, this.expect)
+			}
+		}
+	}
+}
+
+func TestAfter(t *testing.T) {
+	for i, this := range []struct {
+		count    interface{}
+		sequence interface{}
+		expect   interface{}
+	}{
+		{int(2), []string{"a", "b", "c", "d"}, []string{"c", "d"}},
+		{int32(3), []string{"a", "b"}, false},
+		{int64(2), []int{100, 200, 300}, []int{300}},
+		{100, []int{100, 200}, false},
+		{"1", []int{100, 200, 300}, []int{200, 300}},
+		{int64(-1), []int{100, 200, 300}, false},
+		{"noint", []int{100, 200, 300}, false},
+		{1, nil, false},
+		{nil, []int{100}, false},
+		{1, t, false},
+	} {
+		results, err := After(this.count, this.sequence)
 		if b, ok := this.expect.(bool); ok && !b {
 			if err == nil {
 				t.Errorf("[%d] First didn't return an expected error", i)


### PR DESCRIPTION
The `first` template function allows the user to select the first X items of an array. I have a use case where I want those X first items, but I also want the rest of the items after X for separate processing. `after` adds this functionality.

```go
{{ range after 10 .Data.Pages }}
    {{ .Render "title" }}
{{ end }}
```
There is one open question and that's the one of naming things :smiling_imp: 
Is `after` properly named? I chose it over `remaining`, as the supplied limit would not make sense. Are there any other candidates that need to be considered? /cc @spf13 what's your opinion on this?