### PR TITLE
Allow renaming of sitemap.xml

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -227,7 +227,7 @@ func LoadDefaultSettings() {
 	viper.SetDefault("RemovePathAccents", false)
 	viper.SetDefault("Taxonomies", map[string]string{"tag": "tags", "category": "categories"})
 	viper.SetDefault("Permalinks", make(hugolib.PermalinkOverrides, 0))
-	viper.SetDefault("Sitemap", hugolib.Sitemap{Priority: -1})
+	viper.SetDefault("Sitemap", hugolib.Sitemap{Priority: -1, Filename: "sitemap.xml"})
 	viper.SetDefault("DefaultExtension", "html")
 	viper.SetDefault("PygmentsStyle", "monokai")
 	viper.SetDefault("PygmentsUseClasses", false)

--- a/docs/content/templates/sitemap.md
+++ b/docs/content/templates/sitemap.md
@@ -23,6 +23,7 @@ along with Sitemap-specific ones:
 
 **.Sitemap.ChangeFreq** The page change frequency<br>
 **.Sitemap.Priority** The priority of the page<br>
+**.Sitemap.Filename** The sitemap filename<br>
 
 In addition to the standard node variables, the homepage has access to all
 site pages through `.Data.Pages`.
@@ -53,10 +54,11 @@ on render. Please don't include this in the template as it's not valid HTML.*
 
 ## Configuring sitemap.xml
 
-Defaults for `<changefreq>` and `<priority>` values can be set in the site's config file, e.g.:
+Defaults for `<changefreq>`, `<priority>` and `filename` values can be set in the site's config file, e.g.:
 
     [sitemap]
       changefreq = "monthly"
       priority = 0.5
+      filename = "sitemap.xml"
 
 The same fields can be specified in an individual page's front matter in order to override the value for that page.

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1375,11 +1375,15 @@ func (s *Site) RenderSitemap() error {
 		if page.Sitemap.Priority == -1 {
 			page.Sitemap.Priority = sitemapDefault.Priority
 		}
+
+		if page.Sitemap.Filename == "" {
+			page.Sitemap.Filename = sitemapDefault.Filename
+		}
 	}
 
 	smLayouts := []string{"sitemap.xml", "_default/sitemap.xml", "_internal/_default/sitemap.xml"}
 
-	if err := s.renderAndWriteXML("sitemap", "sitemap.xml", n, s.appendThemeTemplates(smLayouts)...); err != nil {
+	if err := s.renderAndWriteXML("sitemap", page.Sitemap.Filename, n, s.appendThemeTemplates(smLayouts)...); err != nil {
 		return err
 	}
 

--- a/hugolib/sitemap.go
+++ b/hugolib/sitemap.go
@@ -8,10 +8,11 @@ import (
 type Sitemap struct {
 	ChangeFreq string
 	Priority   float64
+	Filename   string
 }
 
 func parseSitemap(input map[string]interface{}) Sitemap {
-	sitemap := Sitemap{Priority: -1}
+	sitemap := Sitemap{Priority: -1, Filename: "sitemap.xml"}
 
 	for key, value := range input {
 		switch key {
@@ -19,6 +20,8 @@ func parseSitemap(input map[string]interface{}) Sitemap {
 			sitemap.ChangeFreq = cast.ToString(value)
 		case "priority":
 			sitemap.Priority = cast.ToFloat64(value)
+		case "filename":
+			sitemap.Filename = cast.ToString(value)
 		default:
 			jww.WARN.Printf("Unknown Sitemap field: %s\n", key)
 		}


### PR DESCRIPTION
Hi, 

I developed this quick hack to enable the renaming of sitemap.xml.
(my use case : provide a main sitemap-index that imports hugo's sitemap)

I added the support of a "filename" property to the sitemap part of config.toml

Regards