### PR TITLE
Docs: Enable plain id anchors

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -3,6 +3,9 @@ baseurl = "http://gohugo.io/"
 MetaDataFormat = "yaml"
 pluralizeListTitles = false
 
+[blackfriday]
+  plainIDAnchors = true
+
 [params]
   description = "Documentation of Hugo, a fast and flexible static site generator built with love by spf13, bep and friends in Go"
   author = "Steve Francia (spf13) and friends"


### PR DESCRIPTION
Making it possible to post permanent anchored links to StackExchange etc.