### PR TITLE
docs: Add missing configuration option disableHugoGeneratorInject

### DIFF
--- a/docs/content/overview/configuration.md
+++ b/docs/content/overview/configuration.md
@@ -107,6 +107,8 @@ Following is a list of Hugo-defined variables that you can configure and their c
     enableRobotsTXT:            false
     # Do not render 404 page
     disable404:                 false
+    # Do not inject generator meta tag on homepage
+    disableHugoGeneratorInject: false
     # edit new content with this editor, if provided
     editor:                     ""
     # Enable Emoji emoticons support for page content.


### PR DESCRIPTION
The documentation for disableHugoGeneratorInject configuration option was missing. This config disables hugo from injecting a generator meta tag on the site homepage.