### PR TITLE
helpers: Ignore cache for Pygments when flag set

### DIFF
--- a/docs/content/extras/highlighting.md
+++ b/docs/content/extras/highlighting.md
@@ -106,6 +106,7 @@ It is also possible to add syntax highlighting with GitHub flavoured code fences
 ### Disclaimers
 
  * Pygments is relatively slow and _causes a performance hit when building your site_, but Hugo has been designed to cache the results to disk.
+ * The caching can be turned off by setting the `--ignoreCache` flag to `true`.
  * Languages available depends on your Pygments installation.
 
 ## Client-side

--- a/helpers/pygments.go
+++ b/helpers/pygments.go
@@ -62,10 +62,11 @@ func Highlight(code, lang, optsStr string) string {
 
 	fs := hugofs.Os()
 
+	ignoreCache := viper.GetBool("IgnoreCache")
 	cacheDir := viper.GetString("CacheDir")
 	var cachefile string
 
-	if cacheDir != "" {
+	if !ignoreCache && cacheDir != "" {
 		cachefile = filepath.Join(cacheDir, fmt.Sprintf("pygments-%x", hash.Sum(nil)))
 
 		exists, err := Exists(cachefile, fs)
@@ -120,7 +121,7 @@ func Highlight(code, lang, optsStr string) string {
 		str = strings.Replace(str, "</pre>", "</code></pre>", 1)
 	}
 
-	if cachefile != "" {
+	if !ignoreCache && cachefile != "" {
 		// Write cache file
 		if err := WriteToDisk(cachefile, strings.NewReader(str), fs); err != nil {
 			jww.ERROR.Print(stderr.String())


### PR DESCRIPTION
When the --ignoreCache flag is set to true, do not write and read
the Pygments results to/from the cache directory.

Fixes #2066