### PR TITLE
WIP: Convert pages on modified templates and data files

### DIFF
--- a/hugolib/handler_page.go
+++ b/hugolib/handler_page.go
@@ -111,6 +111,16 @@ func (h mmarkHandler) PageConvert(p *Page, t tpl.Template) HandledResult {
 }
 
 func commonConvert(p *Page, t tpl.Template) HandledResult {
+
+	if p.Site.running {
+		//  prepare grounds for partial reloads
+		if len(p.rawOrigContent) > 0 {
+			p.rawContent = append([]byte(nil), p.rawOrigContent...)
+		} else {
+			p.rawOrigContent = append([]byte(nil), p.rawContent...)
+		}
+	}
+
 	p.ProcessShortcodes(t)
 
 	var err error

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -69,6 +69,7 @@ type Page struct {
 	linkTitle           string
 	frontmatter         []byte
 	rawContent          []byte
+	rawOrigContent      []byte // needed for partial rebuilding
 	contentShortCodes   map[string]string
 	plain               string // TODO should be []byte
 	plainWords          []string
@@ -299,7 +300,7 @@ func (p *Page) getRenderingConfig() *helpers.Blackfriday {
 func newPage(filename string) *Page {
 	page := Page{contentType: "",
 		Source: Source{File: *source.NewFile(filename)},
-		Node:   Node{Keywords: []string{}, Sitemap: Sitemap{Priority: -1}},
+		Node:   Node{Keywords: []string{}, Sitemap: Sitemap{Priority: -1}, Site: &SiteInfo{}},
 		Params: make(map[string]interface{})}
 
 	jww.DEBUG.Println("Reading from", page.File.Path())

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -123,6 +123,7 @@ type SiteInfo struct {
 	canonifyURLs          bool
 	preserveTaxonomyNames bool
 	paginationPageCount   uint64
+	running               bool
 	Data                  *map[string]interface{}
 }
 
@@ -475,91 +476,102 @@ func (s *Site) ReBuild(events []fsnotify.Event) error {
 	s.resetPageBuildState()
 
 	// If a content file changes, we need to reload only it and re-render the entire site.
-	if len(sourceChanged) > 0 {
+	// Note: We also need to run the converter step when a template (shortcode) or data file has changed.
 
-		// First step is to read the changed files and (re)place them in site.Pages
-		// This includes processing any meta-data for that content
+	// First step is to read the changed files and (re)place them in site.Pages
+	// This includes processing any meta-data for that content
 
-		// The second step is to convert the content into HTML
-		// This includes processing any shortcodes that may be present.
+	// The second step is to convert the content into HTML
+	// This includes processing any shortcodes that may be present.
 
-		// We do this in parallel... even though it's likely only one file at a time.
-		// We need to process the reading prior to the conversion for each file, but
-		// we can convert one file while another one is still reading.
-		errs := make(chan error)
-		readResults := make(chan HandledResult)
-		filechan := make(chan *source.File)
-		convertResults := make(chan HandledResult)
-		pageChan := make(chan *Page)
-		fileConvChan := make(chan *source.File)
-		coordinator := make(chan bool)
+	// We do this in parallel... even though it's likely only one file at a time.
+	// We need to process the reading prior to the conversion for each file, but
+	// we can convert one file while another one is still reading.
+	errs := make(chan error)
+	readResults := make(chan HandledResult)
+	filechan := make(chan *source.File)
+	convertResults := make(chan HandledResult)
+	pageChan := make(chan *Page)
+	fileConvChan := make(chan *source.File)
+	coordinator := make(chan bool)
 
-		wg := &sync.WaitGroup{}
-		wg.Add(2)
-		for i := 0; i < 2; i++ {
-			go sourceReader(s, filechan, readResults, wg)
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	for i := 0; i < 2; i++ {
+		go sourceReader(s, filechan, readResults, wg)
+	}
+
+	wg2 := &sync.WaitGroup{}
+	wg2.Add(4)
+	for i := 0; i < 2; i++ {
+		go fileConverter(s, fileConvChan, convertResults, wg2)
+
+		go pageConverter(s, pageChan, convertResults, wg2)
+	}
+
+	go incrementalReadCollator(s, readResults, pageChan, fileConvChan, coordinator, errs)
+	go converterCollator(s, convertResults, errs)
+
+	if len(tmplChanged) > 0 || len(dataChanged) > 0 {
+		// Do not need to read the files again, but they need conversion
+		// for shortocde processing.
+		for _, p := range s.Pages {
+			pageChan <- p
+		}
+	}
+
+	for _, ev := range sourceChanged {
+
+		if ev.Op&fsnotify.Remove == fsnotify.Remove {
+			//remove the file & a create will follow
+			path, _ := helpers.GetRelativePath(ev.Name, s.absContentDir())
+			s.RemovePageByPath(path)
+			continue
 		}
 
-		wg2 := &sync.WaitGroup{}
-		wg2.Add(4)
-		for i := 0; i < 2; i++ {
-			go fileConverter(s, fileConvChan, convertResults, wg2)
-			go pageConverter(s, pageChan, convertResults, wg2)
-		}
-
-		go incrementalReadCollator(s, readResults, pageChan, fileConvChan, coordinator, errs)
-		go converterCollator(s, convertResults, errs)
-
-		for _, ev := range sourceChanged {
-
-			if ev.Op&fsnotify.Remove == fsnotify.Remove {
-				//remove the file & a create will follow
+		// Some editors (Vim) sometimes issue only a Rename operation when writing an existing file
+		// Sometimes a rename operation means that file has been renamed other times it means
+		// it's been updated
+		if ev.Op&fsnotify.Rename == fsnotify.Rename {
+			// If the file is still on disk, it's only been updated, if it's not, it's been moved
+			if ex, err := afero.Exists(hugofs.SourceFs, ev.Name); !ex || err != nil {
 				path, _ := helpers.GetRelativePath(ev.Name, s.absContentDir())
 				s.RemovePageByPath(path)
 				continue
 			}
-
-			// Some editors (Vim) sometimes issue only a Rename operation when writing an existing file
-			// Sometimes a rename operation means that file has been renamed other times it means
-			// it's been updated
-			if ev.Op&fsnotify.Rename == fsnotify.Rename {
-				// If the file is still on disk, it's only been updated, if it's not, it's been moved
-				if ex, err := afero.Exists(hugofs.SourceFs, ev.Name); !ex || err != nil {
-					path, _ := helpers.GetRelativePath(ev.Name, s.absContentDir())
-					s.RemovePageByPath(path)
-					continue
-				}
-			}
-
-			file, err := s.ReReadFile(ev.Name)
-			if err != nil {
-				errs <- err
-			}
-
-			filechan <- file
 		}
-		// we close the filechan as we have sent everything we want to send to it.
-		// this will tell the sourceReaders to stop iterating on that channel
-		close(filechan)
 
-		// waiting for the sourceReaders to all finish
-		wg.Wait()
-		// Now closing readResults as this will tell the incrementalReadCollator to
-		// stop iterating over that.
-		close(readResults)
+		file, err := s.ReReadFile(ev.Name)
+		if err != nil {
+			errs <- err
+		}
 
-		// once readResults is finished it will close coordinator and move along
-		<-coordinator
-		// allow that routine to finish, then close page & fileconvchan as we've sent
-		// everything to them we need to.
-		close(pageChan)
-		close(fileConvChan)
+		filechan <- file
+	}
 
-		wg2.Wait()
-		close(convertResults)
+	// we close the filechan as we have sent everything we want to send to it.
+	// this will tell the sourceReaders to stop iterating on that channel
+	close(filechan)
 
-		s.timerStep("read & convert pages from source")
+	// waiting for the sourceReaders to all finish
+	wg.Wait()
+	// Now closing readResults as this will tell the incrementalReadCollator to
+	// stop iterating over that.
+	close(readResults)
 
+	// once readResults is finished it will close coordinator and move along
+	<-coordinator
+	// allow that routine to finish, then close page & fileconvchan as we've sent
+	// everything to them we need to.
+	close(pageChan)
+	close(fileConvChan)
+
+	wg2.Wait()
+	close(convertResults)
+
+	s.timerStep("read & convert pages from source")
+
+	if len(sourceChanged) > 0 {
 		s.setupPrevNext()
 		if err = s.BuildSiteMeta(); err != nil {
 			return err
@@ -818,6 +830,7 @@ func (s *Site) initializeSiteInfo() {
 		Params:     params,
 		Permalinks: permalinks,
 		Data:       &s.Data,
+		running:    s.Running(),
 	}
 }
 


### PR DESCRIPTION
We don't need to re-read the files from disk when shortcodes or data
files changes in server-mode, but we need to run the convert step.

To make this work, a copy is made of the original content when running
in watch mode, to use as a template so to speak.

Fixes #1971