### PR TITLE
Insert code tag for server-side syntax highlighting

### DIFF
--- a/helpers/content_renderer_test.go
+++ b/helpers/content_renderer_test.go
@@ -38,7 +38,7 @@ func TestCodeFence(t *testing.T) {
 		input, expected string
 	}
 	data := []test{
-		{true, "<html></html>", "<div class=\"highlight\"><pre><span class=\"nt\">&lt;html&gt;&lt;/html&gt;</span>\n</pre></div>\n"},
+		{true, "<html></html>", "<div class=\"highlight\"><pre><code class=\"language-html\" data-lang=\"html\"><span class=\"nt\">&lt;html&gt;&lt;/html&gt;</span>\n</code></pre></div>\n"},
 		{false, "<html></html>", "<pre><code class=\"language-html\">&lt;html&gt;&lt;/html&gt;</code></pre>\n"},
 	}
 

--- a/helpers/pygments.go
+++ b/helpers/pygments.go
@@ -111,14 +111,23 @@ func Highlight(code, lang, optsStr string) string {
 		return code
 	}
 
+	str := out.String()
+
+	// inject code tag into Pygments output
+	if lang != "" && strings.Contains(str, "<pre>") {
+		codeTag := fmt.Sprintf(`<pre><code class="language-%s" data-lang="%s">`, lang, lang)
+		str = strings.Replace(str, "<pre>", codeTag, 1)
+		str = strings.Replace(str, "</pre>", "</code></pre>", 1)
+	}
+
 	if cachefile != "" {
 		// Write cache file
-		if err := WriteToDisk(cachefile, bytes.NewReader(out.Bytes()), fs); err != nil {
+		if err := WriteToDisk(cachefile, strings.NewReader(str), fs); err != nil {
 			jww.ERROR.Print(stderr.String())
 		}
 	}
 
-	return out.String()
+	return str
 }
 
 var pygmentsKeywords = make(map[string]bool)

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -35,7 +35,7 @@ func CheckShortCodeMatchAndError(t *testing.T, input, expected string, template 
 	}
 
 	if output != expected {
-		t.Fatalf("Shortcode render didn't match. got %q but exxpected %q", output, expected)
+		t.Fatalf("Shortcode render didn't match. got %q but expected %q", output, expected)
 	}
 }
 


### PR DESCRIPTION
Inserts a code tag into Pygments output with the language-info that is present when using client-side highlighting (useful for CSS hooks)

```html
<code class="language-go" data-lang="go">
```

closes #1490

This change won't show up until the Pygments cache is cleared:

```console
rm -Rf $TMPDIR/hugo_cache
```

or ` --ignoreCache`