### PR TITLE
Set description in Page.Params map (Fix #1484)

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -506,6 +506,7 @@ func (p *Page) update(f interface{}) error {
 			p.linkTitle = cast.ToString(v)
 		case "description":
 			p.Description = cast.ToString(v)
+			p.Params["description"] = p.Description
 		case "slug":
 			p.Slug = cast.ToString(v)
 		case "url":


### PR DESCRIPTION
Set description in Page.Params map