### PR TITLE
[Windows] Fix taxonomy pages generation

### DIFF
--- a/target/file.go
+++ b/target/file.go
@@ -40,7 +40,7 @@ func (fs *Filesystem) Publish(path string, r io.Reader) (err error) {
 }
 
 func (fs *Filesystem) Translate(src string) (dest string, err error) {
-	return filepath.Join(fs.PublishDir, src), nil
+	return filepath.Join(fs.PublishDir, filepath.FromSlash(src)), nil
 }
 
 func (fs *Filesystem) extension(ext string) string {


### PR DESCRIPTION
Hugo uses the taxonomy base generated in https://github.com/spf13/hugo/blob/master/hugolib/site.go#L1095
as a path destination, and also other things that I don't understand.

The problem is that in windows, it tries to generate taxonomy pages with `/` in the path, rather than `\`. Creating a bunch of additional garbage files in the public directory. Things like `public/tagslatest_reviews.html` and so on. This is caused because the `/` is completely ignored, forming filenames with the format `TAXONOMY_PLURALterm.html`.

This might not be the _right_ fix, but it solves the problem. I don't know much about Hugo's internals to actually find the _right_ solution.

Signed-off-by: David Calavera <david.calavera@gmail.com>