### PR TITLE
Add support for baseof.ace templates in themes.

### DIFF
--- a/docs/content/templates/ace.md
+++ b/docs/content/templates/ace.md
@@ -35,6 +35,8 @@ In Hugo the base template will be chosen in the following order:
 2. <current-path>/baseof.ace
 3. _default/<template-name>-baseof.ace, e.g. list-baseof.ace.
 4. _default/baseof.ace	
+5. <themedir>/layouts/_default/<template-name>-baseof.ace
+6. <themedir>/layouts/_default/baseof.ace
 ```
 
 In the above, `current-path` is where the corresponding inner template lives, `list.ace`, `single.ace`, `index.ace` ...

--- a/helpers/path.go
+++ b/helpers/path.go
@@ -204,6 +204,15 @@ func GetStaticDirPath() string {
 	return AbsPathify(viper.GetString("StaticDir"))
 }
 
+// Get the root directory of the current theme, if there is one.
+// If there is no theme, returns the empty string.
+func GetThemeDir() string {
+	if ThemeSet() {
+		return AbsPathify(filepath.Join("themes", viper.GetString("theme")))
+	}
+	return ""
+}
+
 // GetThemeStaticDirPath returns the theme's static dir path if theme is set.
 // If theme is set and the static dir doesn't exist, an error is returned.
 func GetThemeStaticDirPath() (string, error) {
@@ -219,7 +228,7 @@ func GetThemeDataDirPath() (string, error) {
 func getThemeDirPath(path string) (string, error) {
 	var themeDir string
 	if ThemeSet() {
-		themeDir = AbsPathify("themes/"+viper.GetString("theme")) + FilePathSeparator + path
+		themeDir = filepath.Join(GetThemeDir(), path)
 		if _, err := os.Stat(themeDir); os.IsNotExist(err) {
 			return "", fmt.Errorf("Unable to find %s directory for theme %s in %s", path, viper.GetString("theme"), themeDir)
 		}
@@ -227,8 +236,11 @@ func getThemeDirPath(path string) (string, error) {
 	return themeDir, nil
 }
 
+// Get the 'static' directory of the current theme, if there is one.
+// Ignores underlying errors. Candidate for deprecation?
 func GetThemesDirPath() string {
-	return AbsPathify(filepath.Join("themes", viper.GetString("theme"), "static"))
+	dir, _ := getThemeDirPath("static")
+	return dir
 }
 
 func MakeStaticPathRelative(inPath string) (string, error) {

--- a/tpl/template.go
+++ b/tpl/template.go
@@ -21,7 +21,6 @@ import (
 	"github.com/spf13/hugo/helpers"
 	"github.com/spf13/hugo/hugofs"
 	jww "github.com/spf13/jwalterweatherman"
-	"github.com/spf13/viper"
 	"github.com/yosssi/ace"
 	"html/template"
 	"io"
@@ -306,8 +305,7 @@ func (t *GoHTMLTemplate) loadTemplates(absPath string, prefix string) {
 
 					currBaseAceFilename := fmt.Sprintf("%s-%s", helpers.Filename(path), baseAceFilename)
 					templateDir := filepath.Dir(path)
-					themeDir := filepath.Join(
-						viper.GetString("WorkingDir"), "themes", viper.GetString("theme"))
+					themeDir := helpers.GetThemeDir()
 
 					pathsToCheck := []string{
 						filepath.Join(templateDir, currBaseAceFilename),

--- a/tpl/template.go
+++ b/tpl/template.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/hugo/helpers"
 	"github.com/spf13/hugo/hugofs"
 	jww "github.com/spf13/jwalterweatherman"
+	"github.com/spf13/viper"
 	"github.com/yosssi/ace"
 	"html/template"
 	"io"
@@ -300,15 +301,22 @@ func (t *GoHTMLTemplate) loadTemplates(absPath string, prefix string) {
 					//   2. <current-path>/baseof.ace
 					//   3. _default/<template-name>-baseof.ace, e.g. list-baseof.ace.
 					//   4. _default/baseof.ace
+					//   5. <themedir>/layouts/_default/<template-name>-baseof.ace
+					//   6. <themedir>/layouts/_default/baseof.ace
 
 					currBaseAceFilename := fmt.Sprintf("%s-%s", helpers.Filename(path), baseAceFilename)
 					templateDir := filepath.Dir(path)
+					themeDir := filepath.Join(
+						viper.GetString("WorkingDir"), "themes", viper.GetString("theme"))
 
 					pathsToCheck := []string{
 						filepath.Join(templateDir, currBaseAceFilename),
 						filepath.Join(templateDir, baseAceFilename),
 						filepath.Join(absPath, "_default", currBaseAceFilename),
-						filepath.Join(absPath, "_default", baseAceFilename)}
+						filepath.Join(absPath, "_default", baseAceFilename),
+						filepath.Join(themeDir, "layouts", "_default", currBaseAceFilename),
+						filepath.Join(themeDir, "layouts", "_default", baseAceFilename),
+					}
 
 					for _, pathToCheck := range pathsToCheck {
 						if ok, err := helpers.Exists(pathToCheck, hugofs.OsFs); err == nil && ok {


### PR DESCRIPTION
When we find a template that requires a base template, we should also look
for that base template in the current theme.

Fixes #1215.