### PR TITLE
tpl: Make the safeHTML and cousins accept more than strings

### DIFF
--- a/tpl/template_funcs.go
+++ b/tpl/template_funcs.go
@@ -1459,25 +1459,25 @@ func index(item interface{}, indices ...interface{}) (interface{}, error) {
 //
 // safeHTMLAttr is currently disabled, pending further discussion
 // on its use case.  2015-01-19
-func safeHTMLAttr(text string) template.HTMLAttr {
-	return template.HTMLAttr(text)
+func safeHTMLAttr(a interface{}) template.HTMLAttr {
+	return template.HTMLAttr(cast.ToString(a))
 }
 
 // safeCSS returns a given string as html/template CSS content.
-func safeCSS(text string) template.CSS {
-	return template.CSS(text)
+func safeCSS(a interface{}) template.CSS {
+	return template.CSS(cast.ToString(a))
 }
 
 // safeURL returns a given string as html/template URL content.
-func safeURL(text string) template.URL {
-	return template.URL(text)
+func safeURL(a interface{}) template.URL {
+	return template.URL(cast.ToString(a))
 }
 
 // safeHTML returns a given string as html/template HTML content.
-func safeHTML(a string) template.HTML { return template.HTML(a) }
+func safeHTML(a interface{}) template.HTML { return template.HTML(cast.ToString(a)) }
 
 // safeJS returns the given string as a html/template JS content.
-func safeJS(a string) template.JS { return template.JS(a) }
+func safeJS(a interface{}) template.JS { return template.JS(cast.ToString(a)) }
 
 func doArithmetic(a, b interface{}, op rune) (interface{}, error) {
 	av := reflect.ValueOf(a)

--- a/tpl/template_funcs_test.go
+++ b/tpl/template_funcs_test.go
@@ -103,6 +103,11 @@ jsonify: {{ (slice "A" "B" "C") | jsonify }}
 md5: {{ md5 "Hello world, gophers!" }}
 sha1: {{ sha1 "Hello world, gophers!" }}
 emojify: {{ "I :heart: Hugo" | emojify }}
+safeHTML: {{ "Bat&Man" | safeHTML }}
+safeHTML: {{ "Bat&Man" | safeHTML | safeHTML }}
+safeCSS: {{ "Bat&Man" | safeCSS | safeCSS }}
+safeURL: {{ "http://gohugo.io" | safeURL | safeURL }}
+safeJS: {{ "(1*2)" | safeJS | safeJS }}
 `
 	expected := `chomp: <p>Blockhead</p>
 dateFormat: Wednesday, Jan 21, 2015
@@ -141,6 +146,11 @@ jsonify: ["A","B","C"]
 md5: b3029f756f98f79e7f1b7f1d1f0dd53b
 sha1: c8b5b0e33d408246e30f53e32b8f7627a7a649d4
 emojify: I ❤️  Hugo
+safeHTML: Bat&Man
+safeHTML: Bat&Man
+safeCSS: Bat&amp;Man
+safeURL: http://gohugo.io
+safeJS: (1*2)
 `
 
 	var b bytes.Buffer
@@ -166,7 +176,7 @@ emojify: I ❤️  Hugo
 	}
 
 	if b.String() != expected {
-		t.Errorf("Got\n%q\nExpected\n>%q<", b.String(), expected)
+		t.Errorf("Got\n%q\nExpected\n%q", b.String(), expected)
 	}
 }
 


### PR DESCRIPTION
NOTE: This depends on https://github.com/spf13/cast/pull/22