### PR TITLE
Add automatic page date fallback

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -663,6 +663,13 @@ func (p *Page) update(f interface{}) error {
 		p.Draft = !*published
 	}
 
+	if p.Date.IsZero() {
+		fi, err := hugofs.Source().Stat(filepath.Join(helpers.AbsPathify(viper.GetString("ContentDir")), p.File.Path()))
+		if err == nil {
+			p.Date = fi.ModTime()
+		}
+	}
+
 	if p.Lastmod.IsZero() {
 		p.Lastmod = p.Date
 	}


### PR DESCRIPTION
Hi,

This PR adds an automatic value for `Page.Date` using the file's `ModTime` as fallback when none is provided?

Please let me know if it suits to you.

Regards.