### PR TITLE
Let travis test against go-tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: go
 go:
   - 1.3
   - 1.4.2
+  - tip
+matrix:
+  allow_failures:
+    - go: tip
 script:
   - go test ./...
   - go build


### PR DESCRIPTION
Just a quick PR to let Travis test against go-tip as well. Go tip is not supported by Hugo (I would assume), but it's a great way to know if there are any issues with upcoming releases of Go. Testing against Go tip has been marked as an allowed failure.