### PR TITLE
Ignore emacs temp files (#filename.md# and .#filename.md)..

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -745,17 +745,20 @@ func NewWatcher(port int) error {
 
 				for _, ev := range evs {
 					ext := filepath.Ext(ev.Name)
+					baseName := filepath.Base(ev.Name)
 					istemp := strings.HasSuffix(ext, "~") ||
 						(ext == ".swp") || // vim
 						(ext == ".swx") || // vim
 						(ext == ".tmp") || // generic temp file
 						(ext == ".DS_Store") || // OSX Thumbnail
-						filepath.Base(ev.Name) == "4913" || // vim
+						baseName == "4913" || // vim
 						strings.HasPrefix(ext, ".goutputstream") || // gnome
 						strings.HasSuffix(ext, "jb_old___") || // intelliJ
 						strings.HasSuffix(ext, "jb_tmp___") || // intelliJ
 						strings.HasSuffix(ext, "jb_bak___") || // intelliJ
-						strings.HasPrefix(ext, ".sb-") // byword
+						strings.HasPrefix(ext, ".sb-") || // byword
+						strings.HasPrefix(baseName, ".#") || // emacs
+						strings.HasPrefix(baseName, "#") // emacs
 					if istemp {
 						continue
 					}

--- a/source/content_directory_test.go
+++ b/source/content_directory_test.go
@@ -43,6 +43,8 @@ func TestIgnoreDotFilesAndDirectories(t *testing.T) {
 		{"foobar/foo.html", false, []string{"\\.md$", "\\.boo$"}},
 		{"foobar/foo.md", true, []string{"^foo"}},
 		{"foobar/foo.md", false, []string{"*", "\\.md$", "\\.boo$"}},
+		{"foobar/.#content.md", true, []string{"/\\.#"}},
+		{".#foobar.md", true, []string{"^\\.#"}},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
In emacs, if you edit whatever files, Hugo would always pick up the first auto-save, and sometimes it would be building while you saved the actual file, so the real change would not be picked up. Really annoying :)

This solves it for emacs in the same way spf13 fixed it for vim and other editors.
