### PR TITLE
add example for translation files

### DIFF
--- a/examples/multilingual/data/translations/en.yaml
+++ b/examples/multilingual/data/translations/en.yaml
@@ -1,0 +1,2 @@
+head_title: Multilingual
+title: My multilingual site

--- a/examples/multilingual/data/translations/et.yaml
+++ b/examples/multilingual/data/translations/et.yaml
@@ -1,0 +1,2 @@
+head_title: Mitmekeelne
+title: Minu mitmekeelne leht

--- a/examples/multilingual/layouts/partials/head.html
+++ b/examples/multilingual/layouts/partials/head.html
@@ -3,11 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	{{ if .Title }}
-		{{ if (eq .Params.lang "et") }}
-		<title>Mitmekeelne - {{ .Title }}</title>
-		{{ else }}
-		<title>Multilingual - {{ .Title }}</title>
-		{{ end }}
+		<title>{{ (index .Site.Data.translations .Params.lang).head_title }} - {{ .Title }}</title>
 	{{ end }}
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="stylesheet" href="/main.css">

--- a/examples/multilingual/layouts/partials/header.html
+++ b/examples/multilingual/layouts/partials/header.html
@@ -4,11 +4,7 @@
 		<a href="/kodu">Eesti</a>
 	</nav>
 
-	{{ if (eq .Params.lang "et") }}
-	<h1 id="title">Minu mitmekeelne leht</h1>
-	{{ else }}
-	<h1 id="title">My multilingual site</h1>
-	{{ end }}
+	<h1 id="title">{{ (index .Site.Data.translations .Params.lang).title }}</h1>
 
 	<nav id="main-menu">
 		{{ range (index .Site.Taxonomies.menu .Params.lang).Pages }}


### PR DESCRIPTION
I had a little bit of trouble making the [example for translation files](https://gohugo.io/tutorials/create-a-multilingual-site/#reference-strings-in-templates) work, so I thought I should contribute and expand on this example.