### PR TITLE
helpers: Remove ToReader funcs

### DIFF
--- a/helpers/general.go
+++ b/helpers/general.go
@@ -130,16 +130,6 @@ func ReaderToString(lines io.Reader) string {
 	return b.String()
 }
 
-// StringToReader does the opposite of ReaderToString.
-func StringToReader(in string) io.Reader {
-	return strings.NewReader(in)
-}
-
-// BytesToReader does the opposite of ReaderToBytes.
-func BytesToReader(in []byte) io.Reader {
-	return bytes.NewReader(in)
-}
-
 // ReaderContains reports whether subslice is within r.
 func ReaderContains(r io.Reader, subslice []byte) bool {
 

--- a/helpers/general_test.go
+++ b/helpers/general_test.go
@@ -14,10 +14,11 @@
 package helpers
 
 import (
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGuessType(t *testing.T) {
@@ -60,20 +61,6 @@ func TestFirstUpper(t *testing.T) {
 			t.Errorf("[%d] got %s but expected %s", i, result, this.expect)
 		}
 	}
-}
-
-func TestBytesToReader(t *testing.T) {
-	asBytes := ReaderToBytes(strings.NewReader("Hello World!"))
-	asReader := BytesToReader(asBytes)
-	assert.Equal(t, []byte("Hello World!"), asBytes)
-	assert.Equal(t, asBytes, ReaderToBytes(asReader))
-}
-
-func TestStringToReader(t *testing.T) {
-	asString := ReaderToString(strings.NewReader("Hello World!"))
-	assert.Equal(t, "Hello World!", asString)
-	asReader := StringToReader(asString)
-	assert.Equal(t, asString, ReaderToString(asReader))
 }
 
 var containsTestText = (`На берегу пустынных волн
@@ -136,7 +123,7 @@ var containsAdditionalTestData = []struct {
 
 func TestReaderContains(t *testing.T) {
 	for i, this := range append(containsBenchTestData, containsAdditionalTestData...) {
-		result := ReaderContains(StringToReader(this.v1), this.v2)
+		result := ReaderContains(strings.NewReader(this.v1), this.v2)
 		if result != this.expect {
 			t.Errorf("[%d] got %t but expected %t", i, result, this.expect)
 		}
@@ -150,7 +137,7 @@ func BenchmarkReaderContains(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for i, this := range containsBenchTestData {
-			result := ReaderContains(StringToReader(this.v1), this.v2)
+			result := ReaderContains(strings.NewReader(this.v1), this.v2)
 			if result != this.expect {
 				b.Errorf("[%d] got %t but expected %t", i, result, this.expect)
 			}

--- a/hugolib/handler_file.go
+++ b/hugolib/handler_file.go
@@ -14,8 +14,9 @@
 package hugolib
 
 import (
+	"bytes"
+
 	"github.com/dchest/cssmin"
-	"github.com/spf13/hugo/helpers"
 	"github.com/spf13/hugo/source"
 	"github.com/spf13/hugo/tpl"
 )
@@ -48,6 +49,6 @@ type cssHandler struct{ basicFileHandler }
 func (h cssHandler) Extensions() []string { return []string{"css"} }
 func (h cssHandler) FileConvert(f *source.File, s *Site) HandledResult {
 	x := cssmin.Minify(f.Bytes())
-	s.writeDestFile(f.Path(), helpers.BytesToReader(x))
+	s.writeDestFile(f.Path(), bytes.NewReader(x))
 	return HandledResult{file: f}
 }

--- a/source/file_test.go
+++ b/source/file_test.go
@@ -14,9 +14,10 @@
 package source
 
 import (
-	"github.com/spf13/hugo/helpers"
-	"github.com/stretchr/testify/assert"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFileUniqueID(t *testing.T) {
@@ -28,11 +29,11 @@ func TestFileUniqueID(t *testing.T) {
 }
 
 func TestFileString(t *testing.T) {
-	assert.Equal(t, "abc", NewFileWithContents("a", helpers.StringToReader("abc")).String())
+	assert.Equal(t, "abc", NewFileWithContents("a", strings.NewReader("abc")).String())
 	assert.Equal(t, "", NewFile("a").String())
 }
 
 func TestFileBytes(t *testing.T) {
-	assert.Equal(t, []byte("abc"), NewFileWithContents("a", helpers.StringToReader("abc")).Bytes())
+	assert.Equal(t, []byte("abc"), NewFileWithContents("a", strings.NewReader("abc")).Bytes())
 	assert.Equal(t, []byte(""), NewFile("a").Bytes())
 }

--- a/transform/chain_test.go
+++ b/transform/chain_test.go
@@ -15,11 +15,12 @@ package transform
 
 import (
 	"bytes"
-	"github.com/spf13/hugo/helpers"
-	"github.com/stretchr/testify/assert"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spf13/hugo/helpers"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -148,7 +149,7 @@ func TestChaingMultipleTransformers(t *testing.T) {
 	tr := NewChain(f1, f2, f3, f4)
 
 	out := new(bytes.Buffer)
-	if err := tr.Apply(out, helpers.StringToReader("Test: f4 f3 f1 f2 f1 The End."), []byte("")); err != nil {
+	if err := tr.Apply(out, strings.NewReader("Test: f4 f3 f1 f2 f1 The End."), []byte("")); err != nil {
 		t.Errorf("Multi transformer chain returned an error: %s", err)
 	}
 

--- a/transform/livereloadinject_test.go
+++ b/transform/livereloadinject_test.go
@@ -16,7 +16,7 @@ package transform
 import (
 	"bytes"
 	"fmt"
-	"github.com/spf13/hugo/helpers"
+	"strings"
 	"testing"
 )
 
@@ -27,7 +27,7 @@ func TestLiveReloadInject(t *testing.T) {
 
 func doTestLiveReloadInject(t *testing.T, bodyEndTag string) {
 	out := new(bytes.Buffer)
-	in := helpers.StringToReader(bodyEndTag)
+	in := strings.NewReader(bodyEndTag)
 
 	tr := NewChain(LiveReloadInject)
 	tr.Apply(out, in, []byte("path"))


### PR DESCRIPTION
Remove StringToReader and BytesToReader in favor of using the stdlib directly.