### PR TITLE
Use https for youtube shortcode

### DIFF
--- a/docs/layouts/shortcodes/youtube.html
+++ b/docs/layouts/shortcodes/youtube.html
@@ -1,4 +1,4 @@
 <div class="video-container">
-<iframe class="youtube-player" type="text/html" width="100%" height="auto" src="http://www.youtube.com/embed/{{ index .Params 0 }}" allowfullscreen frameborder="0">
+<iframe class="youtube-player" type="text/html" width="100%" height="auto" src="https://www.youtube.com/embed/{{ index .Params 0 }}" allowfullscreen frameborder="0">
 </iframe>
 </div>


### PR DESCRIPTION
The Hugo site uses HTTPS but the video link was HTTP, which made chrome block the video