### PR TITLE
Allow page.HasMenuCurrent() and node.HasMenuCurrent() to proceed with multi-level nested menus

### DIFF
--- a/hugolib/menu_test.go
+++ b/hugolib/menu_test.go
@@ -471,7 +471,7 @@ func TestHomeNodeMenu(t *testing.T) {
 		{"main", homeMenuEntry, true, false},
 		{"doesnotexist", homeMenuEntry, false, false},
 		{"main", &MenuEntry{Name: "Somewhere else", URL: "/somewhereelse"}, false, false},
-		{"grandparent", findTestMenuEntryByID(s, "grandparent", "grandparentId"), false, false},
+		{"grandparent", findTestMenuEntryByID(s, "grandparent", "grandparentId"), false, true},
 		{"grandparent", findTestMenuEntryByID(s, "grandparent", "parentId"), false, true},
 		{"grandparent", findTestMenuEntryByID(s, "grandparent", "grandchildId"), true, false},
 	} {

--- a/hugolib/node.go
+++ b/hugolib/node.go
@@ -14,10 +14,11 @@
 package hugolib
 
 import (
-	"github.com/spf13/hugo/helpers"
 	"html/template"
 	"sync"
 	"time"
+
+	"github.com/spf13/hugo/helpers"
 )
 
 type Node struct {
@@ -49,6 +50,9 @@ func (n *Node) HasMenuCurrent(menuID string, inme *MenuEntry) bool {
 
 		for _, child := range inme.Children {
 			if me.IsSameResource(child) {
+				return true
+			}
+			if n.HasMenuCurrent(menuID, child) {
 				return true
 			}
 		}

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -626,6 +626,9 @@ func (p *Page) HasMenuCurrent(menu string, me *MenuEntry) bool {
 				if child.IsEqual(m) {
 					return true
 				}
+				if p.HasMenuCurrent(menu, child) {
+					return true
+				}
 			}
 		}
 	}


### PR DESCRIPTION

new PR, with fixed tests (first PR was #1226)

The following test fixture was buggy i think, because when i look into the menuItem from 
```findTestMenuEntryByID(s, "grandparent", "grandparentId")``` I can see my home menu.
This test worked before because HasMenuCurrent returned after checking the first children, without checking children of children... and so on...

@bep ,  please can you review :)