### PR TITLE
add accessor for the slug used for the page

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -459,6 +459,14 @@ func (p *Page) Extension() string {
 	return viper.GetString("DefaultExtension")
 }
 
+// returns frontmatter slug or generates from filename
+func (p *Page) GetSlug() string {
+	if len(p.Slug) > 0 {
+		return p.Slug
+	}
+	return p.Source.BaseFileName()
+}
+
 func (p *Page) LinkTitle() string {
 	if len(p.linkTitle) > 0 {
 		return p.linkTitle


### PR DESCRIPTION
As mentioned in #1815 I want to be able to access the generated slug to simplify management of a pages digital assets. So I created a simple method to access either the user defined slug or the base filename since it is used for the slug otherwise. I guess the only potential issue with this, is that if the site uses ugly url's (with the .html), then this will exclude the .html from the "slug". Not necessarily sure this is a bad thing. 

Why I think their should be an accessor to the slug versus directly accessing .Source.BaseFileName from the template is because you need to be able to handle for when a slug is user defined.
