### PR TITLE
Close file handle when finished reading file

### DIFF
--- a/tpl/template_resources.go
+++ b/tpl/template_resources.go
@@ -88,7 +88,7 @@ func resGetCache(id string, fs afero.Fs, ignoreCache bool) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	defer f.Close()
 	return ioutil.ReadAll(f)
 }
 
@@ -167,6 +167,7 @@ func resGetLocal(url string, fs afero.Fs) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 	return ioutil.ReadAll(f)
 }
 


### PR DESCRIPTION
the resGetCache and resGetLocal functions open file handles but do not close them when finished. This can cause "too many open files" errors when using `hugo serve` on files with getJSON calls.