### PR TITLE
Add Page.RawContent() to access raw Markdown as a string.

### DIFF
--- a/docs/content/templates/variables.md
+++ b/docs/content/templates/variables.md
@@ -49,6 +49,7 @@ matter, content or derived from file location.
 **.WordCount** The number of words in the content.<br>
 **.ReadingTime** The estimated time it takes to read the content in minutes.<br>
 **.Weight** Assigned weight (in the front matter) to this content, used in sorting.<br>
+**.RawContent** Raw Markdown content without the metadata header. Useful with [remarkjs.com](http://remarkjs.com)<br>
 **.IsNode** Always false for pages.<br>
 **.IsPage** Always true for page.<br>
 **.Site** See [Site Variables]({{< relref "#site-variables" >}}) below.<br>

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -726,6 +726,10 @@ func (p *Page) parse(reader io.Reader) error {
 	return nil
 }
 
+func (p *Page) RawContent() string {
+	return string(p.rawContent)
+}
+
 func (p *Page) SetSourceContent(content []byte) {
 	p.Source.Content = content
 }


### PR DESCRIPTION
In particular, RawContent() excludes the metadata header.

This is necessary in the use case of embedding remarkjs.com slides, as it needs
the unprocessed Markdown content to generate the slides.


So a remarkjs based single.html will look like this:
```
<!DOCTYPE html>
<html>
<head>
  ...
  <script src="//gnab.github.io/remark/downloads/remark-latest.min.js"></script>
</head>
<body>
  <textarea id="source">
{{ .RawContent }}
  </textarea>
  <script>
    var slideshow = remark.create({});
  </script>
</body>
</html>
```