### PR TITLE
docs: Document Go's new `block` keyword. Fixes #1947

### DIFF
--- a/docs/content/content/types.md
+++ b/docs/content/content/types.md
@@ -60,16 +60,15 @@ Create a directory with the name of the type in `/layouts`. Type is always singu
 ### Create single template
 Create a file called `single.html` inside your directory. *E.g. `/layouts/post/single.html`*.
 
-### Create list template
-Create a file called `list.html` inside your directory. *E.g. `/layouts/post/list.html`*.
-
 ### Create views
-Many sites support rendering content in a few different ways, for instance,
-a single page view and a summary view to be used when displaying a list
-of contents on a single page. Hugo makes no assumptions here about how you want
-to display your content, and will support as many different views of a content
-type as your site requires. All that is required for these additional views is
-that a template exists in each `/layouts/TYPE` directory with the same name.
+Many sites support rendering content in a few different ways, for
+instance, a single page view and a summary view to be used when
+displaying a [list of contents on a single page](/templates/list).
+Hugo makes no assumptions here about how you want to display your
+content, and will support as many different views of a content type
+as your site requires. All that is required for these additional
+views is that a template exists in each `/layouts/TYPE` directory
+with the same name.
 
 ### Create a corresponding archetype
 

--- a/docs/content/templates/blocks.md
+++ b/docs/content/templates/blocks.md
@@ -3,15 +3,15 @@ date: 2016-03-29T21:26:20-05:00
 menu:
   main:
     parent: x
-title: Blocks
+title: Block Templates
 weight: 5
 ---
 
-Go 1.6 includes a powerful new keyword, `block`, which provides templates with a nice way to share common code and override only the parts that need changing. This construct allows you to define the outer shell of your pages in a single base template.
+Go 1.6 includes a powerful new keyword, `block`. This construct allows you to define the outer shell of your pages in a single "base" template, filling in or overriding portions as necessary.
 
-## Base
+## Define the base template
 
-Let's define a very simple base template:
+Let's define a simple base template, a shell from which all our pages will start. To find a base template, Hugo searches the same paths and file names as it does for [Ace templates](/templates/ace), just with files suffixed `.html` rather than `.ace`.
 
 ```html
 <!DOCTYPE html>
@@ -37,7 +37,7 @@ Let's define a very simple base template:
 
 ## Overriding the base
 
-Your [default list template](/templates/list) (`_default/list.html`) could implement its own _main_ block from the base template above like so:
+Your [default list template](/templates/list) (`_default/list.html`) will inherit all of the code defined in the base template. It could then implement its own "main" block from the base template above like so:
 
 ```html
 <!-- Note the lack of Go's context "dot" when defining blocks -->
@@ -52,11 +52,9 @@ Your [default list template](/templates/list) (`_default/list.html`) could imple
 {{ end }}
 ```
 
-This replaces the contents of our (basically empty) _main_ block with something useful for the list template.
+This replaces the contents of our (basically empty) "main" block with something useful for the list template. In this case, we didn't define a "title" block so the contents from our base template remain unchanged in lists.
 
-Since we didn't define a _title_ block, the contents from our base template remain unchanged.
-
-In our [the default single template](/templates/content) (`_default/single.html`), let's implement both block:
+In our [default single template](/templates/content) (`_default/single.html`), let's implement both blocks:
 
 ```html
 {{ define "title" }}
