### PR TITLE
commands: Port binding net.OpError handling

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -126,7 +126,7 @@ func server(cmd *cobra.Command, args []string) error {
 	} else {
 		if flagChanged(serverCmd.Flags(), "port") {
 			// port set explicitly by user -- he/she probably meant it!
-			return newSystemErrorF("Port %d already in use", serverPort)
+			return newSystemErrorF("Server startup failed: %s", err)
 		}
 		jww.ERROR.Println("port", serverPort, "already in use, attempting to use an available port")
 		sp, err := helpers.FindAvailablePort()


### PR DESCRIPTION
As @bep suggested, I appended the os err message to create a generic Hugo error.

New messages are:

```
Error: Port 80 permission denied
Error: Port 1025 address already in use
```