### PR TITLE
docs: Clarifies use of default archetypes when themes are active

### DIFF
--- a/docs/content/content/archetypes.md
+++ b/docs/content/content/archetypes.md
@@ -111,7 +111,7 @@ The following rules apply:
 
 * If an archetype with a filename that matches the content type being created, it will be used.
 * If no match is found, `archetypes/default.md` will be used.
-* If neither is present and a theme is in use, then within the theme:
+* If neither is present and a theme is specified via `--theme`, then within the theme:
     * If an archetype with a filename that matches the content type being created, it will be used.
     * If no match is found, `archetypes/default.md` will be used.
 * If no archetype files are present, then the one that ships with Hugo will be used.


### PR DESCRIPTION
I previously thought that, when you ran something like `hugo new notes/test.md`, hugo would automatically look in `themes/THEMENAME/archetypes/deafult.md` if `archetypes/` did not exist, but that is not the case.  

You need to specify the theme for this to work, ala: `hugo new --theme=THEMENAME notes/test.md`.  This tweaks the documentation to remind users about that argument.