### PR TITLE
hugolib: Add the alphabetical and diacritics stripped option to taxonomies ordering

### DIFF
--- a/docs/content/taxonomies/ordering.md
+++ b/docs/content/taxonomies/ordering.md
@@ -33,6 +33,15 @@ Taxonomies can be ordered by either alphabetical key or by the number of content
     {{ end }}
     </ul>
 
+It is possible to strip diacritics such as Č when ordered. Displayed key names are still same.
+
+    <ul>
+    {{ $data := .Data }}
+    {{ range $key, $value := .Data.Taxonomy.AlphabeticalAndDiacriticsStripped }}
+    <li><a href="{{ $data.Plural }}/{{ $value.Name | urlize }}"> {{ $value.Name }} </a> {{ $value.Count }} </li>
+    {{ end }}
+    </ul>
+
 ### Order by Popularity Example
 
     <ul>

--- a/hugolib/taxonomy.go
+++ b/hugolib/taxonomy.go
@@ -15,6 +15,10 @@ package hugolib
 
 import (
 	"sort"
+	"unicode"
+
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
 
 	"github.com/spf13/hugo/helpers"
 )
@@ -93,6 +97,26 @@ func (i Taxonomy) Alphabetical() OrderedTaxonomy {
 	ia := i.TaxonomyArray()
 	oiBy(name).Sort(ia)
 	return ia
+}
+
+// AlphabeticalAndDiacriticsStripped returns an ordered taxonomy sorted by key name.
+// Unlike Alphabetical, diacritics such as Č is stripped when sorted.
+func (i Taxonomy) AlphabeticalAndDiacriticsStripped() OrderedTaxonomy {
+	chain := transform.Chain(norm.NFD, transform.RemoveFunc(isMn), norm.NFC)
+
+	name := func(i1, i2 *OrderedTaxonomyEntry) bool {
+		i1Name, _, _ := transform.String(chain, i1.Name)
+		i2Name, _, _ := transform.String(chain, i2.Name)
+		return i1Name < i2Name
+	}
+
+	ia := i.TaxonomyArray()
+	oiBy(name).Sort(ia)
+	return ia
+}
+
+func isMn(r rune) bool {
+	return unicode.Is(unicode.Mn, r) // Mn: nonspacing marks
 }
 
 // ByCount returns an ordered taxonomy sorted by # of pages per key.

--- a/hugolib/taxonomy_test.go
+++ b/hugolib/taxonomy_test.go
@@ -57,3 +57,35 @@ func TestByCountOrderOfTaxonomies(t *testing.T) {
 		t.Fatalf("ordered taxonomies do not match [a, b, c].  Got: %s", st)
 	}
 }
+
+func TestAlphabeticalAndDiacriticsStrippedOrderOfTaxonomies(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+
+	taxonomies := make(map[string]string)
+
+	taxonomies["tag"] = "tags"
+	taxonomies["category"] = "categories"
+
+	viper.Set("taxonomies", taxonomies)
+
+	pageYaml := `---
+tags: ['rock', 'rose', 'rôle']
+categories: 'd'
+---
+YAML frontmatter with tags and categories taxonomy.`
+
+	site := new(Site)
+	page, _ := NewPageFrom(strings.NewReader(pageYaml), "path/to/page")
+	site.Pages = append(site.Pages, page)
+	site.assembleTaxonomies()
+
+	st := make([]string, 0)
+	for _, t := range site.Taxonomies["tags"].AlphabeticalAndDiacriticsStripped() {
+		st = append(st, t.Name)
+	}
+
+	if !compareStringSlice(st, []string{"rock", "rôle", "rose"}) {
+		t.Fatalf("ordered taxonomies do not match [rock, rôle, rose].  Got: %s", st)
+	}
+}


### PR DESCRIPTION
Fixes #2180

I added the new option `AlphabeticalAndDiacriticsStripped` to sort taxonomies alphabetically. Unlike the existing `Alphabetical` option, diacritics such as 'Č' are stripped when sorted. Displayed key names are still same.

Although it is possible to modify the `Alphabetical` option, I think it is not always desirable to strip diacritics when sorted.
