### PR TITLE
Proper parsing structured array from yaml based FrontMatter

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -518,11 +518,21 @@ func (p *Page) update(f interface{}) error {
 			default: // handle array of strings as well
 				switch vvv := vv.(type) {
 				case []interface{}:
-					var a = make([]string, len(vvv))
-					for i, u := range vvv {
-						a[i] = cast.ToString(u)
+					if len(vvv) > 0 {
+						switch vvv[0].(type) {
+						case map[interface{}]interface{}: // Proper parsing structured array from yaml based FrontMatter
+							p.Params[loki] = vvv
+						default:
+							a := make([]string, len(vvv))
+							for i, u := range vvv {
+								a[i] = cast.ToString(u)
+							}
+
+							p.Params[loki] = a
+						}
+					} else {
+						p.Params[loki] = []string{}
 					}
-					p.Params[loki] = a
 				default:
 					p.Params[loki] = vv
 				}


### PR DESCRIPTION
I have faced exactly same problem like here: http://discuss.gohugo.io/t/use-an-array-of-structured-frontmatter-in-yaml/207

Since i use same markdown file as a input for pandoc converter i cant simply prefix structure by `params:`.