### PR TITLE
docs: Removed comma from json example.

### DIFF
--- a/docs/content/content/front-matter.md
+++ b/docs/content/content/front-matter.md
@@ -73,7 +73,7 @@ Content of the file goes Here
         "Development",
         "VIM"
     ],
-    "slug": "spf13-vim-3-0-release-and-new-website",
+    "slug": "spf13-vim-3-0-release-and-new-website"
 }
 
 Content of the file goes Here


### PR DESCRIPTION
The comma are causing invalid json and hugo not compile the file based on the same example.