### PR TITLE
Asciidoc[tor]: use --no-header-footer option

### DIFF
--- a/helpers/content.go
+++ b/helpers/content.go
@@ -414,7 +414,7 @@ func GetAsciidocContent(content []byte) string {
 	}
 
 	jww.INFO.Println("Rendering with", path, "...")
-	cmd := exec.Command(path, "--safe", "-")
+	cmd := exec.Command(path, "--no-header-footer", "--safe", "-")
 	cmd.Stdin = bytes.NewReader(cleanContent)
 	var out bytes.Buffer
 	cmd.Stdout = &out
@@ -422,13 +422,7 @@ func GetAsciidocContent(content []byte) string {
 		jww.ERROR.Println(err)
 	}
 
-	asciidocLines := strings.Split(out.String(), "\n")
-	for i, line := range asciidocLines {
-		if strings.HasPrefix(line, "<body") {
-			asciidocLines = (asciidocLines[i+1 : len(asciidocLines)-3])
-		}
-	}
-	return strings.Join(asciidocLines, "\n")
+	return out.String()
 }
 
 // GetRstContent calls the Python script rst2html as an external helper


### PR DESCRIPTION
This simplifies the retrieval of the HTML (no more need to extract the
part within body) and also removes the unwanted "Last Updated" part in
the article.

This is somehow a followup to @mojavelinux 's comment here: https://github.com/spf13/hugo/issues/470#issuecomment-107251499

Cheers