### PR TITLE
Export MainSite var so I can fix hacdias/caddy-hugo#46

### DIFF
--- a/commands/benchmark.go
+++ b/commands/benchmark.go
@@ -14,9 +14,10 @@
 package commands
 
 import (
-	"github.com/spf13/cobra"
 	"os"
 	"runtime/pprof"
+
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -56,7 +57,7 @@ func benchmark(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		for i := 0; i < benchmarkTimes; i++ {
-			mainSite = nil
+			MainSite = nil
 			_ = buildSite()
 		}
 		pprof.WriteHeapProfile(f)
@@ -75,7 +76,7 @@ func benchmark(cmd *cobra.Command, args []string) error {
 		pprof.StartCPUProfile(f)
 		defer pprof.StopCPUProfile()
 		for i := 0; i < benchmarkTimes; i++ {
-			mainSite = nil
+			MainSite = nil
 			_ = buildSite()
 		}
 	}

--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -46,7 +46,7 @@ import (
 	"gopkg.in/fsnotify.v1"
 )
 
-var mainSite *hugolib.Site
+var MainSite *hugolib.Site
 
 // userError is an error used to signal different error situations in command handling.
 type commandError struct {
@@ -648,18 +648,19 @@ func getDirList() []string {
 }
 
 func buildSite(watching ...bool) (err error) {
+	fmt.Println("Started building site")
 	startTime := time.Now()
-	if mainSite == nil {
-		mainSite = new(hugolib.Site)
+	if MainSite == nil {
+		MainSite = new(hugolib.Site)
 	}
 	if len(watching) > 0 && watching[0] {
-		mainSite.RunMode.Watching = true
+		MainSite.RunMode.Watching = true
 	}
-	err = mainSite.Build()
+	err = MainSite.Build()
 	if err != nil {
 		return err
 	}
-	mainSite.Stats()
+	MainSite.Stats()
 	jww.FEEDBACK.Printf("in %v ms\n", int(1000*time.Since(startTime).Seconds()))
 
 	return nil
@@ -667,11 +668,11 @@ func buildSite(watching ...bool) (err error) {
 
 func rebuildSite(events []fsnotify.Event) error {
 	startTime := time.Now()
-	err := mainSite.ReBuild(events)
+	err := MainSite.ReBuild(events)
 	if err != nil {
 		return err
 	}
-	mainSite.Stats()
+	MainSite.Stats()
 	jww.FEEDBACK.Printf("in %v ms\n", int(1000*time.Since(startTime).Seconds()))
 
 	return nil


### PR DESCRIPTION
Hello!

There has been an [issue](https://github.com/hacdias/caddy-hugo/issues/43) on ```caddy-hugo``` plugin for Caddy related to multisite functionality.

I ended up discovering that to fix that bug, I would have to redefine ```MainSite``` to ```nil``` so it didn't use the configurations of a previous generated website, creating a new instance.

That's why I'm making this pull request. I hope it can be merged asap.

Thanks,