### PR TITLE
Per #2279: `querify` func was double-escaping reserved characters

### DIFF
--- a/tpl/template_funcs.go
+++ b/tpl/template_funcs.go
@@ -1769,7 +1769,7 @@ func querify(params ...interface{}) (string, error) {
 	}
 
 	for name, value := range vals {
-		qs.Add(name, url.QueryEscape(fmt.Sprintf("%v", value)))
+		qs.Add(name, fmt.Sprintf("%v", value))
 	}
 
 	return qs.Encode(), nil

--- a/tpl/template_funcs_test.go
+++ b/tpl/template_funcs_test.go
@@ -103,7 +103,7 @@ modBool: {{modBool 15 3}}
 mul: {{mul 2 3}}
 plainify: {{ plainify  "Hello <strong>world</strong>, gophers!" }}
 pluralize: {{ "cat" | pluralize }}
-querify: {{ (querify "foo" 1 "bar" 2 "baz" "with spaces") | safeHTML }}
+querify: {{ (querify "foo" 1 "bar" 2 "baz" "with spaces" "qux" "this&that=those") | safeHTML }}
 readDir: {{ range (readDir ".") }}{{ .Name }}{{ end }}
 readFile: {{ readFile "README.txt" }}
 relURL 1: {{ "http://gohugo.io/" | relURL }}
@@ -155,7 +155,7 @@ modBool: true
 mul: 6
 plainify: Hello world, gophers!
 pluralize: cats
-querify: bar=2&baz=with%2Bspaces&foo=1
+querify: bar=2&baz=with+spaces&foo=1&qux=this%26that%3Dthose
 readDir: README.txt
 readFile: Hugo Rocks!
 relURL 1: http://gohugo.io/


### PR DESCRIPTION
Test case modified and expanded for `querify` to reflect original bug and changes.

Fixes #2279, but changes escaping behavior for "+" characters.