### PR TITLE
Make noTimes command flag work

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -244,6 +244,11 @@ func InitializeConfig() {
 	if hugoCmdV.PersistentFlags().Lookup("logFile").Changed {
 		viper.Set("LogFile", LogFile)
 	}
+
+	if hugoCmdV.Flags().Lookup("noTimes").Changed {
+		viper.Set("noTimes", NoTimes)
+	}
+
 	if BaseURL != "" {
 		if !strings.HasSuffix(BaseURL, "/") {
 			BaseURL = BaseURL + "/"


### PR DESCRIPTION
Hugo command provides "noTimes" flag but it doesn't affect synced files
timestamp regardless of whether the flag is specified or not.

This fixes it by adding a flag check and overwriting configuration if it
is specified.

Fix #1583