### PR TITLE
Fix 3 data races in TestPageCache

### DIFF
--- a/hugolib/pageCache_test.go
+++ b/hugolib/pageCache_test.go
@@ -15,10 +15,11 @@ package hugolib
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPageCache(t *testing.T) {
@@ -44,11 +45,12 @@ func TestPageCache(t *testing.T) {
 
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
-		go func() {
+		go func(i int) {
 			defer wg.Done()
 			for j, pages := range testPageSets {
-				msg := fmt.Sprintf("Go %d %d %d %d", i, j, o1, o2)
 				l1.Lock()
+				l2.Lock()
+				msg := fmt.Sprintf("Go %d %d %d %d", i, j, o1, o2)
 				p, c := c1.get("k1", pages, nil)
 				assert.Equal(t, !atomic.CompareAndSwapUint64(&o1, uint64(j), uint64(j+1)), c, "c1: "+msg)
 				l1.Unlock()
@@ -58,14 +60,13 @@ func TestPageCache(t *testing.T) {
 				assert.True(t, probablyEqualPages(p, pages))
 				assert.NotNil(t, p, msg)
 
-				l2.Lock()
 				p3, c3 := c1.get("k2", pages, changeFirst)
 				assert.Equal(t, !atomic.CompareAndSwapUint64(&o2, uint64(j), uint64(j+1)), c3, "c3: "+msg)
 				l2.Unlock()
 				assert.NotNil(t, p3, msg)
 				assert.Equal(t, p3[0].Description, "changed", msg)
 			}
-		}()
+		}(i)
 	}
 
 	wg.Wait()


### PR DESCRIPTION
This commit fixes 3 data races in TestPageCache:

- Pass "i" from the outer for-loop as a parameter to the goroutine
- Move l1.Lock to protect reading of o1
- Move l2.Lock to protect reading of o2