### PR TITLE
Fix links to Ace and Amber pages

### DIFF
--- a/docs/content/templates/ace.md
+++ b/docs/content/templates/ace.md
@@ -14,7 +14,7 @@ title: Ace Templates
 weight: 17
 ---
 
-In addition to [Go templates](/templates/go-templates) and [Amber](/templates/amber-templates) templates, Hugo supports the powerful Ace templates.
+In addition to [Go templates](/templates/go-templates) and [Amber](/templates/amber) templates, Hugo supports the powerful Ace templates.
 
 For template documentation, follow the links from the [Ace project](https://github.com/yosssi/ace). 
 

--- a/docs/content/templates/amber.md
+++ b/docs/content/templates/amber.md
@@ -14,7 +14,7 @@ title: Amber Templates
 weight: 18
 ---
 
-Amber templates are another template type which Hugo supports, in addition to [Go templates](/templates/go-templates) and [Ace templates](/templates/ace-templates) templates.
+Amber templates are another template type which Hugo supports, in addition to [Go templates](/templates/go-templates) and [Ace templates](/templates/ace) templates.
 
 For template documentation, follow the links from the [Amber project](https://github.com/eknkc/amber)
 


### PR DESCRIPTION
Links are incorrect in current version.  

http://gohugo.io/templates/ace/
refers to http://gohugo.io/templates/amber-templates  

and 

http://gohugo.io/templates/amber/
refers to http://gohugo.io/templates/ace-templates
