### PR TITLE
Remove traces of the BaseURL from the sourceRelativeLinksEval code

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -294,7 +294,7 @@ func (s *SiteInfo) SourceRelativeLink(ref string, currentPage *Page) (string, er
 			return "", err
 		}
 		// Can't compare permalink to BaseUrl, as there may be a port, or a scheme change
-		if relpath == "./" {
+		if filepath.ToSlash(relpath) == "./" {
 			link = "/"
 		} else {
 			link = "/" + filepath.ToSlash(relpath)


### PR DESCRIPTION
Closes: #2227

So I think this fixes it properly for most combinations of `canonifyURLs`, `relativeURLs` and `sourceRelativeLinksEval` and `baseurl`

but because the baseUrl part is added (er, i think) in a transform at the end, I have no idea how to write a test for it
