### PR TITLE
Fix golint warnings for helpers/general.go

### DIFF
--- a/helpers/general.go
+++ b/helpers/general.go
@@ -430,7 +430,7 @@ func DoArithmetic(a, b interface{}, op rune) (interface{}, error) {
 	}
 }
 
-// NormalizeHugoFlagsFunc facilitates transitions of Hugo command-line flags,
+// NormalizeHugoFlags facilitates transitions of Hugo command-line flags,
 // e.g. --baseUrl to --baseURL, --uglyUrls to --uglyURLs
 func NormalizeHugoFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 	switch name {


### PR DESCRIPTION
It includes go-style of avoinding elses on after return and fix of
comment for NormalizeHugoFlags.