### PR TITLE
Render page prior to splitting on summary

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -196,8 +196,12 @@ func (p *Page) setSummary() {
 	// rendered and ready in p.contentShortcodes
 
 	if bytes.Contains(p.rawContent, helpers.SummaryDivider) {
-		sections := bytes.Split(p.rawContent, helpers.SummaryDivider)
-		header := sections[0]
+		// If markdown is in use, then we need to render the whole page
+		// prior to splitting because key bits of information (such as
+		// reference links) might be at the bottom of the file and will
+		// result in links not rendering correctly.
+		renderedPage := p.renderBytes(p.rawContent)
+		sections := bytes.Split(renderedPage, helpers.SummaryDivider)
 		p.Truncated = true
 		if len(sections[1]) < 20 {
 			// only whitespace?
@@ -205,7 +209,7 @@ func (p *Page) setSummary() {
 		}
 
 		// TODO(bep) consider doing this once only
-		renderedHeader := p.renderBytes(header)
+		renderedHeader := sections[0]
 		if len(p.contentShortCodes) > 0 {
 			tmpContentWithTokensReplaced, err :=
 				replaceShortcodeTokens(renderedHeader, shortcodePlaceholderPrefix, p.contentShortCodes)


### PR DESCRIPTION
This is my first contribution to Hugo so I expect it to be strongly critiqued as I learn the ropes!

The issue that I found, which I briefly mentioned [here](https://discuss.gohugo.io/t/markdown-content-renders-as-regular-text-in-summary/1396/12), is that the summary generation doesn't work correctly in some cases when Markdown is used.

Hugo splits the page based on the summary marker, and then renders the header separately. If users make use of the references facility that comes with Markdown, then all the links in the reference list at the bottom of the page are no present when the markdown is rendered. Eg:
```
Long and fabulous [summary][] goes here!
.
.
<!--more-->
.
.
  [summary]: http://random.com/
```
With the links missing, the page ends up with Markdown creeping into the summary.

This PR contains an attempt at fixing this issue by rendering the page first. I don't think it's perfect, and so I would appreciate some commentary on what would be a better option. One thing that stands out for me is that the whitespace isn't trimmed due to blank lines being convered to `<p></p>`, but rather that cludge a fix together for that I thought I'd throw it open to commentary.

Thanks again for Hugo, I love it.