### PR TITLE
tpl: Add a querify function to generate query strings inside templates

### DIFF
--- a/tpl/template_funcs.go
+++ b/tpl/template_funcs.go
@@ -27,6 +27,7 @@ import (
 	"html"
 	"html/template"
 	"math/rand"
+	"net/url"
 	"os"
 	"reflect"
 	"regexp"
@@ -1748,6 +1749,21 @@ func sha1(in interface{}) (string, error) {
 	return hex.EncodeToString(hash[:]), nil
 }
 
+// querify converts the given parameters into a url.Values object
+func querify(params ...interface{}) (url.Values, error) {
+	qs := url.Values{}
+	vals, err := dictionary(params...)
+	if err != nil {
+		return url.Values{}, fmt.Errorf("querify keys must be strings")
+	}
+
+	for name, value := range vals {
+		qs.Add(name, url.QueryEscape(fmt.Sprintf("%v", value)))
+	}
+
+	return qs, nil
+}
+
 func init() {
 	funcMap = template.FuncMap{
 		"absURL":       func(a string) template.HTML { return template.HTML(helpers.AbsURL(a)) },
@@ -1797,6 +1813,7 @@ func init() {
 		"partial":      partial,
 		"plainify":     plainify,
 		"pluralize":    pluralize,
+		"querify":      querify,
 		"readDir":      readDirFromWorkingDir,
 		"readFile":     readFileFromWorkingDir,
 		"ref":          ref,

--- a/tpl/template_funcs_test.go
+++ b/tpl/template_funcs_test.go
@@ -103,6 +103,7 @@ modBool: {{modBool 15 3}}
 mul: {{mul 2 3}}
 plainify: {{ plainify  "Hello <strong>world</strong>, gophers!" }}
 pluralize: {{ "cat" | pluralize }}
+querify: {{ (querify "foo" 1 "bar" 2 "baz" "with spaces").Encode | safeHTML }}
 readDir: {{ range (readDir ".") }}{{ .Name }}{{ end }}
 readFile: {{ readFile "README.txt" }}
 relURL 1: {{ "http://gohugo.io/" | relURL }}
@@ -154,6 +155,7 @@ modBool: true
 mul: 6
 plainify: Hello world, gophers!
 pluralize: cats
+querify: bar=2&baz=with%2Bspaces&foo=1
 readDir: README.txt
 readFile: Hugo Rocks!
 relURL 1: http://gohugo.io/


### PR DESCRIPTION
The `querify` function will take a set of parameters specified like a dict and return a url.Values object which can be .Encode'd into a query string.

Example:

```html
<a href="http://www.google.com?{{ (querify "q" "test" "page" 3).Encode | safeHTML }}">Search</a>
```

Returns:

```html
<a href="http://www.google.com?page=3&q=test">Search</a>
```