### PR TITLE
Omit protocol from embedded font resources

### DIFF
--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -11,7 +11,7 @@
     <!-- Bootstrap core CSS -->
     <link href="/css/bootstrap-theme.css" rel="stylesheet">
 
-    <link href='http://fonts.googleapis.com/css?family=Arbutus+Slab%7CCabin:600%7CSource+Code+Pro' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Arbutus+Slab%7CCabin:600%7CSource+Code+Pro' rel='stylesheet' type='text/css'>
     <!-- Add custom CSS here -->
     <link href="/css/HPstyles.css" rel="stylesheet">
     <link href="/css/hugofont.css" rel="stylesheet">

--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -1,5 +1,5 @@
 /* Import fonts */
-@import url(http://fonts.googleapis.com/css?family=Lato:300,400,700,900,300italic,400italic,700italic,900italic);
+@import url(//fonts.googleapis.com/css?family=Lato:300,400,700,900,300italic,400italic,700italic,900italic);
 
 /* ******************************
  For the github btn


### PR DESCRIPTION
Fixes the mixed content errors and loads fonts when accessing
https://gohugo.io/