### PR TITLE
Enable safeHTMLAttr

### DIFF
--- a/docs/content/templates/functions.md
+++ b/docs/content/templates/functions.md
@@ -546,7 +546,6 @@ rendering the whole string as plain-text like this:
 <p>© 2015 Jane Doe.  &lt;a href=&#34;http://creativecommons.org/licenses/by/4.0/&#34;&gt;Some rights reserved&lt;/a&gt;.</p>
 </blockquote>
 
-<!--
 ### safeHTMLAttr
 Declares the provided string as a "safe" HTML attribute
 from a trusted source, for example, ` dir="ltr"`,
@@ -560,8 +559,6 @@ Example: Given a site-wide `config.toml` that contains this menu entry:
 
 * `<a href="{{ .URL }}">` ⇒ `<a href="#ZgotmplZ">` (Bad!)
 * `<a {{ printf "href=%q" .URL | safeHTMLAttr }}>` ⇒ `<a href="irc://irc.freenode.net/#golang">` (Good!)
--->
-
 
 ### safeCSS
 Declares the provided string as a known "safe" CSS string

--- a/tpl/template_funcs.go
+++ b/tpl/template_funcs.go
@@ -1576,9 +1576,6 @@ func readDirFromWorkingDir(i interface{}) ([]os.FileInfo, error) {
 }
 
 // safeHTMLAttr returns a given string as html/template HTMLAttr content.
-//
-// safeHTMLAttr is currently disabled, pending further discussion
-// on its use case.  2015-01-19
 func safeHTMLAttr(a interface{}) template.HTMLAttr {
 	return template.HTMLAttr(cast.ToString(a))
 }
@@ -1806,6 +1803,7 @@ func init() {
 		"replaceRE":    replaceRE,
 		"safeCSS":      safeCSS,
 		"safeHTML":     safeHTML,
+		"safeHTMLAttr": safeHTMLAttr,
 		"safeJS":       safeJS,
 		"safeURL":      safeURL,
 		"sanitizeURL":  helpers.SanitizeURL,


### PR DESCRIPTION
Hi together,

I'm using Hugo shortcodes to generate HTML forms from JSON. I like to set HTML attributes dynamically, but was not able to do so because the attributes were replaced with "ZgotmplZ". The template functions safeHTML, etc. did not work.

After some research I found the template function "safeHTMLAttr", which was already implemented, but disabled, because the developer has seen no use case for it. See https://github.com/spf13/hugo/issues/347#issuecomment-70612848

I have now enabled the function again, because it would be really useful for me. If you like to merge it, I could also write a test and improve the documentation.

Best regards,
Marco