### PR TITLE
Validate aliases to prevent directory traversal etc.

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -242,6 +242,7 @@ func (s *Site) Build() (err error) {
 		return
 	}
 	if err = s.Render(); err != nil {
+		// Better reporting when the template is missing (commit 2bbecc7b)
 		jww.ERROR.Printf("Error rendering site: %s\nAvailable templates:\n", err)
 		for _, template := range s.Tmpl.Templates() {
 			jww.ERROR.Printf("\t%s\n", template.Name())
@@ -1566,7 +1567,7 @@ func (s *Site) WriteDestPage(path string, reader io.Reader) (err error) {
 }
 
 func (s *Site) WriteDestAlias(path string, permalink template.HTML) (err error) {
-	jww.DEBUG.Println("alias created at:", path)
+	jww.DEBUG.Println("creating alias:", path)
 	return s.AliasTarget().Publish(path, permalink)
 }
 


### PR DESCRIPTION
Add validation before creating aliases:

 * Prevent creating aliases outside webroot (public/ dir)
 * Skip empty "" alias
 * Skip "/" → "/index.html", which gets overwritten anyway
 * Refuse to create Windows-invalid filenames on Windows;
   warn on other platforms
 * In case of invalid aliases, after skipping them,
   return `err = nil` to prevent the error passing up
   all the way to `hugolib.Render()` and causing Hugo to abort.
 * Update alias tests.

Fixes #701: Add support for alias with whitespace
Fixes #1418: Add validation for alias