### PR TITLE
Move blackfriday site-wide config loading to NewBlackFriday()

### DIFF
--- a/helpers/content.go
+++ b/helpers/content.go
@@ -24,7 +24,9 @@ import (
 	"unicode/utf8"
 
 	"github.com/miekg/mmark"
+	"github.com/mitchellh/mapstructure"
 	"github.com/russross/blackfriday"
+	"github.com/spf13/cast"
 	bp "github.com/spf13/hugo/bufferpool"
 	jww "github.com/spf13/jwalterweatherman"
 	"github.com/spf13/viper"
@@ -52,17 +54,33 @@ type Blackfriday struct {
 	ExtensionsMask  []string
 }
 
-// NewBlackfriday creates a new Blackfriday with some sane defaults.
+// NewBlackfriday creates a new Blackfriday filled with site config or some sane defaults
 func NewBlackfriday() *Blackfriday {
-	return &Blackfriday{
-		Smartypants:     true,
-		AngledQuotes:    false,
-		Fractions:       true,
-		HrefTargetBlank: false,
-		SmartDashes:     true,
-		LatexDashes:     true,
-		PlainIDAnchors:  false,
+	combinedParam := map[string]interface{}{
+		"smartypants":     true,
+		"angledQuotes":    false,
+		"fractions":       true,
+		"hrefTargetBlank": false,
+		"smartDashes":     true,
+		"latexDashes":     true,
+		"plainIDAnchors":  false,
 	}
+
+	siteParam := viper.GetStringMap("blackfriday")
+	if siteParam != nil {
+		siteConfig := cast.ToStringMap(siteParam)
+
+		for key, value := range siteConfig {
+			combinedParam[key] = value
+		}
+	}
+
+	combinedConfig := &Blackfriday{}
+	if err := mapstructure.Decode(combinedParam, combinedConfig); err != nil {
+		jww.FATAL.Printf("Failed to get site rendering config\n%s", err.Error())
+	}
+
+	return combinedConfig
 }
 
 var blackfridayExtensionMap = map[string]int{

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -245,26 +245,10 @@ func (p *Page) renderContent(content []byte) []byte {
 func (p *Page) getRenderingConfig() *helpers.Blackfriday {
 
 	p.renderingConfigInit.Do(func() {
-		pageParam := p.GetParam("blackfriday")
-		siteParam := viper.GetStringMap("blackfriday")
+		pageParam := cast.ToStringMap(p.GetParam("blackfriday"))
 
-		combinedParam := siteParam
-
-		if pageParam != nil {
-			combinedParam = make(map[string]interface{})
-
-			for k, v := range siteParam {
-				combinedParam[k] = v
-			}
-
-			pageConfig := cast.ToStringMap(pageParam)
-
-			for key, value := range pageConfig {
-				combinedParam[key] = value
-			}
-		}
 		p.renderingConfig = helpers.NewBlackfriday()
-		if err := mapstructure.Decode(combinedParam, p.renderingConfig); err != nil {
+		if err := mapstructure.Decode(pageParam, p.renderingConfig); err != nil {
 			jww.FATAL.Printf("Failed to get rendering config for %s:\n%s", p.BaseFileName(), err.Error())
 		}
 	})


### PR DESCRIPTION
Ok, I've tried to fix #1544

It's only partial solution - ```markdownify``` will still ignore page-level config.