### PR TITLE
Fix links in the documentation

### DIFF
--- a/docs/content/overview/source-directory.md
+++ b/docs/content/overview/source-directory.md
@@ -34,7 +34,7 @@ Learn more about the different directories and what their purpose is:
 * [archetypes](/content/archetypes/)
 * [content](/content/organization/)
 * [layouts](/layout/overview/)
-* [static](/themes/creation#toc_4)
+* [static](/themes/creation#static)
 * [themes](/themes/overview/)
 
 

--- a/docs/content/templates/go-templates.md
+++ b/docs/content/templates/go-templates.md
@@ -425,7 +425,7 @@ so, such as in this example:
 # Template example: Show only upcoming events
 
 Go allows you to do more than what's shown here.  Using Hugo's
-[`where`](/templates/functions/#toc_4) function and Go built-ins, we can list
+[`where`](/templates/functions/#where) function and Go built-ins, we can list
 only the items from `content/events/` whose date (set in the front matter) is in
 the future:
 


### PR DESCRIPTION
A couple of internal links use `#toc_4` to attempt to locate a document
element within another document page. In both of these instances, there
is no element on the linked to pages with the id `#toc_4`. This commit
updates those links with the document elements which were the original
intended links, meaning these links now take you directly to the
intended element.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>