### PR TITLE
hugo: Add check tasks to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ COMMIT_HASH=`git rev-parse --short HEAD 2>/dev/null`
 BUILD_DATE=`date +%FT%T%z`
 LDFLAGS=-ldflags "-X github.com/spf13/hugo/hugolib.CommitHash=${COMMIT_HASH} -X github.com/spf13/hugo/hugolib.BuildDate=${BUILD_DATE}"
 
+DIRS=$(shell go list -f {{.Dir}} ./...)
+
 all: gitinfo
 
 install: install-gitinfo
@@ -31,3 +33,34 @@ docker:
 	docker run --name hugo-build hugo ls /go/bin
 	docker cp hugo-build:/go/bin/hugo .
 	docker rm hugo-build
+
+
+check: fmt vet test
+
+cyclo:
+	@for d in $(DIRS) ; do \
+		if [ "`gocyclo -over 20 $$d | tee /dev/stderr`" ]; then \
+			echo "^ cyclomatic complexity exceeds 20, refactor the code!" && echo && exit 1; \
+		fi \
+	done
+
+fmt:
+	@for d in $(DIRS) ; do \
+		if [ "`gofmt -l $$d/*.go | tee /dev/stderr`" ]; then \
+			echo "^ improperly formatted go files" && echo && exit 1; \
+		fi \
+	done
+
+lint:
+	@if [ "`golint ./... | tee /dev/stderr`" ]; then \
+		echo "^ golint errors!" && echo && exit 1; \
+	fi
+
+test:
+	go test ./...
+
+vet:
+	@if [ "`go vet ./... | tee /dev/stderr`" ]; then \
+		echo "^ go vet errors!" && echo && exit 1; \
+	fi
+


### PR DESCRIPTION
Add some helpful tasks to the Makefile to make it easier to test code quality
prior to committing.  Use `make check` to run the standard checks.  As of now,
the cyclo and lint tasks are not part of the standard checks since we fail
miserably on those.