### PR TITLE
Fix /.xml RSSLink when uglyurls are enabled

### DIFF
--- a/helpers/url.go
+++ b/helpers/url.go
@@ -269,6 +269,10 @@ func Uglify(in string) string {
 		}
 		return in
 	}
+	// /.xml -> /index.xml
+	if name == "" {
+		return path.Dir(in) + "index" + ext
+	}
 	// /section/name.html -> /section/name.html
 	return path.Clean(in)
 }


### PR DESCRIPTION
Prior to this commit the root url with uglyurls enabled is "/.xml".
This commit relates to #175.