### PR TITLE
WIP: Implemented multi-site rendition in one `hugo` run.

### DIFF
--- a/commands/config.go
+++ b/commands/config.go
@@ -56,6 +56,7 @@ func readInMultilingualConfig(cfgFile, source string) error {
 		return fmt.Errorf("found 0 config blocks in %q", filename)
 	}
 
+	// Reset config to base language.
 	viper.SetDefaultConfig(translationsConfigs[0])
 
 	return nil
@@ -76,14 +77,5 @@ func viperSetAll(key string, value interface{}) {
 	viper.Set(key, value)
 	for _, conf := range translationsConfigs {
 		conf.Set(key, value)
-	}
-}
-
-// viperSetDefaultAll calls `viper.SetDefault` on all translations'
-// configs.
-func viperSetDefaultAll(key string, value interface{}) {
-	viper.SetDefault(key, value)
-	for _, conf := range translationsConfigs {
-		conf.SetDefault(key, value)
 	}
 }

--- a/commands/config.go
+++ b/commands/config.go
@@ -1,0 +1,89 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+var translationsConfigs []*viper.Viper
+
+func init() {
+	translationsConfigs = make([]*viper.Viper, 0)
+}
+
+// readInMultilingualConfig reads the configuration, and loads any translations
+// sub-documents in the main config file.
+func readInMultilingualConfig(cfgFile, source string) error {
+	viperSetConfigFile(cfgFile, source)
+
+	// TODO: ignore error in ReadInConfig, simply use that for
+	// discovery of the file.  Then split the config file in chunks,
+	// identify the chunks and feed to ReadConfig().  This could be
+	// replaced if `viper` exposed the File without reading it.
+	_ = viper.ReadInConfig()
+	filename := viper.ConfigFileUsed()
+	cnt, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	// Initial support for YAML only:
+	for i, configDocument := range strings.Split(string(cnt), "\n---") {
+		if len(strings.TrimSpace(string(configDocument))) == 0 {
+			continue
+		}
+		viper.SetDefaultConfig(viper.New())
+
+		viperSetConfigFile(cfgFile, source)
+
+		err := viper.ReadConfig(bytes.NewBuffer([]byte(configDocument)))
+		if err != nil {
+			return fmt.Errorf("in config document %d: %s", i+1, err)
+		}
+
+		viper.RegisterAlias("indexes", "taxonomies")
+
+		LoadDefaultSettings()
+
+		translationsConfigs = append(translationsConfigs, viper.DefaultConfig())
+	}
+
+	if len(translationsConfigs) == 0 {
+		return fmt.Errorf("found 0 config blocks in %q", filename)
+	}
+
+	viper.SetDefaultConfig(translationsConfigs[0])
+
+	return nil
+}
+
+func viperSetConfigFile(cfgFile, source string) {
+	viper.SetConfigFile(CfgFile)
+	// See https://github.com/spf13/viper/issues/73#issuecomment-126970794
+	if Source == "" {
+		viper.AddConfigPath(".")
+	} else {
+		viper.AddConfigPath(Source)
+	}
+}
+
+// viperSetAll calls `viper.Set` on the all translations' configs.
+func viperSetAll(key string, value interface{}) {
+	viper.Set(key, value)
+	for _, conf := range translationsConfigs {
+		conf.Set(key, value)
+	}
+}
+
+// viperSetDefaultAll calls `viper.SetDefault` on all translations'
+// configs.
+func viperSetDefaultAll(key string, value interface{}) {
+	viper.SetDefault(key, value)
+	for _, conf := range translationsConfigs {
+		conf.SetDefault(key, value)
+	}
+}

