### PR TITLE
Add gh shortcode to docs site

### DIFF
--- a/docs/content/meta/release-notes.md
+++ b/docs/content/meta/release-notes.md
@@ -43,64 +43,64 @@ introduces the ability to render and serve directly from memory resulting in
 30%+ lower render times.
 
 Huge thanks to all who participated in this release. A special thanks to
-[@bep](https://github.com/bep) who led the development of Hugo this release again,
-[@anthonyfok](https://github.com/anthonyfok),
-[@eparis](https://github.com/eparis),
-[@tatsushid](https://github.com/tatsushid) and 
-[@DigitalCraftsman](https://github.com/digitalcraftsman/)
+{{< gh "@bep" >}} who led the development of Hugo this release again,
+{{< gh "@anthonyfok" >}},
+{{< gh "@eparis" >}},
+{{< gh "@tatsushid" >}} and
+{{< gh "@DigitalCraftsman" >}}
 
 
 ## New features
-* new `hugo import jekyll` command. [1469](https://github.com/spf13/hugo/pull/1469)
-* The new `Param` convenience method on `Page` and `Node` can be used to get the most specific parameter value for a given key. [1462](https://github.com/spf13/hugo/issues/1462)
+* new `hugo import jekyll` command. {{< gh 1469 >}}
+* The new `Param` convenience method on `Page` and `Node` can be used to get the most specific parameter value for a given key. {{< gh 1462 >}}
 * Several new information elements have been added to `Page` and `Node`:
-    * `RuneCount`: The number of [runes](http://blog.golang.org/strings) in the content, excluding any whitespace. This may be a good alternative to `.WordCount`  for Japanese and other CJK languages where a word-split by spaces makes no sense.  [1266](https://github.com/spf13/hugo/issues/1266)
+    * `RuneCount`: The number of [runes](http://blog.golang.org/strings) in the content, excluding any whitespace. This may be a good alternative to `.WordCount`  for Japanese and other CJK languages where a word-split by spaces makes no sense.  {{< gh 1266 >}}
 	* `RawContent`: Raw Markdown as a string. One use case may be of embedding remarkjs.com slides.
 	* `IsHome`: tells the truth about whether you're on the home page or not.
 
 ## Improvements
 * `hugo server` now builds ~30%+ faster by rendering to memory instead of disk. To get the old behavior, start the server with `--renderToDisk=true`.
 * Hugo now supports dynamic reloading of the config file when watching.
-* We now use a custom-built `LazyFileReader` for reading file contents, which means we don't read media files in `/content` into memory anymore -- and file reading is now performed in parallel on multicore PCs. [1181](https://github.com/spf13/hugo/issues/1181)
-* Hugo is now built with `Go 1.5` which, among many other improvements, have fixed the last known data race in Hugo. [917] (https://github.com/spf13/hugo/issues/917)
-* Paginator now also supports page groups. [1274](https://github.com/spf13/hugo/issues/1274)
+* We now use a custom-built `LazyFileReader` for reading file contents, which means we don't read media files in `/content` into memory anymore -- and file reading is now performed in parallel on multicore PCs. {{< gh 1181 >}}
+* Hugo is now built with `Go 1.5` which, among many other improvements, have fixed the last known data race in Hugo. {{< gh 917 >}}
+* Paginator now also supports page groups. {{< gh 1274 >}}
 * Markdown improvements:
-    * Hugo now supports GitHub-flavoured markdown code fences for highlighting for `md`-files (Blackfriday rendered markdown) and `mmark` files (MMark rendered markdown). [362] (https://github.com/spf13/hugo/issues/362)[1258](https://github.com/spf13/hugo/issues/1258)
+    * Hugo now supports GitHub-flavoured markdown code fences for highlighting for `md`-files (Blackfriday rendered markdown) and `mmark` files (MMark rendered markdown). {{< gh 362 1258 >}}
     * Several new Blackfriday options are added:
         * Option to disable Blackfriday's `Smartypants`.
-        * Option for Blackfriday to open links in a new window/tab. [1220](https://github.com/spf13/hugo/issues/1220)
-        * Option to disable Blackfriday's LaTeX style dashes [1231](https://github.com/spf13/hugo/issues/1231)
+        * Option for Blackfriday to open links in a new window/tab. {{< gh 1220 >}}
+        * Option to disable Blackfriday's LaTeX style dashes {{< gh 1231 >}}
         * Definition lists extension support.
 * `Scratch` now has built-in `map` support.
-* We now fall back to `link title` for the default page sort. [1299](https://github.com/spf13/hugo/issues/1299)
+* We now fall back to `link title` for the default page sort. {{< gh 1299 >}}
 * Some notable new configuration options:
-	*  `IgnoreFiles` can be set with a list of Regular Expressions that matches files to be ignored during build. [1189](https://github.com/spf13/hugo/issues/1189)
-	* `PreserveTaxonomyNames`, when set to `true`, will preserve what you type as the taxonomy name both in the folders created and the taxonomy `key`, but it will be normalized for the URL.  [1180](https://github.com/spf13/hugo/issues/1180)
+	*  `IgnoreFiles` can be set with a list of Regular Expressions that matches files to be ignored during build. {{< gh 1189 >}}
+	* `PreserveTaxonomyNames`, when set to `true`, will preserve what you type as the taxonomy name both in the folders created and the taxonomy `key`, but it will be normalized for the URL.  {{< gh 1180 >}}
 * `hugo gen` can now generate man files, bash auto complete and markdown documentation
 * Hugo will now make suggestions when a command is mistyped
-* Shortcodes now have a boolean `.IsNamedParams` property. [1597](https://github.com/spf13/hugo/pull/1597)
+* Shortcodes now have a boolean `.IsNamedParams` property. {{< gh 1597 >}}
 
 ## New Template Features
 * All template engines:
-	* The new `dict` function that could be used to pass maps into a template.[1463](https://github.com/spf13/hugo/pull/1463)
+	* The new `dict` function that could be used to pass maps into a template.{{< gh 1463 >}}
 	* The new `pluralize` and `singularize` template funcs.
 	* The new `base64Decode` and `base64Encode` template funcs.
-	* The `sort` template func now accepts field/key chaining arguments and pointer values. [1330](https://github.com/spf13/hugo/issues/1330)
-	* Several fixes for `slicestr` and `substr`, most importantly, they now have full `utf-8`-support. [1190](https://github.com/spf13/hugo/issues/1190) [1333](https://github.com/spf13/hugo/issues/1333) [1347](https://github.com/spf13/hugo/issues/1347)
-	* The new `last` template function allows the user to select the last `N` items of a slice. [1148](https://github.com/spf13/hugo/issues/1148)
-	* The new `after` func allows the user to select the items after the `Nth` item. [1200] (https://github.com/spf13/hugo/pull/1200)
+	* The `sort` template func now accepts field/key chaining arguments and pointer values. {{< gh 1330 >}}
+	* Several fixes for `slicestr` and `substr`, most importantly, they now have full `utf-8`-support. {{< gh 1190 1333 1347 >}}
+	* The new `last` template function allows the user to select the last `N` items of a slice. {{< gh 1148 >}}
+	* The new `after` func allows the user to select the items after the `Nth` item. {{< gh 1200 >}}
 	* Add `time.Time` type support to the `where`, `ge`, `gt`, `le`, and `lt` template functions.
-	* It is now possible to use constructs like `where Values ".Param.key" nil` to filter pages that doesn't have a particular parameter. [1232](https://github.com/spf13/hugo/issues/1232)
-	* `getJSON`/`getCSV`: Add retry on invalid content. [1166](https://github.com/spf13/hugo/issues/1166)
-	* 	The new `readDir` func lists local files. [1204](https://github.com/spf13/hugo/pull/1204)
+	* It is now possible to use constructs like `where Values ".Param.key" nil` to filter pages that doesn't have a particular parameter. {{< gh 1232 >}}
+	* `getJSON`/`getCSV`: Add retry on invalid content. {{< gh 1166 >}}
+	* 	The new `readDir` func lists local files. {{< gh 1204 >}}
     * The new `safeJS` function allows the embedding of content into JavaScript contexts in Go templates.
-    * Get the main site RSS link from any page by accessing the `.Site.RSSLink` property. [1566](https://github.com/spf13/hugo/pull/1566)
+    * Get the main site RSS link from any page by accessing the `.Site.RSSLink` property. {{< gh 1566 >}}
 * Ace templates:
-	* Base templates now also works in themes. [1215](https://github.com/spf13/hugo/issues/1215).
-	* And now also on Windows. [1178](https://github.com/spf13/hugo/issues/1178)
+	* Base templates now also works in themes. {{< gh 1215 >}}.
+	* And now also on Windows. {{< gh 1178 >}}
 * Full support for Amber templates including all template functions.
-* A built-in template for Google Analytics. [1505](https://github.com/spf13/hugo/pull/1505)
-* Hugo is now shipped with new built-in shortcodes: [1576](https://github.com/spf13/hugo/issues/1576)
+* A built-in template for Google Analytics. {{< gh 1505 >}}
+* Hugo is now shipped with new built-in shortcodes: {{< gh 1576 >}}
   * `youtube` for YouTube videos
   * `vimeo` for Vimeo videos
   * `gist` for GitHub gists
@@ -109,10 +109,10 @@ Huge thanks to all who participated in this release. A special thanks to
 
 
 ## Bugfixes
-* Fix data races in page sorting and page reversal. These operations are now also cached. [1293](https://github.com/spf13/hugo/issues/1293)
+* Fix data races in page sorting and page reversal. These operations are now also cached. {{< gh 1293 >}}
 * `page.HasMenuCurrent()` and `node.HasMenuCurrent()` now work correctly in multi-level nested menus.
-* Support `Fish and Chips` style section titles. Previously, this would end up as  `Fish And Chips`. Now, the first character is made toupper, but the rest are preserved as-is. [1176](https://github.com/spf13/hugo/issues/1176)
-* Hugo now removes superfluous p-tags around shortcodes. [1148](https://github.com/spf13/hugo/issues/1148)
+* Support `Fish and Chips` style section titles. Previously, this would end up as  `Fish And Chips`. Now, the first character is made toupper, but the rest are preserved as-is. {{< gh 1176 >}}
+* Hugo now removes superfluous p-tags around shortcodes. {{< gh 1148 >}}
 
 ## Notices
 * `hugo server` will watch by default now.
@@ -144,13 +144,13 @@ community.
 This release represents over **240 contributions by 36 contributors** to the main
 Hugo codebase.
 
-Big shout out to [@bep](https://github.com/bep) who led the development of Hugo
-this release, [@anthonyfok](https://github.com/anthonyfok),
-[@eparis](https://github.com/eparis),
-[@SchumacherFM](https://github.com/SchumacherFM),
-[@RickCogley](https://github.com/RickCogley) &
-[@mdhender](https://github.com/mdhender) for their significant contributions
-and [@tatsushid](https://github.com/tatsushid) for his continuous improvements
+Big shout out to {{< gh "@bep" >}} who led the development of Hugo
+this release, {{< gh "@anthonyfok" >}},
+{{< gh "@eparis" >}},
+{{< gh "@SchumacherFM" >}},
+{{< gh "@RickCogley" >}} &
+{{< gh "@mdhender" >}} for their significant contributions
+and {{< gh "@tatsushid" >}} for his continuous improvements
 to the templates. Also a big thanks to all the theme creators. 11 new themes
 have been added since last release and the [hugoThemes repo now has previews of
 all of
@@ -177,7 +177,7 @@ Hugo also depends on a lot of other great projects. A big thanks to all of our d
 * New template functions:
   * `getenv`
   * The string functions `substr` and `slicestr`
-  *`seq`, a sequence generator very similar to its Gnu counterpart
+  * `seq`, a sequence generator very similar to its Gnu counterpart
   * `absURL` and `relURL`, both of which takes the `BaseURL` setting into account
 
 ## Improvements
@@ -195,7 +195,7 @@ Hugo also depends on a lot of other great projects. A big thanks to all of our d
 * Fix crossrefs on Windows.
 * Fix `eq` and `ne` template functions when used with a raw number combined with the result of `add`, `sub` etc.
 * Fix paginator with uglyurls
-* Fix [#998](https://github.com/spf13/hugo/issues/988), supporting UTF8 characters in Permalinks.
+* Fix {{< gh 998 >}}, supporting UTF8 characters in Permalinks.
 
 ## Notices
 * To get variable and function names in line with the rest of the Go community,
@@ -216,19 +216,19 @@ the code changes, the Hugo community has grown significantly and now has over
 
 This release represents **448 contributions by 65 contributors**
 
-A special shout out to [@bep](https://github.com/bep) and
-[@anthonyfok](https://github.com/anthonyfok) for their new role as Hugo
+A special shout out to {{< gh "@bep" >}} and
+{{< gh "@anthonyfok" >}} for their new role as Hugo
 maintainers and their tremendous contributions this release.
 
 ### New major features
 * Support for [data files](/extras/datafiles/) in [YAML](http://yaml.org/),
   [JSON](http://www.json.org/), or [TOML](https://github.com/toml-lang/toml)
-  located in the `data` directory ([#885][])
+  located in the `data` directory ({{< gh 885 >}})
 * Support for [dynamic content](/extras/dynamiccontent/) by loading JSON & CSV
   from remote sources via GetJson and GetCsv in short codes or other layout
-  files ([#748][])
+  files ({{< gh 748 >}})
 * [Pagination support](/extras/pagination/) for home page, sections and
-  taxonomies ([#750][])
+  taxonomies ({{< gh 750 >}})
 * Universal sequencing support
     * A new, generic Next/Prev functionality is added to all lists of pages
       (sections, taxonomies, etc.)
@@ -237,7 +237,7 @@ maintainers and their tremendous contributions this release.
   variables
 * [Cross Reference](/extras/crossreferences/) support to easily link documents
   together with the ref and relref shortcodes.
-* [Ace](http://ace.yoss.si/) template engine support ([#541][])
+* [Ace](http://ace.yoss.si/) template engine support ({{< gh 541 >}})
 * A new [shortcode](/extras/shortcodes/) token of `{{</* */>}}` (raw HTML)
   alongside the existing `{{%/* */%}}` (Markdown)
 * A top level `Hugo` variable (on Page & Node) is added with various build
@@ -276,8 +276,8 @@ maintainers and their tremendous contributions this release.
     * Configuration of footnote rendering
     * Optional support for smart angled quotes, e.g. `"Hugo"` → «Hugo»
     * Enable descriptive header IDs
-* URLs in XML output is now correctly canonified ([#725][], [#728][], and part
-  of [#789][])
+* URLs in XML output is now correctly canonified ({{< gh 725 728 >}}, and part
+  of {{< gh 789 >}})
 
 ### Other improvements
 
@@ -285,7 +285,7 @@ maintainers and their tremendous contributions this release.
   and providing measurable performance improvements overall
 * Changes to docs:
     * A new [Troubleshooting](/troubleshooting/overview/) section is added
-    * It's now searchable through Google Custom Search ([#753][])
+    * It's now searchable through Google Custom Search ({{< gh 753 >}})
     * Some new great tutorials:
         * [Automated deployments with
           Wercker](/tutorials/automated-deployments/)
@@ -294,20 +294,10 @@ maintainers and their tremendous contributions this release.
 * Improved unit test coverage
 * Fixed a lot of Windows-related path issues
 * Improved error messages for template and rendering errors
-* Enabled soft LiveReload of CSS and images ([#490][])
-* Various fixes in RSS feed generation ([#789][])
+* Enabled soft LiveReload of CSS and images ({{< gh 490 >}})
+* Various fixes in RSS feed generation ({{< gh 789 >}})
 * `HasMenuCurrent` and `IsMenuCurrent` is now supported on Nodes
 * A bunch of [bug fixes](https://github.com/spf13/hugo/commits/master)
-
-[#490]: https://github.com/spf13/hugo/pull/490 "Pull Request #490: Livereload CSS and images without browser refresh"
-[#541]: https://github.com/spf13/hugo/pull/541 "Pull Request #541: Add Ace template engine support"
-[#725]: https://github.com/spf13/hugo/issues/725 "Issue #725: CanonifyUrls does not canonicalize urls in RSS"
-[#728]: https://github.com/spf13/hugo/issues/728 "Pull Request #728: Add ability to canonify URLs in rendered XML output."
-[#748]: https://github.com/spf13/hugo/issues/748 "Feature: GetJson and GetJson in short codes or other layout files"
-[#750]: https://github.com/spf13/hugo/issues/750 "Pull Request: Add pagination support for home page, sections and taxonomies"
-[#753]: https://github.com/spf13/hugo/issues/753 "Add search to documentation"
-[#789]: https://github.com/spf13/hugo/issues/789 "Issue #789: RSS feeds do not validate"
-[#885]: https://github.com/spf13/hugo/issues/885 "Feature/datadir"
 
 
 ## **0.12.0** Sept 1, 2014

--- a/docs/layouts/shortcodes/gh.html
+++ b/docs/layouts/shortcodes/gh.html
@@ -1,0 +1,7 @@
+{{ range .Params }}
+{{   if eq (substr . 0 1) "@" }}
+<a href="//github.com/{{ substr . 1 }}">{{ . }}</a>
+{{   else }}
+<a href="//github.com/spf13/hugo/issues/{{ . }}">{{ . }}</a>
+{{   end }}
+{{ end }}


### PR DESCRIPTION
The `gh` shortcode has two modes: users and issues.  For user mode, pass a list
of `@username` arguments.  For the issues/PR mode, pass a list of issue or PR
numbers.  PRs link to the "issues/" URL since Github redirects to the correct
URL.

Thanks to @ryanclarke for suggesting an improved template.