### PR TITLE
tpl: Send actual values to in from intersect

### DIFF
--- a/tpl/template_funcs.go
+++ b/tpl/template_funcs.go
@@ -329,20 +329,20 @@ func intersect(l1, l2 interface{}) (interface{}, error) {
 					l2vv := l2v.Index(j)
 					switch l1vv.Kind() {
 					case reflect.String:
-						if l1vv.Type() == l2vv.Type() && l1vv.String() == l2vv.String() && !in(r, l2vv) {
+						if l1vv.Type() == l2vv.Type() && l1vv.String() == l2vv.String() && !in(r.Interface(), l2vv.Interface()) {
 							r = reflect.Append(r, l2vv)
 						}
 					case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 						switch l2vv.Kind() {
 						case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-							if l1vv.Int() == l2vv.Int() && !in(r, l2vv) {
+							if l1vv.Int() == l2vv.Int() && !in(r.Interface(), l2vv.Interface()) {
 								r = reflect.Append(r, l2vv)
 							}
 						}
 					case reflect.Float32, reflect.Float64:
 						switch l2vv.Kind() {
 						case reflect.Float32, reflect.Float64:
-							if l1vv.Float() == l2vv.Float() && !in(r, l2vv) {
+							if l1vv.Float() == l2vv.Float() && !in(r.Interface(), l2vv.Interface()) {
 								r = reflect.Append(r, l2vv)
 							}
 						}

--- a/tpl/template_funcs_test.go
+++ b/tpl/template_funcs_test.go
@@ -766,7 +766,7 @@ func TestIntersect(t *testing.T) {
 		sequence2 interface{}
 		expect    interface{}
 	}{
-		{[]string{"a", "b", "c"}, []string{"a", "b"}, []string{"a", "b"}},
+		{[]string{"a", "b", "c", "c"}, []string{"a", "b", "b"}, []string{"a", "b"}},
 		{[]string{"a", "b"}, []string{"a", "b", "c"}, []string{"a", "b"}},
 		{[]string{"a", "b", "c"}, []string{"d", "e"}, []string{}},
 		{[]string{}, []string{}, []string{}},


### PR DESCRIPTION
The `intersect` function uses `in` to avoid adding duplicates to the
resulting set.  We were passing `reflect.Value` items when we should
have been using `Value.Interface()` to send the actual data structure.
This fixes that.

See #1952