### PR TITLE
Allow page.HasMenuCurrent() and node.HasMenuCurrent() to proceed with…

### DIFF
--- a/hugolib/menu_test.go
+++ b/hugolib/menu_test.go
@@ -471,7 +471,7 @@ func TestHomeNodeMenu(t *testing.T) {
 		{"main", homeMenuEntry, true, false},
 		{"doesnotexist", homeMenuEntry, false, false},
 		{"main", &MenuEntry{Name: "Somewhere else", URL: "/somewhereelse"}, false, false},
-		{"grandparent", findTestMenuEntryByID(s, "grandparent", "grandparentId"), false, false},
+		{"grandparent", findTestMenuEntryByID(s, "grandparent", "grandparentId"), false, true},
 		{"grandparent", findTestMenuEntryByID(s, "grandparent", "parentId"), false, true},
 		{"grandparent", findTestMenuEntryByID(s, "grandparent", "grandchildId"), true, false},
 	} {

--- a/hugolib/node.go
+++ b/hugolib/node.go
@@ -14,10 +14,11 @@
 package hugolib
 
 import (
-	"github.com/spf13/hugo/helpers"
 	"html/template"
 	"sync"
 	"time"
+
+	"github.com/spf13/hugo/helpers"
 )
 
 type Node struct {
@@ -49,6 +50,9 @@ func (n *Node) HasMenuCurrent(menuID string, inme *MenuEntry) bool {
 
 		for _, child := range inme.Children {
 			if me.IsSameResource(child) {
+				return true
+			}
+			if n.HasMenuCurrent(menuID, child) {
 				return true
 			}
 		}

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -626,6 +626,9 @@ func (p *Page) HasMenuCurrent(menu string, me *MenuEntry) bool {
 				if child.IsEqual(m) {
 					return true
 				}
+				if p.HasMenuCurrent(menu, child) {
+					return true
+				}
 			}
 		}
 	}


### PR DESCRIPTION
… multi-level nested menus

Currently HasMenuCurrent() only process the first 2 levels.