### PR TITLE
Leave aliases unsanitized, allowing whitespace etc.

### DIFF
--- a/target/alias_test.go
+++ b/target/alias_test.go
@@ -16,11 +16,11 @@ func TestHTMLRedirectAlias(t *testing.T) {
 		{"", ""},
 		{"s", filepath.FromSlash("s/index.html")},
 		{"/", filepath.FromSlash("/index.html")},
-		{"alias 1", filepath.FromSlash("alias-1/index.html")},
-		{"alias 2/", filepath.FromSlash("alias-2/index.html")},
-		{"alias 3.html", "alias-3.html"},
+		{"alias 1", filepath.FromSlash("alias 1/index.html")},
+		{"alias 2/", filepath.FromSlash("alias 2/index.html")},
+		{"alias 3.html", "alias 3.html"},
 		{"alias4.html", "alias4.html"},
-		{"/alias 5.html", filepath.FromSlash("/alias-5.html")},
+		{"/alias 5.html", filepath.FromSlash("/alias 5.html")},
 		{"/трям.html", filepath.FromSlash("/трям.html")},
 	}
 

--- a/target/htmlredirect.go
+++ b/target/htmlredirect.go
@@ -41,7 +41,7 @@ func (h *HTMLRedirectAlias) Translate(alias string) (aliasPath string, err error
 	} else if !strings.HasSuffix(alias, ".html") {
 		alias = alias + "/index.html"
 	}
-	return filepath.Join(h.PublishDir, helpers.MakePath(alias)), nil
+	return filepath.Join(h.PublishDir, alias), nil
 }
 
 type AliasNode struct {


### PR DESCRIPTION
so that user-created aliases like these:

    aliases = [ "/wiki/Some Page/", "/wiki/Some+Page/" ]

would work as expected.

Fixes #701: Add support for alias with whitespace