### PR TITLE
Make alias redirect output URL's relative

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -2095,7 +2095,19 @@ func (s *Site) writeDestPage(path string, publisher target.Publisher, reader io.
 }
 
 func (s *Site) writeDestAlias(path string, permalink string) (err error) {
-	jww.DEBUG.Println("creating alias:", path)
+	if viper.GetBool("RelativeURLs") {
+		// convert `permalink` into URI relative to location of `path`
+		baseURL := helpers.SanitizeURLKeepTrailingSlash(viper.GetString("BaseURL"))
+		if strings.HasPrefix(permalink, baseURL) {
+			permalink = "/" + strings.TrimPrefix(permalink, baseURL)
+		}
+		permalink, err = helpers.GetRelativePath(permalink, path)
+		if err != nil {
+			jww.ERROR.Println("Failed to make a RelativeURL alias:", path, "redirecting to", permalink)
+		}
+		permalink = filepath.ToSlash(permalink)
+	}
+	jww.DEBUG.Println("creating alias:", path, "redirecting to", permalink)
 	return s.aliasTarget().Publish(path, permalink)
 }
 


### PR DESCRIPTION
we use `relativeURLs = true`


Before the change, hugo output the `BaseURL` - which prevents us from moving the html around
```
Sven Dowideit@DESKTOP-5ACOFLK MINGW64 ~/src/docker/docs (master)
$ curl http://localhost:1313/engine/reference/logging/awslogs/
<!DOCTYPE html><html><head><link rel="canonical" href="http://localhost:1313/engine/admin/logging/awslogs/"/><meta http-equiv="content-type" content="text/html; charset=utf-8" /><meta http-equiv="refresh" content="0;url=http://localhost:1313/engine/admin/logging/awslogs/" /></head></html>
Sven Dowideit@DESKTOP-5ACOFLK MINGW64 ~/src/docker/docs (master)
```

This PR changes the output to:
```
Sven Dowideit@DESKTOP-5ACOFLK MINGW64 ~/src/docker/docs (master)
$ curl http://localhost:1313/engine/reference/logging/awslogs/
<!DOCTYPE html><html><head><link rel="canonical" href="../../../admin/logging/awslogs/"/><meta http-equiv="content-type" content="text/html; charset=utf-8" /><meta http-equiv="refresh" content="0;url=../../../admin/logging/awslogs/" /></head></html>
Sven Dowideit@DESKTOP-5ACOFLK MINGW64 ~/src/docker/docs (master)
```