### PR TITLE
Docs: Updated install instructions to reflect hugo.exe filename change

### DIFF
--- a/docs/content/tutorials/installing-on-windows.md
+++ b/docs/content/tutorials/installing-on-windows.md
@@ -36,8 +36,7 @@ You'll need a place to store the Hugo executable, your content (the files that y
 
 1. Download the latest zipped Hugo executable from the [Hugo Releases](https://github.com/spf13/hugo/releases) page.
 2. Extract all contents to your `..\Hugo\bin` folder.
-3. You'll probably want to rename the Hugo executable to something short like `hugo.exe`.
-4. In Powershell or your preferred CLI, add the `hugo.exe` executable to your PATH by navigating to `C:\Hugo\bin` (or the location of your hugo.exe file) and use the command `set PATH=%PATH%;C:\Hugo\bin`. If the `hugo` command does not work after a reboot, you may have to run the command prompt as administrator.
+3. In Powershell or your preferred CLI, add the `hugo.exe` executable to your PATH by navigating to `C:\Hugo\bin` (or the location of your hugo.exe file) and use the command `set PATH=%PATH%;C:\Hugo\bin`. If the `hugo` command does not work after a reboot, you may have to run the command prompt as administrator.
 
 ## Less technical users
 
@@ -46,24 +45,24 @@ You'll need a place to store the Hugo executable, your content (the files that y
 3. Find the Windows files near the bottom (they're in alphabetical order, so Windows is last) – download either the 32-bit or 64-bit file depending on whether you have 32-bit or 64-bit Windows. (If you don't know, [see here](https://esupport.trendmicro.com/en-us/home/pages/technical-support/1038680.aspx).)
 4. Move the ZIP file into your `C:\Hugo\bin` folder.
 5. Double-click on the ZIP file and extract its contents. Be sure to extract the contents into the same `C:\Hugo\bin` folder – Windows will do this by default unless you tell it to extract somewhere else.
-6. You should now have three new files: an .exe file, license.md, and readme.md. (you can delete the ZIP download now.)
-7. Rename the .exe file to `hugo.exe`.
-8. Now add Hugo to your Windows PATH settings:
+6. You should now have three new files: hugo.exe, license.md, and readme.md. (you can delete the ZIP download now.)
+7. Now add Hugo to your Windows PATH settings:
 
-#### For Windows 10 users:
-- Right click on the **Start** button
-- Click on **System**
-- Click on **Advanced System Settings** on the left
-- Click on the **Environment Variables** button on the bottom
-- In the User variables section, find the row that starts with PATH (PATH will be all caps)
-- Double-click on **PATH**
-- Click the **New** button.
-- Type in Hugo's path, which is `C:\Hugo\bin\hugo.exe` if you went by the instructions above. Press Enter when you're done typing.
-- Click OK at every window to exit.
+  #### For Windows 10 users:
+  - Right click on the **Start** button
+  - Click on **System**
+  - Click on **Advanced System Settings** on the left
+  - Click on the **Environment Variables** button on the bottom
+  - In the User variables section, find the row that starts with PATH (PATH will be all caps)
+  - Double-click on **PATH**
+  - Click the **New** button.
+  - Type in Hugo's path, which is `C:\Hugo\bin\hugo.exe` if you went by the instructions above. Press Enter when you're done typing.
+  - Click OK at every window to exit.
 
-(Note that the path editor in Windows 10 was added in the large [November 2015 Update](https://blogs.windows.com/windowsexperience/2015/11/12/first-major-update-for-windows-10-available-today/). You'll need to have that or a later update installed for the above steps to work. You can see what Windows 10 build you have by clicking on the Start button → Settings → System → About. See [here](http://www.howtogeek.com/236195/how-to-find-out-which-build-and-version-of-windows-10-you-have/) for more.)
+    (Note that the path editor in Windows 10 was added in the large [November 2015 Update](https://blogs.windows.com/windowsexperience/2015/11/12/first-major-update-for-windows-10-available-today/). You'll need to have that or a later update installed for the above steps to work. You can see what Windows 10 build you have by clicking on the Start button → Settings → System → About. See [here](http://www.howtogeek.com/236195/how-to-find-out-which-build-and-version-of-windows-10-you-have/) for more.)
 
-Windows 7 and 8.1 do not include an easy path editor, so non-technical users on those platforms are advised to install a free third-party path editor like [Windows Environment Variables Editor](http://eveditor.com/) or [Path Editor](https://patheditor2.codeplex.com/).
+  #### For Windows 7 and 8.x users
+  Windows 7 and 8.1 do not include the easy path editor included in Windows 10, so non-technical users on those platforms are advised to install a free third-party path editor like [Windows Environment Variables Editor](http://eveditor.com/) or [Path Editor](https://patheditor2.codeplex.com/).
 
 ## Verify the executable
 


### PR DESCRIPTION
The install tutorial instructed users to rename the *.exe file to hugo.exe because it used to have a big long name. In Hugo 0.16 the file is already named hugo.exe, so the tutorial made no sense on that point. Edited out those instructions.