### PR TITLE
Adds documentation for Google Analytics internal template

### DIFF
--- a/docs/content/extras/aliases.md
+++ b/docs/content/extras/aliases.md
@@ -8,7 +8,7 @@ date: 2013-07-09
 menu:
   main:
     parent: extras
-next: /extras/builders
+next: /extras/analytics
 prev: /taxonomies/ordering
 title: Aliases
 weight: 10

--- a/docs/content/extras/analytics.md
+++ b/docs/content/extras/analytics.md
@@ -1,0 +1,29 @@
+---
+date: 2016-02-06
+linktitle: Analytics
+menu:
+  main:
+    parent: extras
+next: /extras/builders
+prev: /extras/aliases
+title: Analytics in Hugo
+weight: 15
+---
+
+Hugo ships with prebuilt internal templates for Google Analytics tracking, including both synchronous and asynchronous tracking codes.
+
+## Configuring Google Analytics
+
+Provide your tracking id in your configuration file, e.g. config.yaml.
+
+    googleAnalytics = "UA-123-45"
+
+## Example
+
+Include the internal template in your templates like so:
+
+    {{ template "_internal/google_analytics.html" . }}
+
+For async include the async template:
+
+    {{ template "_internal/google_analytics_async.html" . }}

--- a/docs/content/extras/builders.md
+++ b/docs/content/extras/builders.md
@@ -6,7 +6,7 @@ menu:
   main:
     parent: extras
 next: /extras/comments
-prev: /extras/aliases
+prev: /extras/analytics
 title: Hugo Builders
 weight: 20
 ---

--- a/docs/content/overview/configuration.md
+++ b/docs/content/overview/configuration.md
@@ -101,6 +101,8 @@ Following is a list of Hugo-defined variables that you can configure and their c
     editor:                     ""
     footnoteAnchorPrefix:       ""
     footnoteReturnLinkContents: ""
+    # google analytics tracking id
+    googleAnalytics:            ""
     languageCode:               ""
     layoutdir:                  "layouts"
     # Enable Logging


### PR DESCRIPTION
Adds googleanalytics tracking id line into the configuration documentation.

Adds a new page in extras, I named it "Analytics" in case there are additional analytics templates added in the future, they can be added to this page.  I added weight 15 so it would show up under Aliases and above Builders.

See #1654