### PR TITLE
Disable LiveReload when Hugo is not running as a server

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1449,7 +1449,7 @@ func (s *Site) renderAndWritePage(name string, dest string, d interface{}, layou
 		transformLinks = append(transformLinks, transform.AbsURL)
 	}
 
-	if viper.GetBool("watch") && !viper.GetBool("DisableLiveReload") {
+	if s.Running() && viper.GetBool("watch") && !viper.GetBool("DisableLiveReload") {
 		transformLinks = append(transformLinks, transform.LiveReloadInject)
 	}
 


### PR DESCRIPTION
This change fixes #1410.