### PR TITLE
Return error if shortcode template.Tree is nil

### DIFF
--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -343,6 +343,9 @@ Loop:
 			if tmpl == nil {
 				return sc, fmt.Errorf("Unable to locate template for shortcode '%s' in page %s", sc.name, p.BaseFileName())
 			}
+			if tmpl.Tree == nil {
+				return sc, fmt.Errorf("Template for shortcode '%s' failed to compile for page '%s'", sc.name, p.BaseFileName())
+			}
 			isInner = isInnerShortcode(tmpl)
 
 		case tScParam:


### PR DESCRIPTION
If a shortcode template fails to compile, the template will be non-nil, but
template.Tree will be nil which caused a panic.

Fixes #1575 