### PR TITLE
Test builds on OS X with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ go:
   - 1.4.2
   - 1.5
   - tip
+os:
+  - linux
+  - osx
 matrix:
   allow_failures:
     - go: tip


### PR DESCRIPTION
Add an "os" target for OS X to test builds on Mac. No reason to believe it won't work, but always worth testing things.