### PR TITLE
Fix GroupByParam to return original param string

### DIFF
--- a/hugolib/pageGroup.go
+++ b/hugolib/pageGroup.go
@@ -171,7 +171,7 @@ func (p Pages) GroupByParam(key string, order ...string) (PagesGroup, error) {
 	}
 
 	for _, e := range p {
-		param := e.GetParam(key)
+		param := e.getParam(key, false)
 		if param == nil || reflect.TypeOf(param) != keyt {
 			continue
 		}

--- a/hugolib/pageGroup_test.go
+++ b/hugolib/pageGroup_test.go
@@ -220,6 +220,25 @@ func TestGroupByParamInReverseOrder(t *testing.T) {
 	}
 }
 
+func TestGroupByParamCalledWithCapitalLetterString(t *testing.T) {
+	testStr := "TestString"
+	f := "/section1/test_capital.md"
+	p, err := NewPage(filepath.FromSlash(f))
+	if err != nil {
+		t.Fatalf("failed to prepare test page %s", f)
+	}
+	p.Params["custom_param"] = testStr
+	pages := Pages{p}
+
+	groups, err := pages.GroupByParam("custom_param")
+	if err != nil {
+		t.Fatalf("Unable to make PagesGroup array: %s", err)
+	}
+	if groups[0].Key != testStr {
+		t.Errorf("PagesGroup key is converted to a lower character string. It should be %#v, got %#v", testStr, groups[0].Key)
+	}
+}
+
 func TestGroupByParamCalledWithSomeUnavailableParams(t *testing.T) {
 	pages := preparePageGroupTestPages(t)
 	delete(pages[1].Params, "custom_param")


### PR DESCRIPTION
Page.GroupByParam function internally uses Page.GetParam to get a
parameter value for a key of a page group but now Page.GetParam returns
a lowercase character string every time. It has no need to using
lowercase character string as a group key value and it confuse a
function user.

This fixes it to keep and return an original parameter string as a group
key value.

Fix #1564