### PR TITLE
Fix Hugo hang up with empty content directory

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -876,8 +876,13 @@ func (s *Site) ReadPagesFromSource() chan error {
 		panic(fmt.Sprintf("s.Source not set %s", s.absContentDir()))
 	}
 
+	errs := make(chan error)
+
 	if len(s.Source.Files()) < 1 {
-		return nil
+		go func() {
+			close(errs)
+		}()
+		return errs
 	}
 
 	files := s.Source.Files()
@@ -890,8 +895,6 @@ func (s *Site) ReadPagesFromSource() chan error {
 	for i := 0; i < procs*4; i++ {
 		go sourceReader(s, filechan, results, wg)
 	}
-
-	errs := make(chan error)
 
 	// we can only have exactly one result collator, since it makes changes that
 	// must be synchronized.


### PR DESCRIPTION
Site.ReadPagesFromSource returns nil chan error value when a site
content directory is empty but its receiver expects to be passed
something error values via the channel.

This fixes it by returning a channel which will be immediately closed.

Fix #1797