### PR TITLE
Remove transformation of menu URLs

### DIFF
--- a/hugolib/menu_test.go
+++ b/hugolib/menu_test.go
@@ -47,7 +47,7 @@ const (
 	identifier="1"
 [[menu.tax]]
 	name = "Tax2"
-    url = "/two/key"
+    url = "/two/key/"
 	identifier="2"
 [[menu.tax]]
 	name = "Tax RSS"
@@ -304,44 +304,34 @@ func TestMenuWithHashInURL(t *testing.T) {
 
 	assert.NotNil(t, me)
 
-	assert.Equal(t, "/Zoo/resource/#anchor", me.URL)
+	assert.Equal(t, "/Zoo/resource#anchor", me.URL)
 }
 
 // issue #719
 func TestMenuWithUnicodeURLs(t *testing.T) {
 
-	for _, uglyURLs := range []bool{true, false} {
-		for _, canonifyURLs := range []bool{true, false} {
-			doTestMenuWithUnicodeURLs(t, canonifyURLs, uglyURLs)
-		}
+	for _, canonifyURLs := range []bool{true, false} {
+		doTestMenuWithUnicodeURLs(t, canonifyURLs)
 	}
 }
 
-func doTestMenuWithUnicodeURLs(t *testing.T, canonifyURLs, uglyURLs bool) {
+func doTestMenuWithUnicodeURLs(t *testing.T, canonifyURLs bool) {
 	viper.Reset()
 	defer viper.Reset()
 
 	viper.Set("CanonifyURLs", canonifyURLs)
-	viper.Set("UglyURLs", uglyURLs)
 
 	s := setupMenuTests(t, MENU_PAGE_SOURCES)
 
 	unicodeRussian := findTestMenuEntryByID(s, "unicode", "unicode-russian")
 
-	expectedBase := "/%D0%BD%D0%BE%D0%B2%D0%BE%D1%81%D1%82%D0%B8-%D0%BF%D1%80%D0%BE%D0%B5%D0%BA%D1%82%D0%B0"
+	expected := "/%D0%BD%D0%BE%D0%B2%D0%BE%D1%81%D1%82%D0%B8-%D0%BF%D1%80%D0%BE%D0%B5%D0%BA%D1%82%D0%B0"
 
 	if !canonifyURLs {
-		expectedBase = "/Zoo" + expectedBase
+		expected = "/Zoo" + expected
 	}
 
-	var expected string
-	if uglyURLs {
-		expected = expectedBase + ".html"
-	} else {
-		expected = expectedBase + "/"
-	}
-
-	assert.Equal(t, expected, unicodeRussian.URL, "uglyURLs[%t]", uglyURLs)
+	assert.Equal(t, expected, unicodeRussian.URL)
 }
 
 // Issue #1114
@@ -383,6 +373,9 @@ func doTestSectionPagesMenu(canonifyUrls bool, t *testing.T) {
 	assert.NotNil(t, fishySectionMenuEntry)
 	assert.NotNil(t, nodeFishy)
 
+	firstSectionMenuEntry.URL = firstSectionMenuEntry.URL + "/"
+	secondSectionMenuEntry.URL = secondSectionMenuEntry.URL + "/"
+	fishySectionMenuEntry.URL = fishySectionMenuEntry.URL + "/"
 	assert.True(t, nodeFirst.IsMenuCurrent("spm", firstSectionMenuEntry))
 	assert.False(t, nodeFirst.IsMenuCurrent("spm", secondSectionMenuEntry))
 	assert.False(t, nodeFirst.IsMenuCurrent("spm", fishySectionMenuEntry))

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -736,7 +736,7 @@ func (s *SiteInfo) createNodeMenuEntryURL(in string) string {
 	}
 	// make it match the nodes
 	menuEntryURL := in
-	menuEntryURL = helpers.URLizeAndPrep(menuEntryURL)
+	menuEntryURL = helpers.SanitizeURLKeepTrailingSlash(helpers.URLize(menuEntryURL))
 	if !s.canonifyURLs {
 		menuEntryURL = helpers.AddContextRoot(string(s.BaseURL), menuEntryURL)
 	}


### PR DESCRIPTION
Fixes https://github.com/spf13/hugo/issues/1239. With this change, menu URLS will only be urlized and sanitized. It removes the URL prep step, which incorrectly transformed links in some cases. 

Would appreciate some feedback on `TestSectionPagesMenu` since I'm not quite sure if the changes preserve the intent of that test.

Also, I signed the CLA.