### PR TITLE
Make ByCount sort consistently

### DIFF
--- a/hugolib/taxonomy.go
+++ b/hugolib/taxonomy.go
@@ -96,9 +96,16 @@ func (i Taxonomy) Alphabetical() OrderedTaxonomy {
 }
 
 // ByCount returns an ordered taxonomy sorted by # of pages per key.
+// If taxonomies have the same # of pages, sort them alphabetical
 func (i Taxonomy) ByCount() OrderedTaxonomy {
 	count := func(i1, i2 *OrderedTaxonomyEntry) bool {
-		return len(i1.WeightedPages) > len(i2.WeightedPages)
+		li1 := len(i1.WeightedPages)
+		li2 := len(i2.WeightedPages)
+
+		if li1 == li2 {
+			return i1.Name < i2.Name
+		}
+		return li1 > li2
 	}
 
 	ia := i.TaxonomyArray()

--- a/hugolib/taxonomy_test.go
+++ b/hugolib/taxonomy_test.go
@@ -16,6 +16,8 @@ package hugolib
 import (
 	"strings"
 	"testing"
+
+	"github.com/spf13/viper"
 )
 
 func TestSitePossibleTaxonomies(t *testing.T) {
@@ -27,5 +29,31 @@ func TestSitePossibleTaxonomies(t *testing.T) {
 		if !compareStringSlice(taxonomies, []string{"categories", "tags"}) {
 			t.Fatalf("possible taxonomies do not match [tags categories].  Got: %s", taxonomies)
 		}
+	}
+}
+
+func TestByCountOrderOfTaxonomies(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+
+	taxonomies := make(map[string]string)
+
+	taxonomies["tag"] = "tags"
+	taxonomies["category"] = "categories"
+
+	viper.Set("taxonomies", taxonomies)
+
+	site := new(Site)
+	page, _ := NewPageFrom(strings.NewReader(pageYamlWithTaxonomiesA), "path/to/page")
+	site.Pages = append(site.Pages, page)
+	site.assembleTaxonomies()
+
+	st := make([]string, 0)
+	for _, t := range site.Taxonomies["tags"].ByCount() {
+		st = append(st, t.Name)
+	}
+
+	if !compareStringSlice(st, []string{"a", "b", "c"}) {
+		t.Fatalf("ordered taxonomies do not match [a, b, c].  Got: %s", st)
 	}
 }


### PR DESCRIPTION
When two or more taxonomies have the same number of pages,
sort them by name to have consistent ByCount sorting of
taxonomies.

Fixes #1930