### PR TITLE
Add shortcode IsNamedParams property

### DIFF
--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -31,9 +31,10 @@ import (
 )
 
 type ShortcodeWithPage struct {
-	Params interface{}
-	Inner  template.HTML
-	Page   *Page
+	Params        interface{}
+	Inner         template.HTML
+	Page          *Page
+	IsNamedParams bool
 }
 
 func (scp *ShortcodeWithPage) Ref(ref string) (string, error) {
@@ -186,12 +187,16 @@ const innerCleanupRegexp = `\A<p>(.*)</p>\n\z`
 const innerCleanupExpand = "$1"
 
 func renderShortcode(sc shortcode, p *Page, t tpl.Template) string {
-	var data = &ShortcodeWithPage{Params: sc.params, Page: p}
 	tmpl := getShortcodeTemplate(sc.name, t)
 
 	if tmpl == nil {
 		jww.ERROR.Printf("Unable to locate template for shortcode '%s' in page %s", sc.name, p.BaseFileName())
 		return ""
+	}
+
+	data := &ShortcodeWithPage{Params: sc.params, Page: p}
+	if sc.params != nil {
+		data.IsNamedParams = reflect.TypeOf(sc.params).Kind() == reflect.Map
 	}
 
 	if len(sc.inner) > 0 {

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -119,6 +119,20 @@ func TestNamedParamSC(t *testing.T) {
 	CheckShortCodeMatch(t, `{{< img src = "one" class = "aspen grove" >}}`, `<img src="one" class="aspen grove">`, tem)
 }
 
+func TestIsNamedParamsSC(t *testing.T) {
+	tem := tpl.New()
+	tem.AddInternalShortcode("byposition.html", `<div id="{{ .Get 0 }}">`)
+	tem.AddInternalShortcode("byname.html", `<div id="{{ .Get "id" }}">`)
+	tem.AddInternalShortcode("ifnamedparams.html", `<div id="{{ if .IsNamedParams }}{{ .Get "id" }}{{ else }}{{ .Get 0 }}{{end}}">`)
+
+	CheckShortCodeMatch(t, `{{< ifnamedparams id="name" >}}`, `<div id="name">`, tem)
+	CheckShortCodeMatch(t, `{{< ifnamedparams position >}}`, `<div id="position">`, tem)
+	CheckShortCodeMatch(t, `{{< byname id="name" >}}`, `<div id="name">`, tem)
+	CheckShortCodeMatch(t, `{{< byname position >}}`, `<div id="error: cannot access positional params by string name">`, tem)
+	CheckShortCodeMatch(t, `{{< byposition position >}}`, `<div id="position">`, tem)
+	CheckShortCodeMatch(t, `{{< byposition id="name" >}}`, `<div id="error: cannot access named params by position">`, tem)
+}
+
 func TestInnerSC(t *testing.T) {
 	tem := tpl.New()
 	tem.AddInternalShortcode("inside.html", `<div{{with .Get "class"}} class="{{.}}"{{end}}>{{ .Inner }}</div>`)


### PR DESCRIPTION
It would be helpful to know whether a shortcode was called with positional or
named parameters.  This commit adds a `ParamsType` function that returns `name`
or `position`.

If this proposed change is acceptable, I can write tests for it.