### PR TITLE
Security: Disallow listing of absolute paths

### DIFF
--- a/tpl/template_resources.go
+++ b/tpl/template_resources.go
@@ -276,6 +276,10 @@ func ReadDir(path string) []os.FileInfo {
 		jww.ERROR.Printf("Path %s contains parent directory marker", path)
 		return nil
 	}
+	if filepath.IsAbs(path) {
+		jww.ERROR.Printf("Path %s is an absolute path", path)
+		return nil
+	}
 
 	p = filepath.Clean(path)
 	p = filepath.Join(wd, p)


### PR DESCRIPTION
Removes the possibility of listing all directories in system folders like
/etc, /usr, etc.

This is potentially dangerous when Hugo is used in shared environments, as
reported by @fransr.