--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -519,8 +519,9 @@ func getDirList() []string {
 }
 
 func buildSite(watching ...bool) (err error) {
-	startTime := time.Now()
+	defer viper.SetDefaultConfig(translationsConfigs[0])
 
+	startTime := time.Now()
 	for _, langConfig := range translationsConfigs {
 		viper.SetDefaultConfig(langConfig)
 
@@ -534,7 +535,7 @@ func buildSite(watching ...bool) (err error) {
 		}
 		site.Stats()
 		if len(translationsConfigs) > 1 {
-			jww.FEEDBACK.Printf("translation %q rendered", viper.GetString("RenderLanguage"))
+			jww.FEEDBACK.Printf("translation %q rendered ", viper.GetString("RenderLanguage"))
 		}
 		jww.FEEDBACK.Printf("in %v ms\n", int(1000*time.Since(startTime).Seconds()))
 	}

--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -521,8 +521,8 @@ func getDirList() []string {
 func buildSite(watching ...bool) (err error) {
 	defer viper.SetDefaultConfig(translationsConfigs[0])
 
-	startTime := time.Now()
 	for _, langConfig := range translationsConfigs {
+		startTime := time.Now()
 		viper.SetDefaultConfig(langConfig)
 
 		site := &hugolib.Site{}

--- a/commands/server.go
+++ b/commands/server.go
@@ -100,11 +100,11 @@ func server(cmd *cobra.Command, args []string) error {
 	}
 
 	if cmd.Flags().Lookup("disableLiveReload").Changed {
-		viper.Set("DisableLiveReload", disableLiveReload)
+		viperSetAll("DisableLiveReload", disableLiveReload)
 	}
 
 	if serverWatch {
-		viper.Set("Watch", true)
+		viperSetAll("Watch", true)
 	}
 
 	if viper.GetBool("watch") {
@@ -130,7 +130,7 @@ func server(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	viper.Set("BaseURL", BaseURL)
+	viperSetAll("BaseURL", BaseURL)
 
 	if err := memStats(); err != nil {
 		jww.ERROR.Println("memstats error:", err)
@@ -145,11 +145,11 @@ func server(cmd *cobra.Command, args []string) error {
 	if !renderToDisk {
 		hugofs.DestinationFS = new(afero.MemMapFs)
 		// Rendering to memoryFS, publish to Root regardless of publishDir.
-		viper.Set("PublishDir", "/")
+		viperSetAll("PublishDir", "/")
 	}
 
 	if serverCmd.Flags().Lookup("noTimes").Changed {
-		viper.Set("NoTimes", NoTimes)
+		viperSetAll("NoTimes", NoTimes)
 	}
 
 	if err := build(serverWatch); err != nil {


### PR DESCRIPTION
This is the first draft to a single-file multi-document YAML config.

You can run: `hugo -D serve` and it will rebuild all languages in a swift.

There's much room for optimization after this.  We could re-use the `Site` object, caching the files that were read.  We could simply call `Build()` again on the `Site`.. however that would need to be tested to ensure nothing leaks between runs..

This requires https://github.com/spf13/viper/pull/152 to be merged in
before compiling.

With this merged in, a file like:

```
---
theme: "polymer"

baseurl: "https://blog.abourget.net"
languageCode: "en-US"
title: "geek joy"

paginate: 10 # optional
disqusShortname: "blogabourget" # optional
copyright: "(ɔ) 2015 Copyleft. Alexandre Bourget."

Multilingual: true
RenderLanguage: en
DefaultContentLang: en
LinkLanguages:
 - en
 - fr

params:
  author: "Alexandre Bourget"
  profile: "images/profile.jpg" # optional
  cover: "images/cover-bw.jpg" # optional
  twitter: "bourgetalexndre" # optional
  github: "abourget" # optional
  linkedin: "alexandrebourget" # optional
  googleAnalyticsUserID: "UA-12745853-1"

permalinks:
  post: "/:year/:month/:day/:filename/"

MetaDataFormat: "yaml"

---

theme: "polymer"

baseurl: "https://blog.abourget.net"
languageCode: "fr-CA"
title: "geek joy"

paginate: 10 # optional
disqusShortname: "blogabourget" # optional
copyright: "(ɔ) 2015 Alexandre Bourget. Tous droits renversés."

Multilingual: true
RenderLanguage: fr
DefaultContentLang: en
LinkLanguages:
 - en
 - fr

params:
  author: "Alexandre Bourget"
  profile: "images/profile.jpg" # optional
  cover: "images/cover-bw.jpg" # optional
  twitter: "bourgetalexndre" # optional
  github: "abourget" # optional
  linkedin: "alexandrebourget" # optional
  googleAnalyticsUserID: "UA-12745853-1"

permalinks:
  post: "/:year/:month/:day/:filename/"

MetaDataFormat: "yaml"
---
```

works.

Now it shows needs for deduplication.. but that can be managed in a second time.

/cc @spf13 @anthonyfok 