### PR TITLE
Doc fix: Replace SINGLE with PLURAL in taxonomy template file names

### DIFF
--- a/docs/content/overview/source-directory.md
+++ b/docs/content/overview/source-directory.md
@@ -61,10 +61,10 @@ An example directory may look like:
     |   |   ├── header.html
     |   |   └── footer.html
     |   ├── taxonomies
-    |   |   ├── category.html
-    |   |   ├── post.html
-    |   |   ├── quote.html
-    |   |   └── tag.html
+    |   |   ├── categories.html
+    |   |   ├── categories.terms.html
+    |   |   ├── tags.html
+    |   |   └── tags.terms.html
     |   ├── post
     |   |   ├── li.html
     |   |   ├── single.html

--- a/docs/content/templates/list.md
+++ b/docs/content/templates/list.md
@@ -50,10 +50,10 @@ A Section will be rendered at /`SECTION`/ (e.g.&nbsp;http://spf13.com/project/)
 
 A Taxonomy will be rendered at /`PLURAL`/`TERM`/ (e.g.&nbsp;http://spf13.com/topics/golang/) from:
 
-* /layouts/taxonomy/`SINGULAR`.html (e.g.&nbsp;`/layouts/taxonomy/topic.html`)
+* /layouts/taxonomy/`PLURAL`.html (e.g.&nbsp;`/layouts/taxonomy/topics.html`)
 * /layouts/\_default/taxonomy.html
 * /layouts/\_default/list.html
-* /themes/`THEME`/layouts/taxonomy/`SINGULAR`.html
+* /themes/`THEME`/layouts/taxonomy/`PLURAL`.html
 * /themes/`THEME`/layouts/\_default/taxonomy.html
 * /themes/`THEME`/layouts/\_default/list.html
 
@@ -84,9 +84,9 @@ user.*
 Hugo provides the ability for you to define any RSS type you wish, and
 can have different RSS files for each section and taxonomy.
 
-* /layouts/taxonomy/`SINGULAR`.rss.xml
+* /layouts/taxonomy/`PLURAL`.rss.xml
 * /layouts/\_default/rss.xml
-* /themes/`THEME`/layouts/taxonomy/`SINGULAR`.rss.xml
+* /themes/`THEME`/layouts/taxonomy/`PLURAL`.rss.xml
 * /themes/`THEME`/layouts/\_default/rss.xml
 
 

--- a/docs/content/templates/terms.md
+++ b/docs/content/templates/terms.md
@@ -27,7 +27,7 @@ A Taxonomy Terms List will be rendered at /`PLURAL`/
 (e.g. http://spf13.com/topics/)
 from the following prioritized list:
 
-* /layouts/taxonomy/`SINGULAR`.terms.html (e.g. `/layouts/taxonomy/topic.terms.html`)
+* /layouts/taxonomy/`PLURAL`.terms.html (e.g. `/layouts/taxonomy/topics.terms.html`)
 * /layouts/\_default/terms.html
 
 If a file isn’t present,


### PR DESCRIPTION
Related to issue https://github.com/spf13/hugo/issues/1546