### PR TITLE
correct check of published boolean

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -514,7 +514,7 @@ func (p *Page) update(f interface{}) error {
 			*draft = cast.ToBool(v)
 		case "published": // Intentionally undocumented
 			published = new(bool)
-			*published = !cast.ToBool(v)
+			*published = cast.ToBool(v)
 		case "layout":
 			p.layout = cast.ToString(v)
 		case "markup":

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -869,6 +869,36 @@ func TestDraftAndPublishedFrontMatterError(t *testing.T) {
 	}
 }
 
+var PAGE_WITH_PUBLISHED_FALSE = `---
+title: okay
+published: false
+---
+some content
+`
+var PAGE_WITH_PUBLISHED_TRUE = `---
+title: okay
+published: true
+---
+some content
+`
+
+func TestPublishedFrontMatter(t *testing.T) {
+	p, err := NewPageFrom(strings.NewReader(PAGE_WITH_PUBLISHED_FALSE), "content/post/broken.md")
+	if err != nil {
+		t.Fatalf("err during parse: %s", err)
+	}
+	if !p.Draft {
+		t.Errorf("expected true, got %t", p.Draft)
+	}
+	p, err = NewPageFrom(strings.NewReader(PAGE_WITH_PUBLISHED_TRUE), "content/post/broken.md")
+	if err != nil {
+		t.Fatalf("err during parse: %s", err)
+	}
+	if p.Draft {
+		t.Errorf("expected false, got %t", p.Draft)
+	}
+}
+
 func listEqual(left, right []string) bool {
 	if len(left) != len(right) {
 		return false


### PR DESCRIPTION
Deep apologies. I did not write tests before and the last commit that prevented Draft from being updated if both published and draft were set flipped the published boolean twice.

This now has tests.