### PR TITLE
added a link to hugo-openapispec-shortcode

### DIFF
--- a/docs/content/tools/index.md
+++ b/docs/content/tools/index.md
@@ -103,6 +103,7 @@ And for all the other small things around Hugo:
 
 - [hugo-gallery](https://github.com/icecreammatt/hugo-gallery) lets you create an image gallery for Hugo sites.
 - [flickr-hugo-embed](https://github.com/nikhilm/flickr-hugo-embed) prints shortcodes to embed a set of images from an album on Flickr into Hugo.
+- [hugo-openapispec-shortcode](https://github.com/tenfourty/hugo-openapispec-shortcode) A shortcode which allows you to include [Open API Spec](https://openapis.org) (formerly known as Swagger Spec) in a page.
 
 ----
 


### PR DESCRIPTION
Added a link to the Hugo Open API Spec shortcode which allows you to embed OAI Spec (formerly known as Swagger) in your site.