### PR TITLE
Save auto-detected markup type in Page.Markup

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -263,7 +263,7 @@ func (p *Page) renderBytes(content []byte) []byte {
 		}
 	}
 	return helpers.RenderBytes(
-		&helpers.RenderingContext{Content: content, PageFmt: p.guessMarkupType(),
+		&helpers.RenderingContext{Content: content, PageFmt: p.determineMarkupType(),
 			DocumentID: p.UniqueID(), Config: p.getRenderingConfig(), LinkResolver: fn, FileResolver: fileFn})
 }
 
@@ -278,7 +278,7 @@ func (p *Page) renderContent(content []byte) []byte {
 			return p.Node.Site.GitHubFileLink(ref, p)
 		}
 	}
-	return helpers.RenderBytesWithTOC(&helpers.RenderingContext{Content: content, PageFmt: p.guessMarkupType(),
+	return helpers.RenderBytesWithTOC(&helpers.RenderingContext{Content: content, PageFmt: p.determineMarkupType(),
 		DocumentID: p.UniqueID(), Config: p.getRenderingConfig(), LinkResolver: fn, FileResolver: fileFn})
 }
 
@@ -800,16 +800,15 @@ func (p *Page) Render(layout ...string) template.HTML {
 	return tpl.ExecuteTemplateToHTML(p, l...)
 }
 
-func (p *Page) guessMarkupType() string {
-	// First try the explicitly set markup from the frontmatter
-	if p.Markup != "" {
-		format := helpers.GuessType(p.Markup)
-		if format != "unknown" {
-			return format
-		}
+func (p *Page) determineMarkupType() string {
+	// Try markup explicitly set in the frontmatter
+	p.Markup = helpers.GuessType(p.Markup)
+	if p.Markup == "unknown" {
+		// Fall back to file extension (might also return "unknown")
+		p.Markup = helpers.GuessType(p.Source.Ext())
 	}
 
-	return helpers.GuessType(p.Source.Ext())
+	return p.Markup
 }
 
 func (p *Page) parse(reader io.Reader) error {

--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -224,7 +224,7 @@ func renderShortcode(sc shortcode, parent *ShortcodeWithPage, p *Page, t tpl.Tem
 
 		if sc.doMarkup {
 			newInner := helpers.RenderBytes(&helpers.RenderingContext{
-				Content: []byte(inner), PageFmt: p.guessMarkupType(),
+				Content: []byte(inner), PageFmt: p.determineMarkupType(),
 				DocumentID: p.UniqueID(), Config: p.getRenderingConfig()})
 
 			// If the type is “unknown” or “markdown”, we assume the markdown
@@ -240,7 +240,7 @@ func renderShortcode(sc shortcode, parent *ShortcodeWithPage, p *Page, t tpl.Tem
 			//     substitutions in <div>HUGOSHORTCODE-1</div> which prevents the
 			//     generation, but means that you can’t use shortcodes inside of
 			//     markdown structures itself (e.g., `[foo]({{% ref foo.md %}})`).
-			switch p.guessMarkupType() {
+			switch p.determineMarkupType() {
 			case "unknown", "markdown":
 				if match, _ := regexp.MatchString(innerNewlineRegexp, inner); !match {
 					cleaner, err := regexp.Compile(innerCleanupRegexp)


### PR DESCRIPTION
Always make markup type available to the theme.
Solution to issue #1950.

Also renames guessMarkupType() to determineMarkupType() as discussed in #1950.