### PR TITLE
Fix the embedded shortcodes test so that an AppVeyor build passes

### DIFF
--- a/hugolib/embedded_shortcodes_test.go
+++ b/hugolib/embedded_shortcodes_test.go
@@ -48,7 +48,7 @@ func doTestShortcodeCrossrefs(t *testing.T, relative bool) {
 		expectedBase = baseURL
 	}
 
-	path := "blog/post.md"
+	path := "post.md"
 	in := fmt.Sprintf(`{{< %s "%s" >}}`, refShortcode, path)
 	expected := fmt.Sprintf(`%s/simple/url/`, expectedBase)
 


### PR DESCRIPTION
Merged PR #2204 breaks the AppVeyor build. This PR will fix it.