### PR TITLE
Use .Site.Pages in the documentation examples instead of .Site.Recent

### DIFF
--- a/docs/content/templates/functions.md
+++ b/docs/content/templates/functions.md
@@ -161,7 +161,7 @@ e.g.
     <ul>
     {{ $page_link := .Permalink }}
     {{ $tags := .Params.tags }}
-    {{ range .Site.Recent }}
+    {{ range .Site.Pages }}
         {{ $page := . }}
         {{ $has_common_tags := intersect $tags .Params.tags | len | lt 0 }}
         {{ if and $has_common_tags (ne $page_link $page.Permalink) }}
@@ -259,7 +259,7 @@ e.g.
     series: golang
     +++
 
-    {{ range where .Site.Recent "Params.series" "golang" }}
+    {{ range where .Site.Pages "Params.series" "golang" }}
        {{ .Content }}
     {{ end }}
 

--- a/docs/content/templates/go-templates.md
+++ b/docs/content/templates/go-templates.md
@@ -382,7 +382,7 @@ so, such as in this example:
 ```
 <nav class="recent">
   <h1>Recent Posts</h1>
-  <ul>{{range first .Site.Params.SidebarRecentLimit .Site.Recent}}
+  <ul>{{range first .Site.Params.SidebarRecentLimit .Site.Pages}}
     <li><a href="{{.RelPermalink}}">{{.Title}}</a></li>
   {{end}}</ul>
 </nav>


### PR DESCRIPTION
Replace the deprecated.Site.Recent variable with .Site.Pages in the documentation examples