### PR TITLE
Slicestr fix for other int type param

### DIFF
--- a/tpl/template_funcs_test.go
+++ b/tpl/template_funcs_test.go
@@ -348,29 +348,46 @@ func TestIn(t *testing.T) {
 }
 
 func TestSlicestr(t *testing.T) {
+	var err error
 	for i, this := range []struct {
 		v1     interface{}
-		v2     []int
+		v2     interface{}
+		v3     interface{}
 		expect interface{}
 	}{
-		{"abc", []int{1, 2}, "b"},
-		{"abc", []int{1, 3}, "bc"},
-		{"abc", []int{0, 1}, "a"},
-		{"abcdef", []int{}, "abcdef"},
-		{"abcdef", []int{0, 6}, "abcdef"},
-		{"abcdef", []int{0, 2}, "ab"},
-		{"abcdef", []int{2}, "cdef"},
-		{123, []int{1, 3}, "23"},
-		{123, []int{1, 2, 3}, false},
-		{"abcdef", []int{6}, false},
-		{"abcdef", []int{4, 7}, false},
-		{"abcdef", []int{-1}, false},
-		{"abcdef", []int{-1, 7}, false},
-		{"abcdef", []int{1, -1}, false},
-		{tstNoStringer{}, []int{0, 1}, false},
-		{"ĀĀĀ", []int{0, 1}, "Ā"}, // issue #1333
+		{"abc", 1, 2, "b"},
+		{"abc", 1, 3, "bc"},
+		{"abcdef", 1, int8(3), "bc"},
+		{"abcdef", 1, int16(3), "bc"},
+		{"abcdef", 1, int32(3), "bc"},
+		{"abcdef", 1, int64(3), "bc"},
+		{"abc", 0, 1, "a"},
+		{"abcdef", nil, nil, "abcdef"},
+		{"abcdef", 0, 6, "abcdef"},
+		{"abcdef", 0, 2, "ab"},
+		{"abcdef", 2, nil, "cdef"},
+		{"abcdef", int8(2), nil, "cdef"},
+		{"abcdef", int16(2), nil, "cdef"},
+		{"abcdef", int32(2), nil, "cdef"},
+		{"abcdef", int64(2), nil, "cdef"},
+		{123, 1, 3, "23"},
+		{"abcdef", 6, nil, false},
+		{"abcdef", 4, 7, false},
+		{"abcdef", -1, nil, false},
+		{"abcdef", -1, 7, false},
+		{"abcdef", 1, -1, false},
+		{tstNoStringer{}, 0, 1, false},
+		{"ĀĀĀ", 0, 1, "Ā"}, // issue #1333
 	} {
-		result, err := Slicestr(this.v1, this.v2...)
+
+		var result string
+		if this.v2 == nil {
+			result, err = Slicestr(this.v1)
+		} else if this.v3 == nil {
+			result, err = Slicestr(this.v1, this.v2)
+		} else {
+			result, err = Slicestr(this.v1, this.v2, this.v3)
+		}
 
 		if b, ok := this.expect.(bool); ok && !b {
 			if err == nil {


### PR DESCRIPTION
Changes:

* Take out toInt
* SliceStr param changes from int to interface
* convert to int for SliceStr params (toInt)
* update template_funcs_test test case, switch from array param to regular param.

fix for https://github.com/spf13/hugo/issues/1347