### PR TITLE
hugolib: Un-export internal Site-methods

### DIFF
--- a/hugolib/handler_file.go
+++ b/hugolib/handler_file.go
@@ -39,7 +39,7 @@ type defaultHandler struct{ basicFileHandler }
 
 func (h defaultHandler) Extensions() []string { return []string{"*"} }
 func (h defaultHandler) FileConvert(f *source.File, s *Site) HandledResult {
-	s.WriteDestFile(f.Path(), f.Contents)
+	s.writeDestFile(f.Path(), f.Contents)
 	return HandledResult{file: f}
 }
 
@@ -48,6 +48,6 @@ type cssHandler struct{ basicFileHandler }
 func (h cssHandler) Extensions() []string { return []string{"css"} }
 func (h cssHandler) FileConvert(f *source.File, s *Site) HandledResult {
 	x := cssmin.Minify(f.Bytes())
-	s.WriteDestFile(f.Path(), helpers.BytesToReader(x))
+	s.writeDestFile(f.Path(), helpers.BytesToReader(x))
 	return HandledResult{file: f}
 }

--- a/hugolib/menu_test.go
+++ b/hugolib/menu_test.go
@@ -695,11 +695,11 @@ func testSiteSetup(s *Site, t *testing.T) {
 	s.Menus = Menus{}
 	s.initializeSiteInfo()
 
-	if err := s.CreatePages(); err != nil {
+	if err := s.createPages(); err != nil {
 		t.Fatalf("Unable to create pages: %s", err)
 	}
 
-	if err := s.BuildSiteMeta(); err != nil {
+	if err := s.buildSiteMeta(); err != nil {
 		t.Fatalf("Unable to build site metadata: %s", err)
 	}
 }

--- a/hugolib/robotstxt_test.go
+++ b/hugolib/robotstxt_test.go
@@ -46,23 +46,23 @@ func TestRobotsTXTOutput(t *testing.T) {
 
 	s.prepTemplates("robots.txt", robotTxtTemplate)
 
-	if err := s.CreatePages(); err != nil {
+	if err := s.createPages(); err != nil {
 		t.Fatalf("Unable to create pages: %s", err)
 	}
 
-	if err := s.BuildSiteMeta(); err != nil {
+	if err := s.buildSiteMeta(); err != nil {
 		t.Fatalf("Unable to build site metadata: %s", err)
 	}
 
-	if err := s.RenderHomePage(); err != nil {
+	if err := s.renderHomePage(); err != nil {
 		t.Fatalf("Unable to RenderHomePage: %s", err)
 	}
 
-	if err := s.RenderSitemap(); err != nil {
+	if err := s.renderSitemap(); err != nil {
 		t.Fatalf("Unable to RenderSitemap: %s", err)
 	}
 
-	if err := s.RenderRobotsTXT(); err != nil {
+	if err := s.renderRobotsTXT(); err != nil {
 		t.Fatalf("Unable to RenderRobotsTXT :%s", err)
 	}
 

--- a/hugolib/rss_test.go
+++ b/hugolib/rss_test.go
@@ -59,15 +59,15 @@ func TestRSSOutput(t *testing.T) {
 	s.initializeSiteInfo()
 	s.prepTemplates("rss.xml", rssTemplate)
 
-	if err := s.CreatePages(); err != nil {
+	if err := s.createPages(); err != nil {
 		t.Fatalf("Unable to create pages: %s", err)
 	}
 
-	if err := s.BuildSiteMeta(); err != nil {
+	if err := s.buildSiteMeta(); err != nil {
 		t.Fatalf("Unable to build site metadata: %s", err)
 	}
 
-	if err := s.RenderHomePage(); err != nil {
+	if err := s.renderHomePage(); err != nil {
 		t.Fatalf("Unable to RenderHomePage: %s", err)
 	}
 

--- a/hugolib/site_show_plan_test.go
+++ b/hugolib/site_show_plan_test.go
@@ -72,7 +72,7 @@ func TestDegenerateNoTarget(t *testing.T) {
 	s := &Site{
 		Source: &source.InMemorySource{ByteSource: fakeSource},
 	}
-	must(s.CreatePages())
+	must(s.createPages())
 	expected := "foo/bar/file.md (renderer: markdown)\n canonical => !no target specified!\n\n" +
 		"alias/test/file1.md (renderer: markdown)\n canonical => !no target specified!\n\n" +
 		"section/somecontent.html (renderer: n/a)\n canonical => !no target specified!\n\n"
@@ -90,7 +90,7 @@ func TestFileTarget(t *testing.T) {
 	}
 	s.aliasTarget()
 	s.pageTarget()
-	must(s.CreatePages())
+	must(s.createPages())
 	expected := "foo/bar/file.md (renderer: markdown)\n canonical => foo/bar/file/index.html\n\n" +
 		"alias/test/file1.md (renderer: markdown)\n" +
 		" canonical => alias/test/file1/index.html\n" +
@@ -113,7 +113,7 @@ func TestPageTargetUgly(t *testing.T) {
 	}
 	s.aliasTarget()
 
-	s.CreatePages()
+	s.createPages()
 	expected := "foo/bar/file.md (renderer: markdown)\n canonical => foo/bar/file.html\n\n" +
 		"alias/test/file1.md (renderer: markdown)\n" +
 		" canonical => alias/test/file1.html\n" +
@@ -137,7 +137,7 @@ func TestFileTargetPublishDir(t *testing.T) {
 		Source: &source.InMemorySource{ByteSource: fakeSource},
 	}
 
-	must(s.CreatePages())
+	must(s.createPages())
 	expected := "foo/bar/file.md (renderer: markdown)\n canonical => ../public/foo/bar/file/index.html\n\n" +
 		"alias/test/file1.md (renderer: markdown)\n" +
 		" canonical => ../public/alias/test/file1/index.html\n" +

--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -80,7 +80,7 @@ func TestReadPagesFromSourceWithEmptySource(t *testing.T) {
 	d := time.Second * 2
 	ticker := time.NewTicker(d)
 	select {
-	case err = <-s.ReadPagesFromSource():
+	case err = <-s.readPagesFromSource():
 		break
 	case <-ticker.C:
 		err = fmt.Errorf("ReadPagesFromSource() never returns in %s", d.String())
@@ -92,15 +92,15 @@ func TestReadPagesFromSourceWithEmptySource(t *testing.T) {
 }
 
 func createAndRenderPages(t *testing.T, s *Site) {
-	if err := s.CreatePages(); err != nil {
+	if err := s.createPages(); err != nil {
 		t.Fatalf("Unable to create pages: %s", err)
 	}
 
-	if err := s.BuildSiteMeta(); err != nil {
+	if err := s.buildSiteMeta(); err != nil {
 		t.Fatalf("Unable to build site metadata: %s", err)
 	}
 
-	if err := s.RenderPages(); err != nil {
+	if err := s.renderPages(); err != nil {
 		t.Fatalf("Unable to render pages. %s", err)
 	}
 }
@@ -254,7 +254,7 @@ func TestDraftAndFutureRender(t *testing.T) {
 
 		s.initializeSiteInfo()
 
-		if err := s.CreatePages(); err != nil {
+		if err := s.createPages(); err != nil {
 			t.Fatalf("Unable to create pages: %s", err)
 		}
 		return s
@@ -433,8 +433,8 @@ func doTestShouldAlwaysHaveUglyURLs(t *testing.T, uglyURLs bool) {
 		"sitemap.xml", "<root>SITEMAP</root>")
 
 	createAndRenderPages(t, s)
-	s.RenderHomePage()
-	s.RenderSitemap()
+	s.renderHomePage()
+	s.renderSitemap()
 
 	var expectedPagePath string
 	if uglyURLs {
@@ -522,7 +522,7 @@ func doTestSectionNaming(t *testing.T, canonify, uglify, pluralize bool) {
 		"_default/list.html", "{{ .Title }}")
 
 	createAndRenderPages(t, s)
-	s.RenderSectionLists()
+	s.renderSectionLists()
 
 	tests := []struct {
 		doc         string
@@ -640,15 +640,15 @@ func TestAbsURLify(t *testing.T) {
 
 		s.prepTemplates("blue/single.html", templateWithURLAbs)
 
-		if err := s.CreatePages(); err != nil {
+		if err := s.createPages(); err != nil {
 			t.Fatalf("Unable to create pages: %s", err)
 		}
 
-		if err := s.BuildSiteMeta(); err != nil {
+		if err := s.buildSiteMeta(); err != nil {
 			t.Fatalf("Unable to build site metadata: %s", err)
 		}
 
-		if err := s.RenderPages(); err != nil {
+		if err := s.renderPages(); err != nil {
 			t.Fatalf("Unable to render pages. %s", err)
 		}
 
@@ -737,11 +737,11 @@ func TestOrderedPages(t *testing.T) {
 	}
 	s.initializeSiteInfo()
 
-	if err := s.CreatePages(); err != nil {
+	if err := s.createPages(); err != nil {
 		t.Fatalf("Unable to create pages: %s", err)
 	}
 
-	if err := s.BuildSiteMeta(); err != nil {
+	if err := s.buildSiteMeta(); err != nil {
 		t.Fatalf("Unable to build site metadata: %s", err)
 	}
 
@@ -811,11 +811,11 @@ func TestGroupedPages(t *testing.T) {
 	}
 	s.initializeSiteInfo()
 
-	if err := s.CreatePages(); err != nil {
+	if err := s.createPages(); err != nil {
 		t.Fatalf("Unable to create pages: %s", err)
 	}
 
-	if err := s.BuildSiteMeta(); err != nil {
+	if err := s.buildSiteMeta(); err != nil {
 		t.Fatalf("Unable to build site metadata: %s", err)
 	}
 
@@ -1001,11 +1001,11 @@ func TestWeightedTaxonomies(t *testing.T) {
 	}
 	s.initializeSiteInfo()
 
-	if err := s.CreatePages(); err != nil {
+	if err := s.createPages(); err != nil {
 		t.Fatalf("Unable to create pages: %s", err)
 	}
 
-	if err := s.BuildSiteMeta(); err != nil {
+	if err := s.buildSiteMeta(); err != nil {
 		t.Fatalf("Unable to build site metadata: %s", err)
 	}
 
@@ -1068,7 +1068,7 @@ func setupLinkingMockSite(t *testing.T) *Site {
 
 	site.initializeSiteInfo()
 
-	if err := site.CreatePages(); err != nil {
+	if err := site.createPages(); err != nil {
 		t.Fatalf("Unable to create pages: %s", err)
 	}
 

--- a/hugolib/site_url_test.go
+++ b/hugolib/site_url_test.go
@@ -97,18 +97,18 @@ func TestPageCount(t *testing.T) {
 	s.initializeSiteInfo()
 	s.prepTemplates("indexes/blue.html", indexTemplate)
 
-	if err := s.CreatePages(); err != nil {
+	if err := s.createPages(); err != nil {
 		t.Errorf("Unable to create pages: %s", err)
 	}
-	if err := s.BuildSiteMeta(); err != nil {
+	if err := s.buildSiteMeta(); err != nil {
 		t.Errorf("Unable to build site metadata: %s", err)
 	}
 
-	if err := s.RenderSectionLists(); err != nil {
+	if err := s.renderSectionLists(); err != nil {
 		t.Errorf("Unable to render section lists: %s", err)
 	}
 
-	if err := s.RenderAliases(); err != nil {
+	if err := s.renderAliases(); err != nil {
 		t.Errorf("Unable to render site lists: %s", err)
 	}
 

--- a/hugolib/siteinfo_test.go
+++ b/hugolib/siteinfo_test.go
@@ -38,7 +38,7 @@ func TestSiteInfoParams(t *testing.T) {
 
 	buf := new(bytes.Buffer)
 
-	err := s.renderThing(s.NewNode(), "template", buf)
+	err := s.renderThing(s.newNode(), "template", buf)
 	if err != nil {
 		t.Errorf("Unable to render template: %s", err)
 	}

--- a/hugolib/sitemap_test.go
+++ b/hugolib/sitemap_test.go
@@ -51,23 +51,23 @@ func TestSitemapOutput(t *testing.T) {
 
 	s.prepTemplates("sitemap.xml", SITEMAP_TEMPLATE)
 
-	if err := s.CreatePages(); err != nil {
+	if err := s.createPages(); err != nil {
 		t.Fatalf("Unable to create pages: %s", err)
 	}
 
-	if err := s.BuildSiteMeta(); err != nil {
+	if err := s.buildSiteMeta(); err != nil {
 		t.Fatalf("Unable to build site metadata: %s", err)
 	}
 
-	if err := s.RenderHomePage(); err != nil {
+	if err := s.renderHomePage(); err != nil {
 		t.Fatalf("Unable to RenderHomePage: %s", err)
 	}
 
-	if err := s.RenderSitemap(); err != nil {
+	if err := s.renderSitemap(); err != nil {
 		t.Fatalf("Unable to RenderSitemap: %s", err)
 	}
 
-	if err := s.RenderRobotsTXT(); err != nil {
+	if err := s.renderRobotsTXT(); err != nil {
 		t.Fatalf("Unable to RenderRobotsTXT :%s", err)
 	}
 


### PR DESCRIPTION
These are obviously internal and for the most part undocumented, creating lots of GoLint warnings.

See #1160
See #2014