### PR TITLE
Remove unneeded casts in page.getParam

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,9 @@ RUN go get github.com/stretchr/testify/assert \
 	&& go get github.com/spf13/jwalterweatherman \
 	&& go get github.com/spf13/cobra \
 	&& go get github.com/cpuguy83/go-md2man \
-	&& go get github.com/inconshreveable/mousetrap \
 	&& go get github.com/spf13/pflag \
 	&& go get github.com/spf13/fsync \
 	&& go get github.com/spf13/viper \
-	&& go get github.com/kr/pretty \
-	&& go get github.com/kr/text \
 	&& go get github.com/magiconair/properties \
 	&& go get golang.org/x/text/transform \
 	&& go get golang.org/x/text/unicode/norm \
@@ -45,4 +42,3 @@ WORKDIR /go/src/github.com/spf13/hugo
 RUN go get -d -v
 RUN go build -o hugo main.go
 RUN go test github.com/spf13/hugo/...
-

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -671,26 +671,26 @@ func (p *Page) getParam(key string, stringToLower bool) interface{} {
 
 	switch v.(type) {
 	case bool:
-		return cast.ToBool(v)
-	case string:
-		if stringToLower {
-			return strings.ToLower(cast.ToString(v))
-		}
-		return cast.ToString(v)
+		return v
+	case time.Time:
+		return v
 	case int64, int32, int16, int8, int:
 		return cast.ToInt(v)
 	case float64, float32:
 		return cast.ToFloat64(v)
-	case time.Time:
-		return cast.ToTime(v)
+	case map[string]interface{}: // JSON and TOML
+		return v
+	case map[interface{}]interface{}: // YAML
+		return v
+	case string:
+		if stringToLower {
+			return strings.ToLower(v.(string))
+		}
+		return v
 	case []string:
 		if stringToLower {
 			return helpers.SliceToLower(v.([]string))
 		}
-		return v.([]string)
-	case map[string]interface{}: // JSON and TOML
-		return v
-	case map[interface{}]interface{}: // YAML
 		return v
 	}
 


### PR DESCRIPTION
Some calls to cast.To in getParam are no-ops that can be removed, since they just add type information that is discarded on return