### PR TITLE
fix bugs: '%' in the url will be removed when it call UnicodeSanitize function.

### DIFF
--- a/helpers/path.go
+++ b/helpers/path.go
@@ -96,7 +96,8 @@ func UnicodeSanitize(s string) string {
 	target := make([]rune, 0, len(source))
 
 	for _, r := range source {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) || unicode.IsMark(r) || r == '.' || r == '/' || r == '\\' || r == '_' || r == '-' || r == '#' {
+		// the url contains '%' when it contains CJK characters
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || unicode.IsMark(r) || r == '.' || r == '/' || r == '\\' || r == '_' || r == '-' || r == '#' || r == '%' {
 			target = append(target, r)
 		}
 	}


### PR DESCRIPTION
if the url contains CJK characters, it will escape to %HexHex, but UnicodeSanitize function skips '%' .