### PR TITLE
Remove empty toc list items to fix rendering of toc on pages that don't use full heading hierarchy

### DIFF
--- a/helpers/content.go
+++ b/helpers/content.go
@@ -335,6 +335,15 @@ func ExtractTOC(content []byte) (newcontent []byte, toc []byte) {
 
 	newcontent = append(content[:startOfTOC], content[endOfTOC:]...)
 	toc = append(replacement, origContent[startOfTOC+len(first):endOfTOC]...)
+
+	emptyTop := []byte(`<ul>
+<li>
+`)
+	emptyBottom := []byte(`</ul></li>
+`)
+
+	toc = []byte(strings.Replace(string(toc), string(emptyTop), "", 10))
+	toc = []byte(strings.Replace(string(toc), string(emptyBottom), "", 10))
 	return
 }
 

--- a/helpers/content.go
+++ b/helpers/content.go
@@ -341,9 +341,9 @@ func ExtractTOC(content []byte) (newcontent []byte, toc []byte) {
 `)
 	emptyBottom := []byte(`</ul></li>
 `)
-
-	toc = []byte(strings.Replace(string(toc), string(emptyTop), "", 10))
-	toc = []byte(strings.Replace(string(toc), string(emptyBottom), "", 10))
+	// Replace empty toc list items with empty strings
+	toc = []byte(bytes.Replace(toc, emptyTop, []byte(""), -1))
+	toc = []byte(bytes.Replace(toc, emptyBottom, []byte(""), -1))
 	return
 }
 

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -261,9 +261,39 @@ in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
 pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
 officia deserunt mollit anim id est laborum.`
 
-	pageWithToC = `---
+	pageWithPartialToC = `---
 title: TOC
 ---
+For some moments the old man did not reply. He stood with bowed head, buried in deep thought. But at last he spoke.
+
+## AA
+
+I have no idea, of course, how long it took me to reach the limit of the plain,
+but at last I entered the foothills, following a pretty little canyon upward
+toward the mountains. Beside me frolicked a laughing brooklet, hurrying upon
+its noisy way down to the silent sea. In its quieter pools I discovered many
+small fish, of four-or five-pound weight I should imagine. In appearance,
+except as to size and color, they were not unlike the whale of our own seas. As
+I watched them playing about I discovered, not only that they suckled their
+young, but that at intervals they rose to the surface to breathe as well as to
+feed upon certain grasses and a strange, scarlet lichen which grew upon the
+rocks just above the water line.
+
+### AAA
+
+I remember I felt an extraordinary persuasion that I was being played with,
+that presently, when I was upon the very verge of safety, this mysterious
+death--as swift as the passage of light--would leap after me from the pit about
+the cylinder and strike me down. ## BB
+
+### BBB
+
+"You're a great Granser," he cried delightedly, "always making believe them little marks mean something."
+`
+	pageWithFullToC = `---
+title: TOC
+---
+# A
 For some moments the old man did not reply. He stood with bowed head, buried in deep thought. But at last he spoke.
 
 ## AA
@@ -604,15 +634,27 @@ func TestPageWithAdditionalExtension(t *testing.T) {
 	checkPageContent(t, p, "<p>first line.<br />\nsecond line.</p>\n\n<p>fourth line.</p>\n")
 }
 
-func TestTableOfContents(t *testing.T) {
+func TestTableOfContentsPartialHeadings(t *testing.T) {
 	p, _ := NewPage("tocpage.md")
-	_, err := p.ReadFrom(strings.NewReader(pageWithToC))
+	_, err := p.ReadFrom(strings.NewReader(pageWithPartialToC))
 	p.Convert()
 	if err != nil {
 		t.Fatalf("Unable to create a page with frontmatter and body content: %s", err)
 	}
 	checkPageContent(t, p, "\n\n<p>For some moments the old man did not reply. He stood with bowed head, buried in deep thought. But at last he spoke.</p>\n\n<h2 id=\"aa\">AA</h2>\n\n<p>I have no idea, of course, how long it took me to reach the limit of the plain,\nbut at last I entered the foothills, following a pretty little canyon upward\ntoward the mountains. Beside me frolicked a laughing brooklet, hurrying upon\nits noisy way down to the silent sea. In its quieter pools I discovered many\nsmall fish, of four-or five-pound weight I should imagine. In appearance,\nexcept as to size and color, they were not unlike the whale of our own seas. As\nI watched them playing about I discovered, not only that they suckled their\nyoung, but that at intervals they rose to the surface to breathe as well as to\nfeed upon certain grasses and a strange, scarlet lichen which grew upon the\nrocks just above the water line.</p>\n\n<h3 id=\"aaa\">AAA</h3>\n\n<p>I remember I felt an extraordinary persuasion that I was being played with,\nthat presently, when I was upon the very verge of safety, this mysterious\ndeath&ndash;as swift as the passage of light&ndash;would leap after me from the pit about\nthe cylinder and strike me down. ## BB</p>\n\n<h3 id=\"bbb\">BBB</h3>\n\n<p>&ldquo;You&rsquo;re a great Granser,&rdquo; he cried delightedly, &ldquo;always making believe them little marks mean something.&rdquo;</p>\n")
-	checkPageTOC(t, p, "<nav id=\"TableOfContents\">\n<ul>\n<li>\n<ul>\n<li><a href=\"#aa\">AA</a>\n<ul>\n<li><a href=\"#aaa\">AAA</a></li>\n<li><a href=\"#bbb\">BBB</a></li>\n</ul></li>\n</ul></li>\n</ul>\n</nav>")
+	checkPageTOC(t, p, "<nav id=\"TableOfContents\">\n<ul>\n<li><a href=\"#aa\">AA</a>\n<ul>\n<li><a href=\"#aaa\">AAA</a></li>\n<li><a href=\"#bbb\">BBB</a></li>\n</ul>\n</nav>")
+}
+
+
+func TestTableOfContentsAllHeadings(t *testing.T) {
+	p, _ := NewPage("tocpage.md")
+	_, err := p.ReadFrom(strings.NewReader(pageWithFullToC))
+	p.Convert()
+	if err != nil {
+		t.Fatalf("Unable to create a page with frontmatter and body content: %s", err)
+	}
+	checkPageContent(t, p, "\n\n<h1 id=\"a\">A</h1>\n\n<p>For some moments the old man did not reply. He stood with bowed head, buried in deep thought. But at last he spoke.</p>\n\n<h2 id=\"aa\">AA</h2>\n\n<p>I have no idea, of course, how long it took me to reach the limit of the plain,\nbut at last I entered the foothills, following a pretty little canyon upward\ntoward the mountains. Beside me frolicked a laughing brooklet, hurrying upon\nits noisy way down to the silent sea. In its quieter pools I discovered many\nsmall fish, of four-or five-pound weight I should imagine. In appearance,\nexcept as to size and color, they were not unlike the whale of our own seas. As\nI watched them playing about I discovered, not only that they suckled their\nyoung, but that at intervals they rose to the surface to breathe as well as to\nfeed upon certain grasses and a strange, scarlet lichen which grew upon the\nrocks just above the water line.</p>\n\n<h3 id=\"aaa\">AAA</h3>\n\n<p>I remember I felt an extraordinary persuasion that I was being played with,\nthat presently, when I was upon the very verge of safety, this mysterious\ndeath&ndash;as swift as the passage of light&ndash;would leap after me from the pit about\nthe cylinder and strike me down. ## BB</p>\n\n<h3 id=\"bbb\">BBB</h3>\n\n<p>&ldquo;You&rsquo;re a great Granser,&rdquo; he cried delightedly, &ldquo;always making believe them little marks mean something.&rdquo;</p>\n")
+	checkPageTOC(t, p, "<nav id=\"TableOfContents\">\n<ul>\n<li><a href=\"#a\">A</a>\n<ul>\n<li><a href=\"#aa\">AA</a>\n<ul>\n<li><a href=\"#aaa\">AAA</a></li>\n<li><a href=\"#bbb\">BBB</a></li>\n</ul>\n</nav>")
 }
 
 func TestPageWithMoreTag(t *testing.T) {


### PR DESCRIPTION
This is my first contribution/modification of a Go project so I'm just looking for some thoughts and feedback on best solutions. This is the solution to a render issue that I encountered that is currently working for me.

When a Theme already puts the Title in the template as `<h1>` it is preferred in my case that the markdown of the page not include an `<h1>` (this looks very bad).  However, if `<h1>` is left out of the markdown then empty TOC list items are created which messes up the `TOC` of the page causing some strange situations.

I remove the empty list elements from the `TOC` after the `TOC` is generated so the `TOC` stays good looking regardless of the heading hierarchy.

---

Example of a document that starts at `<h3>` 
Before the change:
![pre change](https://cloud.githubusercontent.com/assets/24335/15508371/c8dc9f5e-2194-11e6-85d1-911803ee9540.png)

---
After the change:
![post change](https://cloud.githubusercontent.com/assets/24335/15508340/afdc4ca2-2194-11e6-97f0-7dc3f6e8f430.png)