### PR TITLE
Clarify that Amazon WS is, actually, AWS

### DIFF
--- a/docs/content/overview/usage.md
+++ b/docs/content/overview/usage.md
@@ -182,7 +182,7 @@ Here is the command:
               --bind=87.245.198.50
 {{< /nohighlight >}}
 
-Note the `bind` option, which is the interface to which the server will bind (defaults to `127.0.0.1`, which is fine for most development use cases). Some hosts, like Amazon WS, runs network address translation and it can sometimes be hard to figure out the actual IP address. Using `--bind=0.0.0.0` will bind to all interfaces.
+Note the `bind` option, which is the interface to which the server will bind (defaults to `127.0.0.1`, which is fine for most development use cases). Some hosts, like Amazon Web Services, runs network address translation and it can sometimes be hard to figure out the actual IP address. Using `--bind=0.0.0.0` will bind to all interfaces.
 
 This way, you may actually deploy just the source files,
 and Hugo on your server will generate the resulting web site


### PR DESCRIPTION
Amazon WS is an uncommon way of referring to Amazon Web Services, which is usually referred to either by its full name, or as AWS.
Fixes this.