### PR TITLE
Fix that live reload is enabled in non-server mode.

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -152,7 +152,7 @@ func LoadDefaultSettings() {
 	viper.SetDefault("DefaultExtension", "html")
 	viper.SetDefault("PygmentsUseClasses", false)
 	viper.SetDefault("PygmentsCodeFences", false)
-	viper.SetDefault("DisableLiveReload", false)
+	viper.SetDefault("DisableLiveReload", true)
 	viper.SetDefault("PluralizeListTitles", true)
 	viper.SetDefault("PreserveTaxonomyNames", false)
 	viper.SetDefault("FootnoteAnchorPrefix", "")
@@ -490,7 +490,7 @@ func NewWatcher(port int) error {
 					jww.FEEDBACK.Printf("Static file changed, syncing\n\n")
 					utils.StopOnErr(copyStatic(), fmt.Sprintf("Error copying static files to %s", helpers.AbsPathify(viper.GetString("PublishDir"))))
 
-					if !BuildWatch && !viper.GetBool("DisableLiveReload") {
+					if !viper.GetBool("DisableLiveReload") {
 						// Will block forever trying to write to a channel that nobody is reading if livereload isn't initalized
 
 						// force refresh when more than one file
@@ -511,7 +511,7 @@ func NewWatcher(port int) error {
 					fmt.Println(time.Now().Format(layout))
 					utils.CheckErr(buildSite(true))
 
-					if !BuildWatch && !viper.GetBool("DisableLiveReload") {
+					if !viper.GetBool("DisableLiveReload") {
 						// Will block forever trying to write to a channel that nobody is reading if livereload isn't initalized
 						livereload.ForceRefresh()
 					}

--- a/commands/server.go
+++ b/commands/server.go
@@ -63,10 +63,6 @@ func init() {
 func server(cmd *cobra.Command, args []string) {
 	InitializeConfig()
 
-	if cmd.Flags().Lookup("disableLiveReload").Changed {
-		viper.Set("DisableLiveReload", disableLiveReload)
-	}
-
 	if serverWatch {
 		viper.Set("Watch", true)
 	}
@@ -74,6 +70,8 @@ func server(cmd *cobra.Command, args []string) {
 	if viper.GetBool("watch") {
 		serverWatch = true
 	}
+
+	viper.Set("DisableLiveReload", !serverWatch || disableLiveReload)
 
 	l, err := net.Listen("tcp", net.JoinHostPort(serverInterface, strconv.Itoa(serverPort)))
 	if err == nil {
@@ -123,6 +121,12 @@ func server(cmd *cobra.Command, args []string) {
 
 func serve(port int) {
 	jww.FEEDBACK.Println("Serving pages from " + helpers.AbsPathify(viper.GetString("PublishDir")))
+
+	if viper.GetBool("DisableLiveReload") {
+		jww.FEEDBACK.Println("Live reload is disabled")
+	} else {
+		jww.FEEDBACK.Println("Live reload is enabled")
+	}
 
 	httpFs := &afero.HttpFs{SourceFs: hugofs.DestinationFS}
 	fileserver := http.FileServer(httpFs.Dir(helpers.AbsPathify(viper.GetString("PublishDir"))))

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1449,7 +1449,7 @@ func (s *Site) renderAndWritePage(name string, dest string, d interface{}, layou
 		transformLinks = append(transformLinks, transform.AbsURL)
 	}
 
-	if viper.GetBool("watch") && !viper.GetBool("DisableLiveReload") {
+	if !viper.GetBool("DisableLiveReload") {
 		transformLinks = append(transformLinks, transform.LiveReloadInject)
 	}
 


### PR DESCRIPTION
* Make "DisableLiveReload" viper key the single feature switch for all the code paths
* Set "DisableLiveReload" to false by default, and allow command line flag to overwrite it when hugo is run in server mode and file watching is turned on