### PR TITLE
add undocumented published setting to front matter

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -508,6 +508,8 @@ func (p *Page) update(f interface{}) error {
 			}
 		case "draft":
 			p.Draft = cast.ToBool(v)
+		case "published": // Intentionally undocumented
+			p.Draft = !cast.ToBool(v)
 		case "layout":
 			p.layout = cast.ToString(v)
 		case "markup":

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -854,6 +854,21 @@ func TestPagePaths(t *testing.T) {
 	}
 }
 
+var PAGE_WITH_DRAFT_AND_PUBLISHED = `---
+title: broken
+published: false
+draft: true
+---
+some content
+`
+
+func TestDraftAndPublishedFrontMatterError(t *testing.T) {
+	_, err := NewPageFrom(strings.NewReader(PAGE_WITH_DRAFT_AND_PUBLISHED), "content/post/broken.md")
+	if err != ErrHasDraftAndPublished {
+		t.Errorf("expected ErrHasDraftAndPublished, was %#v", err)
+	}
+}
+
 func listEqual(left, right []string) bool {
 	if len(left) != len(right) {
 		return false


### PR DESCRIPTION
A new "published" setting that is the opposite of "draft" is added and left intentionally undocumented.

This setting comes from jekyll and eases the transition to hugo greatly. We leave it undocumented so that folks don't rely on it, but also don't shoot themselves in the foot during a jekyll migration. The foot-shooting occurs if they have only a few documents that were drafts ("published: false") in
the jekyll version of their site and don't notice that those drafts were published in the migration to hugo.

I realize this will be a more controversial pull request. However, when combined with spf13/hugo#1314, and spf13/cast#17 (and maybe spf13/hugo#1313 if patched), the jekyll to hugo migration becomes very easy. With those changes, migrating simple websites (like https://www.somethingsimilar.com and many other jekyll installs) requires no editing of the original data at all. 

My jekyll to hugo migration became a copy and paste of my markdown files into the right directory plus adjusting some templates to use the right variables. It's nice.