### PR TITLE
Let Amber template call Hugo's custom functions

### DIFF
--- a/tpl/template.go
+++ b/tpl/template.go
@@ -82,6 +82,9 @@ func New() Template {
 
 	localTemplates = &templates.Template
 
+	for k, v := range funcMap {
+		amber.FuncMap[k] = v
+	}
 	templates.Funcs(funcMap)
 	templates.LoadEmbedded()
 	return templates


### PR DESCRIPTION
Amber doesn't share text/template `FuncMap` functions and has its own
function list. This allows Amber to call Hugo's custom functions.