### PR TITLE
 Handle symlink change event

### DIFF
--- a/helpers/path_test.go
+++ b/helpers/path_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
 )
@@ -139,6 +141,29 @@ func TestGetRelativePath(t *testing.T) {
 		}
 
 	}
+}
+
+func TestGetRealPath(t *testing.T) {
+	d1, err := ioutil.TempDir("", "d1")
+	defer os.Remove(d1)
+	fs := afero.NewOsFs()
+
+	rp1, err := GetRealPath(fs, d1)
+	assert.NoError(t, err)
+	assert.Equal(t, d1, rp1)
+
+	sym := filepath.Join(os.TempDir(), "d1sym")
+	err = os.Symlink(d1, sym)
+	defer os.Remove(sym)
+	assert.NoError(t, err)
+
+	rp2, err := GetRealPath(fs, sym)
+	assert.NoError(t, err)
+
+	// On OS X, the temp folder is itself a symbolic link (to /private...)
+	// This has to do for now.
+	assert.True(t, strings.HasSuffix(rp2, d1))
+
 }
 
 func TestMakePathRelative(t *testing.T) {


### PR DESCRIPTION
Hugo 0.16 announced support for symbolic links for the root folders, /content, /static etc., but this got broken pretty fast.

The main problem this commit tries to solve is the matching of file change events to "what changed".

An example:

ContentDir: /mysites/site/content where /mysites/site/content is a symlink to /mycontent

/mycontent:

/mypost1.md
/post/mypost2.md

* A change to mypost1.md (on OS X) will trigger a file change event with name "/mycontent/mypost1.md"
* A change to mypost2.md gives event with name "/mysites/site/content/mypost2.md"

The first change will not trigger a correct update of Hugo before this commit. This commit fixes this by doing a two-step check:

1. Check if "/mysites/site/content/mypost2.md" is within /mysites/site/content
2. Check if  "/mysites/site/content/mypost2.md" is within the real path that /mysites/site/content points to

Fixes #2265