### PR TITLE
Wordpress import alternative

### DIFF
--- a/docs/content/tools/index.md
+++ b/docs/content/tools/index.md
@@ -30,7 +30,7 @@ Alternatively, you can follow the manual [migration guide]({{< relref "tutorials
 
 ### WordPress
 
-- [wordpress-to-hugo-exporter](https://github.com/SchumacherFM/wordpress-to-hugo-exporter) - A one-click WordPress plugin that converts all posts, pages, taxonomies, metadata, and settings to Markdown and YAML which can be dropped into Hugo.
+- [wordpress-to-hugo-exporter](https://github.com/SchumacherFM/wordpress-to-hugo-exporter) - A one-click WordPress plugin that converts all posts, pages, taxonomies, metadata, and settings to Markdown and YAML which can be dropped into Hugo. (Note: If you have trouble using this plugin, you can [export your site for Jekyll](https://wordpress.org/plugins/jekyll-exporter/) and use Hugo's built in Jekyll converter listed above.)
 
 ### Drupal
 

--- a/docs/content/tutorials/installing-on-windows.md
+++ b/docs/content/tutorials/installing-on-windows.md
@@ -37,7 +37,7 @@ You'll need a place to store the Hugo executable, your content (the files that y
 1. Download the latest zipped Hugo executable from the [Hugo Releases](https://github.com/spf13/hugo/releases) page.
 2. Extract all contents to your `..Hugo\bin` folder.
 3. You'll probably want to rename the Hugo executable to something short like `hugo.exe`.
-4. In Powershell or your preferred CLI, add the `hugo.exe` executable to your PATH with: `C:\Hugo\bin>set PATH=%PATH%;D:\Hugo\bin`
+4. In Powershell or your preferred CLI, add the `hugo.exe` executable to your PATH by navigating to C:\Hugo\bin (or the location of your hugo.exe file) and use the command `set PATH=%PATH%;C:\Hugo\bin`. If the `hugo` command does not work after reboot, you may have to run command prompt as administrator.
 
 ## Less technical users
 


### PR DESCRIPTION
Sometimes the Wordpress to Hugo plugin does not work. This is an easy work around.