### PR TITLE
Disable syntax guessing for PygmentsCodeFences

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -309,6 +309,7 @@ func loadDefaultSettings() {
 	viper.SetDefault("DisablePathToLower", false)
 	viper.SetDefault("HasCJKLanguage", false)
 	viper.SetDefault("EnableEmoji", false)
+	viper.SetDefault("PygmentsCodeFencesGuessSyntax", false)
 }
 
 // InitializeConfig initializes a config file with sensible default configuration flags.

--- a/docs/content/overview/configuration.md
+++ b/docs/content/overview/configuration.md
@@ -126,6 +126,8 @@ Following is a list of Hugo-defined variables that you can configure and their c
     preserveTaxonomyNames:      false
     # filesystem path to write files to
     publishdir:                 "public"
+    # enables syntax guessing for code fences without specified language
+    pygmentsCodeFencesGuessSyntax: false
     # color-codes for highlighting derived from this style
     pygmentsStyle:              "monokai"
     # true: use pygments-css or false: color-codes directly

--- a/helpers/content_renderer.go
+++ b/helpers/content_renderer.go
@@ -35,7 +35,7 @@ type HugoHTMLRenderer struct {
 }
 
 func (renderer *HugoHTMLRenderer) BlockCode(out *bytes.Buffer, text []byte, lang string) {
-	if viper.GetBool("PygmentsCodeFences") {
+	if viper.GetBool("PygmentsCodeFences") && (lang != "" || viper.GetBool("PygmentsCodeFencesGuessSyntax")) {
 		opts := viper.GetString("PygmentsOptions")
 		str := html.UnescapeString(string(text))
 		out.WriteString(Highlight(str, lang, opts))
@@ -78,7 +78,7 @@ type HugoMmarkHTMLRenderer struct {
 }
 
 func (renderer *HugoMmarkHTMLRenderer) BlockCode(out *bytes.Buffer, text []byte, lang string, caption []byte, subfigure bool, callouts bool) {
-	if viper.GetBool("PygmentsCodeFences") {
+	if viper.GetBool("PygmentsCodeFences") && (lang != "" || viper.GetBool("PygmentsCodeFencesGuessSyntax")) {
 		str := html.UnescapeString(string(text))
 		out.WriteString(Highlight(str, lang, ""))
 	} else {


### PR DESCRIPTION
This disables highlighting for fenced code blocks without explicitly specified language. It also introduces a new `PygmentsCodeFencesGuessSyntax` config option (defaulting to false).

To enable syntax guessing again, add the following to your config file:

```
PygmentsCodeFencesGuessSyntax = true
```

This is a breaking change.

Fixes #1861.