### PR TITLE
Add --ignoreFiles command-line flag

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -155,6 +155,7 @@ var (
 	logFile     string
 	theme       string
 	source      string
+	ignoreFiles string
 )
 
 // Execute adds all child commands to the root command HugoCmd and sets flags appropriately.
@@ -229,6 +230,7 @@ func initHugoBuildCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&uglyURLs, "uglyURLs", false, "if true, use /filename.html instead of /filename/")
 	cmd.Flags().BoolVar(&canonifyURLs, "canonifyURLs", false, "if true, all relative URLs will be canonicalized using baseURL")
 	cmd.Flags().StringVarP(&baseURL, "baseURL", "b", "", "hostname (and path) to the root, e.g. http://spf13.com/")
+	cmd.Flags().StringVarP(&ignoreFiles, "ignoreFiles", "", "", "Comma-separated list of RegExs, all matching files will not be rendered")
 
 	cmd.Flags().BoolVar(&nitro.AnalysisOn, "stepAnalysis", false, "display memory and timing of different steps of the program")
 	cmd.Flags().BoolVar(&pluralizeListTitles, "pluralizeListTitles", true, "Pluralize titles in lists using inflect")
@@ -389,6 +391,11 @@ func InitializeConfig(subCmdVs ...*cobra.Command) error {
 		}
 		if flagChanged(cmdV.Flags(), "noTimes") {
 			viper.Set("NoTimes", noTimes)
+		}
+		if flagChanged(cmdV.Flags(), "ignoreFiles") {
+			cliIgnoreFiles := regexp.MustCompile(",\\s*").Split(ignoreFiles, -1)
+			allIgnoreFiles := append(viper.GetStringSlice("IgnoreFiles"), cliIgnoreFiles...)
+			viper.Set("ignoreFiles", allIgnoreFiles)
 		}
 
 	}


### PR DESCRIPTION
This PR adds an `--ignoreFiles [string]` general CLI flag that will slice a provided CSV, and append the []string to the ignoreFiles array set in the cfg file.

It should be noted that I have built and "tested" this code by hand, but I'm not familiar enough with this codebase to know if there's somewhere I could/should be adding automated tests for command-line interactions. It should also be noted that this is the first Golang project I've ever touched, so I might be doing something _real_ stupid without knowing it. Any and all guidance / criticism appreciated.

It's also potentially worth discussing that the use case that motivated this addition would be better served by an additive mechanism (`--renderMatching`? `--ignoreFilesExcept`?), rather than the subtractive tool that's currently in place. This was an easy addition, though, and I don't feel confident enough to make that kind of larger UX change without 1) more experience in Go and 2) input from the community/contributors.