@@ -69,5 +67,3 @@ In our [the default single template](/templates/content) (`_default/single.html`
 ```
 
 This overrides both block areas from the base template with code unique to our single template.
-
-To find a base Go template, Hugo searches the same paths and file names as it does for [Ace templates](/templates/ace), just with files with `.html` rather than `.ace`.

--- a/docs/content/templates/blocks.md
+++ b/docs/content/templates/blocks.md
@@ -1,0 +1,73 @@
+---
+date: 2016-03-29T21:26:20-05:00
+menu:
+  main:
+    parent: x
+title: Blocks
+weight: 5
+---
+
+Go 1.6 includes a powerful new keyword, `block`, which provides templates with a nice way to share common code and override only the parts that need changing. This construct allows you to define the outer shell of your pages in a single base template.
+
+## Base
+
+Let's define a very simple base template:
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>{{ block "title" . }}
+      <!-- Blocks may include default content. -->
+      {{ .Site.Title }}
+    {{ end }}</title>
+  </head>
+  <body>
+    <!-- Code that all your templates share, like a header -->
+
+    {{ block "main" . }}
+      <!-- The part of the page that begins to differ between templates -->
+    {{ end }}
+
+    <!-- More shared code, perhaps a footer -->
+  </body>
+</html>
+```
+
+## Overriding the base
+
+Your [default list template](/templates/list) (`_default/list.html`) could implement its own _main_ block from the base template above like so:
+
+```html
+<!-- Note the lack of Go's context "dot" when defining blocks -->
+{{ define "main" }}
+  <h1>Posts</h1>
+  {{ range .Data.Pages }}
+    <article>
+      <h2>{{ .Title }}</h2>
+      {{ .Content }}
+    </article>
+  {{ end }}
+{{ end }}
+```
+
+This replaces the contents of our (basically empty) _main_ block with something useful for the list template.
+
+Since we didn't define a _title_ block, the contents from our base template remain unchanged.
+
+In our [the default single template](/templates/content) (`_default/single.html`), let's implement both block:
+
+```html
+{{ define "title" }}
+  {{ .Title }} &ndash; {{ .Site.Title }}
+{{ end }}
+{{ define "main" }}
+  <h1>{{ .Title }}</h1>
+  {{ .Content }}
+{{ end }}
+```
+
+This overrides both block areas from the base template with code unique to our single template.
+
+To find a base Go template, Hugo searches the same paths and file names as it does for [Ace templates](/templates/ace), just with files with `.html` rather than `.ace`.

--- a/docs/content/templates/go-templates.md
+++ b/docs/content/templates/go-templates.md
@@ -390,6 +390,12 @@ so, such as in this example:
 </nav>
 ```
 
+## Blocks
+
+Go 1.6 includes a new keyword, `block`, which provides templates with a nice way to share common code and override only the parts that need changing.
+
+This also provides a means for templates to inherit from other more generic templates by means of a base template. To find this base template, Hugo searches the same paths and file names as it does for [Ace templates](/templates/ace). For Go templates, simply suffix your files with `.html` rather than `.ace`.
+
 # Template example: Show only upcoming events
 
 Go allows you to do more than what's shown here.  Using Hugo's

--- a/docs/content/templates/go-templates.md
+++ b/docs/content/templates/go-templates.md
@@ -297,6 +297,38 @@ access this from within the loop, you will likely want to do one of the followin
     > You may, of course, recover from this mischief by using `{{ $ := . }}`
     > in a global context to reset `$` to its default value.
 
+## Whitespace
+
+Go 1.6 includes the ability to trim the whitespace from either side of a Go tag by including a hyphen (`-`) and space immediately beside the corresponding `{{` or `}}` delimiter.
+
+For instance, the following Go template:
+
+```html
+<div>
+  {{ .Title }}
+</div>
+```
+
+will include the newlines and horizontal tab in its HTML output:
+
+```html
+<div>
+  Hello, World!
+</div>
+```
+
+whereas using
+
+```html
+<div>
+  {{- .Title -}}
+</div>
+```
+
+in that case will output simply `<div>Hello, World!</div>`.
+
+Go considers the following characters as whitespace: space, horizontal tab, carriage return and newline.
+
 # Hugo Parameters
 
 Hugo provides the option of passing values to the template language

--- a/docs/content/templates/go-templates.md
+++ b/docs/content/templates/go-templates.md
@@ -390,12 +390,6 @@ so, such as in this example:
 </nav>
 ```
 
-## Blocks
-
-Go 1.6 includes a new keyword, `block`, which provides templates with a nice way to share common code and override only the parts that need changing.
-
-This also provides a means for templates to inherit from other more generic templates by means of a base template. To find this base template, Hugo searches the same paths and file names as it does for [Ace templates](/templates/ace). For Go templates, simply suffix your files with `.html` rather than `.ace`.
-
 # Template example: Show only upcoming events
 
 Go allows you to do more than what's shown here.  Using Hugo's


### PR DESCRIPTION
This pull request would create a new page in [the Templates section of Hugo's documentation](http://gohugo.io/templates/overview/) that explains how blocks in Go 1.6 can work in Hugo. Initially, I just started a new section in the Go Template Primer but I felt the code examples made a blocks section long enough to warrant its own page.

I did not yet add this page to the navigation. Personally, I would think it fits well between [Content Views](http://gohugo.io/templates/views/) and [Partial Templates](http://gohugo.io/templates/partials/) but I wanted a team member's feedback before I just threw it in. 

Happy to change or resubmit as necessary. This is my first substantial pull request into a real project so do let me know if I missed anything.