### PR TITLE
Added missing "Social" section to SiteInfo

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -469,6 +469,7 @@ func (s *Site) initializeSiteInfo() {
 		BaseURL:               template.URL(helpers.SanitizeURLKeepTrailingSlash(viper.GetString("BaseURL"))),
 		Title:                 viper.GetString("Title"),
 		Author:                viper.GetStringMap("author"),
+		Social:                viper.GetStringMapString("social"),
 		LanguageCode:          viper.GetString("languagecode"),
 		Copyright:             viper.GetString("copyright"),
 		DisqusShortname:       viper.GetString("DisqusShortname"),


### PR DESCRIPTION
I could be wrong here, but it looks to me like .Site.Social.facebook is used in tpl/template_embedded.go, but the variable is never set. I've added a line to initializeSiteInfo to map the info from config into this variable.