### PR TITLE
Fix -ldflags for Go 1.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 COMMIT_HASH=`git rev-parse --short HEAD 2>/dev/null`
 BUILD_DATE=`date +%FT%T%z`
-LDFLAGS=-ldflags "-X github.com/spf13/hugo/hugolib.CommitHash ${COMMIT_HASH} -X github.com/spf13/hugo/hugolib.BuildDate ${BUILD_DATE}"
+LDFLAGS=-ldflags "-X github.com/spf13/hugo/hugolib.CommitHash=${COMMIT_HASH} -X github.com/spf13/hugo/hugolib.BuildDate=${BUILD_DATE}"
 
 all: gitinfo
 


### PR DESCRIPTION
In Go 1.5, the following warning is given when running the Makefile:

    % make
    go build -ldflags "-X github.com/spf13/hugo/hugolib.CommitHash `git rev-parse --short HEAD 2>/dev/null` -X github.com/spf13/hugo/hugolib.BuildDate `date +%FT%T%z`" -o hugo main.go
    # command-line-arguments
    link: warning: option -X github.com/spf13/hugo/hugolib.CommitHash e791835 may not work in future releases; use -X github.com/spf13/hugo/hugolib.CommitHash=e791835
    link: warning: option -X github.com/spf13/hugo/hugolib.BuildDate 2015-08-20T13:45:25-0700 may not work in future releases; use -X github.com/spf13/hugo/hugolib.BuildDate=2015-08-20T13:45:25-0700

This pull request fixes the form of `ldflags` to be correct for Go 1.5. I believe this works fine on Go 1.4