### PR TITLE
Update the alias generated HTML files to conform to the W3C HTML spec

### DIFF
--- a/docs/content/extras/aliases.md
+++ b/docs/content/extras/aliases.md
@@ -72,9 +72,10 @@ Assuming a baseurl of `mysite.tld`, the contents of the html file will look some
 <!DOCTYPE html>
 <html>
   <head>
+    <title>http://mysite.tld/posts/my-original-url</title>
     <link rel="canonical" href="http://mysite.tld/posts/my-original-url"/>
     <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
-    <meta http-equiv="refresh" content="0;url=http://mysite.tld/posts/my-original-url"/>
+    <meta http-equiv="refresh" content="0; url=http://mysite.tld/posts/my-original-url"/>
   </head>
 </html>
 ```

--- a/target/htmlredirect.go
+++ b/target/htmlredirect.go
@@ -26,8 +26,8 @@ import (
 	jww "github.com/spf13/jwalterweatherman"
 )
 
-const alias = "<!DOCTYPE html><html><head><link rel=\"canonical\" href=\"{{ .Permalink }}\"/><meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" /><meta http-equiv=\"refresh\" content=\"0;url={{ .Permalink }}\" /></head></html>"
-const aliasXHtml = "<!DOCTYPE html><html xmlns=\"http://www.w3.org/1999/xhtml\"><head><link rel=\"canonical\" href=\"{{ .Permalink }}\"/><meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" /><meta http-equiv=\"refresh\" content=\"0;url={{ .Permalink }}\" /></head></html>"
+const alias = "<!DOCTYPE html><html><head><title>{{ .Permalink }}</title><link rel=\"canonical\" href=\"{{ .Permalink }}\"/><meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" /><meta http-equiv=\"refresh\" content=\"0; url={{ .Permalink }}\" /></head></html>"
+const aliasXHtml = "<!DOCTYPE html><html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>{{ .Permalink }}</title><link rel=\"canonical\" href=\"{{ .Permalink }}\"/><meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" /><meta http-equiv=\"refresh\" content=\"0; url={{ .Permalink }}\" /></head></html>"
 
 var defaultAliasTemplates *template.Template
 


### PR DESCRIPTION
- W3C recommends that there be a [whitespace character][1] between the `;` and the `url=` portions.

- W3C also recommends that there be a [title][2] child in the `head` element

[1]: https://www.w3.org/TR/html-markup/meta.http-equiv.refresh.html
[2]: https://www.w3.org/TR/html-markup/head.html