### PR TITLE
Fix for meminterval not using specified interval

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -94,7 +94,8 @@ func init() {
 	serverCmd.Flags().BoolVar(&disableLiveReload, "disableLiveReload", false, "watch without enabling live browser reload on rebuild")
 	serverCmd.Flags().BoolVar(&renderToDisk, "renderToDisk", false, "render to Destination path (default is render to memory & serve from there)")
 	serverCmd.Flags().String("memstats", "", "log memory usage to this file")
-	serverCmd.Flags().Int("meminterval", 100, "interval to poll memory usage (requires --memstats)")
+	serverCmd.Flags().String("meminterval", "100ms", "interval to poll memory usage (requires --memstats), valid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\".")
+
 	serverCmd.RunE = server
 
 	mime.AddExtensionType(".json", "application/json; charset=utf-8")


### PR DESCRIPTION
Hugo seems to ignore the meminterval I specify and always uses it's default of 100ms.
This seems to be because Hugo tries to take the meminterval from the command line
(an Int) and converts it to a String and passes it to time.ParseDuration. If you pass a
different meminterval (such as `1000` as above) it will fail (time.ParseDuration requires
some units) and use the default instead.

Changed `meminterval` to be a String and added better documentation for valid time units.

Resolves: #2325