### PR TITLE
Doc for other supported formats (external helpers)

### DIFF
--- a/docs/content/content/organization.md
+++ b/docs/content/content/organization.md
@@ -6,14 +6,14 @@ linktitle: Organization
 menu:
   main:
     parent: content
-next: /content/front-matter
+next: /content/supported-formats
 prev: /overview/source-directory
 title: Content Organization
 weight: 10
 toc: true
 ---
 
-Hugo uses Markdown files with headers commonly called the *front matter*. Hugo
+Hugo uses files (see [supported formats](/content/supported-formats/)) with headers commonly called the *front matter*. Hugo
 respects the organization that you provide for your content to minimize any
 extra configuration, though this can be overridden by additional configuration
 in the front matter.
@@ -30,7 +30,7 @@ in Hugo and is used as the [section](/content/sections/).
         ├── post
         |   ├── firstpost.md   // <- http://1.com/post/firstpost/
         |   ├── happy
-        |   |   └── ness.md    // <- http://1.com/post/happy/ness/
+        |   |   └── ness.ad  // <- http://1.com/post/happy/ness/
         |   └── secondpost.md  // <- http://1.com/post/secondpost/
         └── quote
             ├── first.md       // <- http://1.com/quote/first/
@@ -43,7 +43,7 @@ in Hugo and is used as the [section](/content/sections/).
         ├── post
         |   ├── firstpost.md   // <- http://1.com/post/firstpost.html
         |   ├── happy
-        |   |   └── ness.md    // <- http://1.com/post/happy/ness.html
+        |   |   └── ness.ad    // <- http://1.com/post/happy/ness.html
         |   └── secondpost.md  // <- http://1.com/post/secondpost.html
         └── quote
             ├── first.md       // <- http://1.com/quote/first.html

--- a/docs/content/content/supported-formats.md
+++ b/docs/content/content/supported-formats.md
@@ -1,0 +1,26 @@
+---
+aliases:
+- /doc/supported-formats/
+date: 2015-08-01
+menu:
+  main:
+    parent: content
+next: /content/front-matter
+prev: /content/organization
+title: Supported Formats
+weight: 15
+toc: true
+---
+
+  Since 0.14, Hugo has defined a new concept called _external helpers_. It means that you can write your content using Asciidoc[tor], or reStructuredText. If you have files with associated extensions ([details](https://github.com/spf13/hugo/blob/77c60a3440806067109347d04eb5368b65ea0fe8/helpers/general.go#L65)), then Hugo will call external commands to generate the content.
+
+  This means that you will have to install the associated tool on your machine to be able to use those formats.
+
+  For example, for Asciidoc files, Hugo will try to call __asciidoctor__ or __asciidoc__ command.
+
+  To use those formats, just use the standard extension and the front matter exactly as you would do with natively supported _.md_ files.
+
+  Notes:
+
+  * as these are external commands, generation performance for that content will heavily depend on the performance of those external tools.
+  * this feature is still in early stage, hence feedback is even more welcome.

--- a/docs/content/overview/introduction.md
+++ b/docs/content/overview/introduction.md
@@ -85,7 +85,7 @@ links work properly with most hosting companies.
 
 ## What does Hugo do?
 
-In technical terms, Hugo takes a source directory of Markdown files and
+In technical terms, Hugo takes a source directory of files and
 templates and uses these as input to create a complete website.
 
 Hugo boasts the following features:
@@ -114,7 +114,8 @@ Hugo boasts the following features:
 
 ### Content
 
-  * Content written in [Markdown](/content/example/)
+  * Native support for content written in [Markdown](/content/example/)
+    * Support for other languages through _external helpers_, see [supported formats](/content/supported-formats)
   * Support for TOML, YAML and JSON metadata in [frontmatter](/content/front-matter/)
   * Completely [customizable homepage](/layout/homepage/)
   * Support for multiple [content types](/content/types/)


### PR DESCRIPTION
Basically small doc refactoring to not make Markdown the only possible language usable with Hugo! :-)

As Hugo now supports more formats thanks to the new "external helpers"
feature recently introduced, and as requested by some people, I added
some lines in the doc:
* basically confirming it actually exists
* how to use it