### PR TITLE
Fix searching YAML/TOML delimiters in frontmatter

### DIFF
--- a/parser/page.go
+++ b/parser/page.go
@@ -207,7 +207,7 @@ func extractFrontMatterDelims(r *bufio.Reader, left, right []byte) (fm FrontMatt
 		switch c {
 		case left[len(left)-1]:
 			if sameDelim { // YAML, TOML case
-				if bytes.HasSuffix(buf.Bytes(), left) {
+				if bytes.HasSuffix(buf.Bytes(), left) && (buf.Len() == len(left) || buf.Bytes()[buf.Len()-len(left)-1] == '\n') {
 				nextByte:
 					c, err = r.ReadByte()
 					if err != nil {

--- a/parser/parse_frontmatter_test.go
+++ b/parser/parse_frontmatter_test.go
@@ -238,6 +238,7 @@ func TestExtractFrontMatter(t *testing.T) {
 		{"---  \nminc\n--- \ncontent", []byte("---\nminc\n---\n"), true},
 		{"---\ncnim\n---\ncontent\n", []byte("---\ncnim\n---\n"), true},
 		{"---\ntitle: slug doc 2\nslug: slug-doc-2\n---\ncontent\n", []byte("---\ntitle: slug doc 2\nslug: slug-doc-2\n---\n"), true},
+		{"---\npermalink: '/blog/title---subtitle.html'\n---\ncontent\n", []byte("---\npermalink: '/blog/title---subtitle.html'\n---\n"), true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
When a YAML/TOML's delimiter character sequence is included in a
frontmatter string, parser mistakes it as a delimiter. This fixes it by
checking a character right before the delimiter sequence is '\n' or it
is the beginning of the frontmatter.

Fix #1320