### PR TITLE
Copy static dir files without theme's static dir

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -369,8 +369,7 @@ func copyStatic() error {
 
 	themeDir, err := helpers.GetThemeStaticDirPath()
 	if err != nil {
-		jww.ERROR.Println(err)
-		return nil
+		jww.WARN.Println(err)
 	}
 
 	// Copy the theme's static directory


### PR DESCRIPTION
Hugo command doesn't copy site's "static" directory files to "public"
directory if a specified theme doesn't have "static" directory because
theme's "static" directory checking always returns an error.

This fixes it by just showing a warning message about theme's "static"
directory absence and not skipping following processes.

Fix #1655