### PR TITLE
Use spf13/pflag's new SetAnnotation helper

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -111,9 +111,7 @@ func init() {
 
 	// for Bash autocomplete
 	validConfigFilenames := []string{"json", "js", "yaml", "yml", "toml", "tml"}
-	annotation := make(map[string][]string)
-	annotation[cobra.BashCompFilenameExt] = validConfigFilenames
-	HugoCmd.PersistentFlags().Lookup("config").Annotations = annotation
+	HugoCmd.PersistentFlags().SetAnnotation("config", cobra.BashCompFilenameExt, validConfigFilenames)
 
 	// This message will be shown to Windows users if Hugo is opened from explorer.exe
 	cobra.MousetrapHelpText = `


### PR DESCRIPTION
And make our bash completion code more compact.

Saves 40 bytes in my locally compiled hugo binary!  ;-)