### PR TITLE
Add option to disable Blackfriday Smartypants

### DIFF
--- a/docs/content/overview/configuration.md
+++ b/docs/content/overview/configuration.md
@@ -166,6 +166,16 @@ But Hugo does expose some options---as listed in the table below, matched with t
 
 <tbody>
 <tr>
+<td><code><strong>smartypants</strong></code></td>
+<td><code>true</code></td>
+<td><code>HTML_USE_SMARTYPANTS</code></td>
+</tr>
+<tr>
+<td class="purpose-title">Purpose:</td>
+<td class="purpose-description" colspan="2">Enable enable smart punctuation substitutions.</td>
+</tr>
+
+<tr>
 <td><code><strong>angledQuotes</strong></code></td>
 <td><code>false</code></td>
 <td><code>HTML_SMARTYPANTS_ANGLED_QUOTES</code></td>
@@ -191,16 +201,6 @@ but only these three.</small></td>
 </tr>
 
 <tr>
-<td><code><strong>hrefTargetBlank</strong></code></td>
-<td><code>false</code></td>
-<td><code>HTML_HREF_TARGET_BLANK</code></td>
-</tr>
-<tr>
-<td class="purpose-title">Purpose:</td>
-<td class="purpose-description" colspan="2">Open external links in a new window/tab.</small></td>
-</tr>
-
-<tr>
 <td><code><strong>latexDashes</strong></code></td>
 <td><code>true</code></td>
 <td><code>HTML_SMARTYPANTS_LATEX_DASHES</code></td>
@@ -208,6 +208,18 @@ but only these three.</small></td>
 <tr>
 <td class="purpose-title">Purpose:</td>
 <td class="purpose-description" colspan="2">Disable LaTeX style dashes.</small></td>
+</tr>
+
+<tr style="height: 0.3em;"></tr>
+
+<tr>
+<td><code><strong>hrefTargetBlank</strong></code></td>
+<td><code>false</code></td>
+<td><code>HTML_HREF_TARGET_BLANK</code></td>
+</tr>
+<tr>
+<td class="purpose-title">Purpose:</td>
+<td class="purpose-description" colspan="2">Open external links in a new window/tab.</small></td>
 </tr>
 
 <tr>
@@ -219,6 +231,8 @@ but only these three.</small></td>
 <td class="purpose-title">Purpose:</td>
 <td class="purpose-description" colspan="2">If <code>true</code>, then header and footnote IDs are generated without the document ID <small>(e.g.&nbsp;<code>#my-header</code> instead of <code>#my-header:bec3ed8ba720b9073ab75abcf3ba5d97</code>)</small></td>
 </tr>
+
+<tr style="height: 0.3em;"></tr>
 
 <tr>
 <td><code><strong>extensions</strong></code></td>

--- a/helpers/content.go
+++ b/helpers/content.go
@@ -40,6 +40,7 @@ var SummaryDivider = []byte("<!--more-->")
 
 // Blackfriday holds configuration values for Blackfriday rendering.
 type Blackfriday struct {
+	Smartypants     bool
 	AngledQuotes    bool
 	Fractions       bool
 	HrefTargetBlank bool
@@ -52,6 +53,7 @@ type Blackfriday struct {
 // NewBlackfriday creates a new Blackfriday with some sane defaults.
 func NewBlackfriday() *Blackfriday {
 	return &Blackfriday{
+		Smartypants:     true,
 		AngledQuotes:    false,
 		Fractions:       true,
 		HrefTargetBlank: false,
@@ -148,8 +150,11 @@ func GetHTMLRenderer(defaultFlags int, ctx *RenderingContext) blackfriday.Render
 
 	htmlFlags := defaultFlags
 	htmlFlags |= blackfriday.HTML_USE_XHTML
-	htmlFlags |= blackfriday.HTML_USE_SMARTYPANTS
 	htmlFlags |= blackfriday.HTML_FOOTNOTE_RETURN_LINKS
+
+	if ctx.getConfig().Smartypants {
+		htmlFlags |= blackfriday.HTML_USE_SMARTYPANTS
+	}
 
 	if ctx.getConfig().AngledQuotes {
 		htmlFlags |= blackfriday.HTML_SMARTYPANTS_ANGLED_QUOTES


### PR DESCRIPTION
Can be used in site config or per page front matter:

```
[blackfriday]
smartypants = false
```

----

Hello,

Returning from a long hiatus from Hugo, I am delighted to see all the new nifty features in the new Hugo v0.14/0.15-DEV like the new `genautocomplete` and `gendoc`.

While trying to fine-tune the automatically generated command docs (gendoc) such as http://test.gohugo.io/commands/hugo_genautocomplete/, I tried to make the two hyphens in the `--completetionfile` long option display correctly like so:

> Add **--completionfile=**/path/to/file flag to set alternative file-path and name.

But all I could get was this, where the two hyphens got turned into an en dash:

> Add **&ndash;completionfile=**/path/to/file flag to set alternative file-path and name.

I was trying to avoid use of backticks (`) so the weird backticks won't show up when `hugo help genautocomplete` is run, even though I later changed my mind.

Seeing that the Kubernetes command-line documentation generated by cobra (e.g. http://kubernetes.io/v1.0/docs/user-guide/kubectl/kubectl_config.html) can handle the two hyphens correctly:

> The loading order follows these rules: 1. If the **--kubeconfig** flag is set, then only that file is loaded.

and seeing that GitHub Favored Markdown does not support smart dashes, I thought perhaps there may be cases where the ability to disable smart dashes or even SmartyPants altogether is necessary.

Hence this pull request to allow the end user to configure `blackfriday.HTML_USE_SMARTYPANTS` as necessary.

----

Meanwhile, I have also sent [a pull request to Blackfriday](https://github.com/russross/blackfriday/pull/190) to add `HTML_SMARTYPANTS_DASHES` to allow turning off just the smart dashes while keeping the handy smart quotes, etc.: https://github.com/russross/blackfriday/pull/190.  If that pull request is accepted, I will have another patch for Hugo to expose the new option.  :-)

Many thanks!
