### PR TITLE
Describe the use of custom archetypes in the docs

### DIFF
--- a/docs/content/content/archetypes.md
+++ b/docs/content/content/archetypes.md
@@ -56,8 +56,35 @@ Hugo would create the file with the following contents:
 
 We see that the `title` and `date` variables have been added, in addition to the `tags` and `categories` variables which were carried over from `archetype/default.md`.
 
-Congratulations!  We have successfully created an archetype and used it for our new contents.  That's all there is to it!
+Congratulations!  We have successfully created an archetype and used it for our new contents. But wait, what if I want to have different variables for another content type, like musicians? No problem.
 
+### Creating custom archetypes
+
+Earlier you created a new content type by adding a new subfolder to the content directory. In our case it's name would be `content/musician`. To use the corresponding archetype you just need to create a file named after the content type called `musician.md` in the `archetypes` directory, similar to the one below.
+
+#### archetypes/musician.md
+
+    +++
+    name = ""
+    bio = ""
+    genre = ""
+    +++
+
+Now let's create a new musician.
+
+    $ hugo new musician/mozart.md
+
+This time, Hugo recognizes the custom archetype and uses it instead of the default one. So the generated file's frontmatter now includes the variables `name`, `bio` and `genre`.
+
+#### content/musician/mozart.md
+
+    +++
+    title = "mozart"
+    date = "2015-08-24T13:04:37+02:00"
+    name = ""
+    bio = ""
+    genre = ""
+    +++
 
 ## Using a different front matter format
 


### PR DESCRIPTION
This PR adds a section about the creation and use of custom archetypes. Until now, only the default archetype is mentioned.

If this contributions will be accepted I would need to make an entry in this [forum thread](http://discuss.gohugo.io/t/switching-to-apache-2-license/173/52) so that Steve can switch to a different license, right?