### PR TITLE
Fix panic when using URLize

### DIFF
--- a/helpers/path.go
+++ b/helpers/path.go
@@ -91,6 +91,19 @@ func MakeTitle(inpath string) string {
 	return strings.Replace(strings.TrimSpace(inpath), "-", " ", -1)
 }
 
+// From https://golang.org/src/net/url/url.go
+func ishex(c rune) bool {
+	switch {
+	case '0' <= c && c <= '9':
+		return true
+	case 'a' <= c && c <= 'f':
+		return true
+	case 'A' <= c && c <= 'F':
+		return true
+	}
+	return false
+}
+
 // UnicodeSanitize sanitizes string to be used in Hugo URL's, allowing only
 // a predefined set of special Unicode characters.
 // If RemovePathAccents configuration flag is enabled, Uniccode accents
@@ -99,8 +112,10 @@ func UnicodeSanitize(s string) string {
 	source := []rune(s)
 	target := make([]rune, 0, len(source))
 
-	for _, r := range source {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) || unicode.IsMark(r) || r == '%' || r == '.' || r == '/' || r == '\\' || r == '_' || r == '-' || r == '#' || r == '+' {
+	for i, r := range source {
+		if r == '%' && i+2 < len(source) && ishex(source[i+1]) && ishex(source[i+2]) {
+			target = append(target, r)
+		} else if unicode.IsLetter(r) || unicode.IsDigit(r) || unicode.IsMark(r) || r == '.' || r == '/' || r == '\\' || r == '_' || r == '-' || r == '#' || r == '+' {
 			target = append(target, r)
 		}
 	}

--- a/helpers/url_test.go
+++ b/helpers/url_test.go
@@ -31,6 +31,7 @@ func TestURLize(t *testing.T) {
 		{"foo,bar:foobar", "foobarfoobar"},
 		{"foo/bar.html", "foo/bar.html"},
 		{"трям/трям", "%D1%82%D1%80%D1%8F%D0%BC/%D1%82%D1%80%D1%8F%D0%BC"},
+		{"100%-google", "100-google"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Using URLize on a string like '100%-true' would cause a panic.

This fixes the issue by verifying that a % is followed by two hex characters in the UnicodeSanitize function in the path helper.