### PR TITLE
tpl: Add replaceRE function

### DIFF
--- a/docs/content/templates/functions.md
+++ b/docs/content/templates/functions.md
@@ -451,6 +451,13 @@ Replaces all occurrences of the search string with the replacement string.
 e.g. `{{ replace "Batman and Robin" "Robin" "Catwoman" }}` → "Batman and Catwoman"
 
 
+### replaceRE
+Replaces all occurrences of a regular expression with the replacement pattern.
+
+e.g. `{{ replaceRE "^https?://([^/]+).*" "$1" "http://gohugo.io/docs" }}` → "gohugo.io"
+e.g. `{{ "http://gohugo.io/docs" | replaceRE "^https?://([^/]+).*" "$1" }}` → "gohugo.io"
+
+
 ### safeHTML
 Declares the provided string as a "safe" HTML document fragment
 so Go html/template will not filter it.  It should not be used

--- a/tpl/template_funcs_test.go
+++ b/tpl/template_funcs_test.go
@@ -1781,6 +1781,27 @@ func TestReplace(t *testing.T) {
 	assert.NotNil(t, e, "tstNoStringer cannot be converted to string")
 }
 
+func TestReplaceRE(t *testing.T) {
+	for i, val := range []struct {
+		pattern string
+		repl    string
+		src     string
+		expect  string
+		ok      bool
+	}{
+		{"^https?://([^/]+).*", "$1", "http://gohugo.io/docs", "gohugo.io", true},
+		{"^https?://([^/]+).*", "$2", "http://gohugo.io/docs", "", true},
+		{"(ab)", "AB", "aabbaab", "aABbaAB", true},
+		{"(ab", "AB", "aabb", "", false}, // invalid re
+	} {
+		v, err := replaceRE(val.pattern, val.repl, val.src)
+		if (err == nil) != val.ok {
+			t.Errorf("[%d] %s", i, err)
+		}
+		assert.Equal(t, val.expect, v)
+	}
+}
+
 func TestTrim(t *testing.T) {
 
 	for i, this := range []struct {


### PR DESCRIPTION
This commit addes a `replaceRE` template function.  Regexp patterns are compiled
once and cached.