### PR TITLE
Add template func join [WIP]

### DIFF
--- a/tpl/template_funcs.go
+++ b/tpl/template_funcs.go
@@ -1371,6 +1371,6 @@ func init() {
 		"readDir":     ReadDir,
 		"seq":         helpers.Seq,
 		"getenv":      func(varName string) string { return os.Getenv(varName) },
+		"join":        func(data []string, seperator string) string { return strings.Join(data, seperator) },
 	}
-
 }


### PR DESCRIPTION
This PR adds a template function that joins a slice of strings - a seperator can be defined. The only problem is that the function fails silently if the slice's values aren't strings (`[]string`).

TODO:
- Add documentation
