### PR TITLE
Be less aggressive with CHMOD filesystem events

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -775,7 +775,10 @@ func NewWatcher(port int) error {
 					// A workaround is to put your site(s) on the Spotlight exception list,
 					// but that may be a little mysterious for most end users.
 					// So, for now, we skip reload on CHMOD.
-					if ev.Op&fsnotify.Chmod == fsnotify.Chmod {
+					// We do have to check for WRITE though. On slower laptops a Chmod
+					// could be aggregated with other important events, and we still want
+					// to rebuild on those
+					if ev.Op&(fsnotify.Chmod|fsnotify.Write|fsnotify.Create) == fsnotify.Chmod {
 						continue
 					}
 


### PR DESCRIPTION
On 4679fbee41d3, rebuild was disabled on CHMOD filesystem events, but the code is overly aggressive.

In some situations, specially with older Mac's (using a Late 2008 Macbook), the events we receive might be aggregated. On my particular laptop, I get this events:

    INFO: 2016/07/26 18:08:51 hugo.go:737: Received System Events: ["<path>": WRITE|CHMOD]

These events are ignored because the code only checks for Chmod. This commit fixes this by checking that the event is also not a Write or Create.

Related to #1587.

----

This is my first contribution to any Go project, so please forgive any Go-newbiness going on. Any comments are appreciated.

I also don't know how to write tests about this. I don't see a `hugo_test.go` and frankly I don't know how to simulate filesystem events to reproduce this. I do know that Hugo now rebuilds correctly on these events on my slow Mac :). Help is appreciated here.

Thank you,