### PR TITLE
hugo import jekyll: Fixed target path location check

### DIFF
--- a/commands/import_jekyll.go
+++ b/commands/import_jekyll.go
@@ -81,7 +81,7 @@ func importFromJekyll(cmd *cobra.Command, args []string) error {
 
 	jww.INFO.Println("Import Jekyll from:", jekyllRoot, "to:", targetDir)
 
-	if strings.HasPrefix(targetDir, jekyllRoot) {
+	if strings.HasPrefix(filepath.Dir(targetDir), jekyllRoot) {
 		return newUserError("Target path should not be inside the Jekyll root, aborting.")
 	}
 


### PR DESCRIPTION
I ran into the following error:
```
~/Workspace/jelmertiete.com-hugo$ hugo import jekyll ../jelmertiete.com .
Error: Target path should not be inside the Jekyll root, aborting.
```
Note that I'm trying to import into a folder named `jelmertiete.com-hugo` from a folder named `jelmertiete.com`, both in the same directory, which shouldn't throw an error.

Problem was the `HasPrefix` on the full path. Changed it to a `HasPrefix` on the directory instead. 