### PR TITLE
Add RSSLink to SiteInfo

### DIFF
--- a/docs/content/templates/variables.md
+++ b/docs/content/templates/variables.md
@@ -111,6 +111,7 @@ The last two can also be reversed: **.Data.Terms.Alphabetical.Reverse**, **.Data
 Also available is `.Site` which has the following:
 
 **.Site.BaseURL** The base URL for the site as defined in the site configuration file.<br>
+**.Site.RSSLink** The URL for the site RSS.<br>
 **.Site.Taxonomies** The [taxonomies](/taxonomies/usage/) for the entire site.  Replaces the now-obsolete `.Site.Indexes` since v0.11.<br>
 **.Site.Pages** Array of all content ordered by Date, newest first.  Replaces the now-deprecated `.Site.Recent` starting v0.13.<br>
 **.Site.Params** A container holding the values from the `params` section of your site configuration file. For example, a TOML config file might look like this:

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -103,6 +103,7 @@ type SiteInfo struct {
 	Menus                 *Menus
 	Hugo                  *HugoInfo
 	Title                 string
+	RSSLink               string
 	Author                map[string]interface{}
 	LanguageCode          string
 	DisqusShortname       string
@@ -458,6 +459,7 @@ func (s *Site) initializeSiteInfo() {
 		Copyright:             viper.GetString("copyright"),
 		DisqusShortname:       viper.GetString("DisqusShortname"),
 		GoogleAnalytics:       viper.GetString("GoogleAnalytics"),
+		RSSLink:               s.permalinkStr(viper.GetString("RSSUri")),
 		BuildDrafts:           viper.GetBool("BuildDrafts"),
 		canonifyURLs:          viper.GetBool("CanonifyURLs"),
 		preserveTaxonomyNames: viper.GetBool("PreserveTaxonomyNames"),


### PR DESCRIPTION
It would be helpful to have be able to link to the main site RSS feed from any page/template.  This commit solves that problem.