### PR TITLE
Implement `hugo --theme=[Tab][Tab]` bash completion

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -112,6 +112,7 @@ func init() {
 	// for Bash autocomplete
 	validConfigFilenames := []string{"json", "js", "yaml", "yml", "toml", "tml"}
 	HugoCmd.PersistentFlags().SetAnnotation("config", cobra.BashCompFilenameExt, validConfigFilenames)
+	HugoCmd.PersistentFlags().SetAnnotation("theme", cobra.BashCompSubdirsInDir, []string{"themes"})
 
 	// This message will be shown to Windows users if Hugo is opened from explorer.exe
 	cobra.MousetrapHelpText = `


### PR DESCRIPTION
... using the new `BashCompSubdirsInDir` annotation in http://github.com/spf13/cobra.

Depends on Pull Requests spf13/cobra#126 (Add new BashCompSubdirsInDir annotation)
and spf13/hugo#1340 (Use spf13/pflag's new SetAnnotation helper).