### PR TITLE
tpl: Fix panic in sort of nil sequence

### DIFF
--- a/tpl/template_funcs.go
+++ b/tpl/template_funcs.go
@@ -955,6 +955,10 @@ func delimit(seq, delimiter interface{}, last ...interface{}) (template.HTML, er
 
 // sortSeq returns a sorted sequence.
 func sortSeq(seq interface{}, args ...interface{}) (interface{}, error) {
+	if seq == nil {
+		return nil, errors.New("sequence must be provided")
+	}
+
 	seqv := reflect.ValueOf(seq)
 	seqv, isNil := indirect(seqv)
 	if isNil {

--- a/tpl/template_funcs_test.go
+++ b/tpl/template_funcs_test.go
@@ -1535,6 +1535,7 @@ func TestSort(t *testing.T) {
 			"asc",
 			false,
 		},
+		{nil, nil, "asc", false},
 	} {
 		var result interface{}
 		var err error


### PR DESCRIPTION
Properly handle a nil sequence in the sortSeq function.  Test included.
Discovered while using `range sort .Site.Data.source.Undefined "foo"`.