### PR TITLE
Change .yaml extension to .yml (.yaml still works)

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -209,7 +209,7 @@ func initHugoBuilderFlags(cmd *cobra.Command) {
 }
 
 func initRootPersistentFlags() {
-	HugoCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is path/config.yaml|json|toml)")
+	HugoCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is path/config.yml|json|toml)")
 
 	// Set bash-completion
 	validConfigFilenames := []string{"json", "js", "yaml", "yml", "toml", "tml"}

--- a/commands/import_jekyll.go
+++ b/commands/import_jekyll.go
@@ -193,7 +193,7 @@ func loadJekyllConfig(jekyllRoot string) map[string]interface{} {
 	exists, err := helpers.Exists(path, fs)
 
 	if err != nil || !exists {
-		jww.WARN.Println("_config.yaml not found: Is the specified Jekyll root correct?")
+		jww.WARN.Println("_config.yml not found: Is the specified Jekyll root correct?")
 		return nil
 	}
 
@@ -245,18 +245,8 @@ func createConfigFromJekyll(inpath string, kind string, jekyllConfig map[string]
 		"languageCode":       "en-us",
 		"disablePathToLower": true,
 	}
-	kind = parser.FormatSanitize(kind)
 
-	by, err := parser.InterfaceToConfig(in, parser.FormatToLeadRune(kind))
-	if err != nil {
-		return err
-	}
-
-	err = helpers.WriteToDisk(filepath.Join(inpath, "config."+kind), bytes.NewReader(by), hugofs.Source())
-	if err != nil {
-		return
-	}
-
+	createConfig(inpath, kind, in)
 	return nil
 }
 

--- a/commands/new.go
+++ b/commands/new.go
@@ -135,7 +135,7 @@ func doNewSite(basepath string, force bool) error {
 			return errors.New(basepath + " already exists and is not empty")
 
 		case !isEmpty && force:
-			all := append(dirs, filepath.Join(basepath, "config."+configFormat))
+			all := append(dirs, filepath.Join(basepath, parser.ConfigBasename(configFormat)))
 			for _, path := range all {
 				if exists, _ := helpers.Exists(path, hugofs.Source()); exists {
 					return errors.New(path + " already exists")
@@ -148,7 +148,12 @@ func doNewSite(basepath string, force bool) error {
 		hugofs.Source().MkdirAll(dir, 0777)
 	}
 
-	createConfig(basepath, configFormat)
+	in := map[string]interface{}{
+		"baseurl":      "http://replace-this-with-your-hugo-site.com/",
+		"title":        "My New Hugo Site",
+		"languageCode": "en-us",
+	}
+	createConfig(basepath, configFormat, in)
 
 	jww.FEEDBACK.Printf("Congratulations! Your new Hugo site is created in %q.\n\n", basepath)
 	jww.FEEDBACK.Println(`Just a few more steps and you're ready to go:
@@ -316,12 +321,7 @@ func newContentPathSection(path string) (string, string) {
 	return createpath, section
 }
 
-func createConfig(inpath string, kind string) (err error) {
-	in := map[string]string{
-		"baseurl":      "http://replace-this-with-your-hugo-site.com/",
-		"title":        "My New Hugo Site",
-		"languageCode": "en-us",
-	}
+func createConfig(inpath string, kind string, in map[string]interface{}) (err error) {
 	kind = parser.FormatSanitize(kind)
 
 	by, err := parser.InterfaceToConfig(in, parser.FormatToLeadRune(kind))
@@ -329,7 +329,7 @@ func createConfig(inpath string, kind string) (err error) {
 		return err
 	}
 
-	err = helpers.WriteToDisk(filepath.Join(inpath, "config."+kind), bytes.NewReader(by), hugofs.Source())
+	err = helpers.WriteToDisk(filepath.Join(inpath, parser.ConfigBasename(kind)), bytes.NewReader(by), hugofs.Source())
 	if err != nil {
 		return
 	}

--- a/commands/new_test.go
+++ b/commands/new_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/spf13/hugo/hugofs"
+	"github.com/spf13/hugo/parser"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -99,4 +100,25 @@ func TestDoNewSite_error_force_config_inside_exists(t *testing.T) {
 	hugofs.Source().Create(configPath)
 	err := doNewSite(basepath, true)
 	assert.NotNil(t, err)
+}
+
+func TestDoNewSite_basename_func_called(t *testing.T) {
+	var configBasenameSave = parser.ConfigBasename
+	actual_count := 0
+	parser.ConfigBasename = func(string) string {
+		actual_count++
+		return "anything"
+	}
+	basepath := filepath.Join(os.TempDir(), "blog")
+	hugofs.InitMemFs()
+
+	hugofs.Source().MkdirAll(basepath, 777)
+	doNewSite(basepath, true)
+
+	hugofs.Source().RemoveAll(basepath)
+	doNewSite(basepath, false)
+
+	expected_count := 2
+	assert.Equal(t, expected_count, actual_count)
+	parser.ConfigBasename = configBasenameSave
 }

--- a/docs/content/extras/analytics.md
+++ b/docs/content/extras/analytics.md
@@ -14,7 +14,7 @@ Hugo ships with prebuilt internal templates for Google Analytics tracking, inclu
 
 ## Configuring Google Analytics
 
-Provide your tracking id in your configuration file, e.g. config.yaml.
+Provide your tracking id in your configuration file, e.g. config.yml.
 
     googleAnalytics = "UA-123-45"
 

--- a/docs/content/extras/comments.md
+++ b/docs/content/extras/comments.md
@@ -27,7 +27,7 @@ Hugo comes with all the code you would need to include load Disqus. Simply inclu
 
 ## Configuring Disqus
 
-That template requires you to set a single value in your site config file, e.g. config.yaml.
+That template requires you to set a single value in your site config file, e.g. config.yml.
 
     disqusShortname = "XYW"
 

--- a/docs/content/extras/highlighting.md
+++ b/docs/content/extras/highlighting.md
@@ -32,7 +32,7 @@ If you have never worked with Pygments before, here is a brief primer:
 
 On Debian and Ubuntu systems, you may also install Pygments by running `sudo apt-get install python3-pygments`.
 
-Hugo gives you two options that you can set with the variable `pygmentsuseclasses` (default `false`) in `config.toml` (or `config.yaml`).
+Hugo gives you two options that you can set with the variable `pygmentsuseclasses` (default `false`) in `config.toml` (or `config.yml`).
 
 1. Color-codes for highlighting keywords are directly inserted if `pygmentsuseclasses = false` (default). See in the example below. The color-codes depend on your choice of the `pygmentsstyle` (default `"monokai"`). You can explore the different color styles on [pygments.org](http://pygments.org/) after inserting some example code.
 2. If you choose `pygmentsuseclasses = true`, Hugo includes class names in your code instead of color-codes. For class-names to be meaningful, you need to include a `.css`-file in your website representing your color-scheme. You can either generate this `.css`-files according to this [description](http://pygments.org/docs/cmdline/) or download the standard ones from the [GitHub pygments-css repository](https://github.com/richleland/pygments-css).

--- a/docs/content/extras/menus.md
+++ b/docs/content/extras/menus.md
@@ -108,7 +108,7 @@ Here’s an example `config.toml`:
         weight = -100
         url = "/getting-started/"
 
-And the equivalent example `config.yaml`:
+And the equivalent example `config.yml`:
 
     ---
     menu:

--- a/docs/content/overview/configuration.md
+++ b/docs/content/overview/configuration.md
@@ -20,7 +20,7 @@ websites since the defaults follow commonly used patterns.
 
 Hugo expects to find the config file in the root of the source directory and
 will look there first for a `config.toml` file. If none is present, it will
-then look for a `config.yaml` file, followed by a `config.json` file.
+then look for a `config.yml` file, followed by a `config.json` file.
 
 The config file is a site-wide config. The config file provides directions to
 hugo on how to build the site as well as site-wide parameters and menus.
@@ -33,13 +33,13 @@ env HUGO_TITLE="Some Title" hugo
 
 ## Examples
 
-The following is an example of a typical yaml config file:
+The following is an example of a typical YAML config file:
 
     ---
     baseurl: "http://yoursite.example.com/"
     ...
 
-The following is an example of a toml config file with some of the default values.
+The following is an example of a TOML config file with some of the default values.
 Values under `[params]` will populate the `.Site.Params` variable for use in templates:
 
     contentdir = "content"
@@ -57,7 +57,7 @@ Values under `[params]` will populate the `.Site.Params` variable for use in tem
       description = "Tesla's Awesome Hugo Site"
       author = "Nikola Tesla"
 
-Here is a yaml configuration file which sets a few more options:
+Here is a YAML configuration file which sets a few more options:
 
     ---
     baseurl: "http://yoursite.example.com/"
@@ -92,7 +92,7 @@ Following is a list of Hugo-defined variables that you can configure and their c
     # enable this to make all relative URLs relative to content root. Note that this does not affect absolute URLs.
     relativeURLs:               false
     canonifyURLs:               false
-    # config file (default is path/config.yaml|json|toml)
+    # config file (default is path/config.yml|json|toml)
     config:                     "config.toml"
     contentdir:                 "content"
     dataDir:                    "data"

--- a/docs/content/overview/usage.md
+++ b/docs/content/overview/usage.md
@@ -42,7 +42,7 @@ Flags:
   -D, --buildDrafts=false: include content marked as draft
   -F, --buildFuture=false: include content with publishdate in the future
       --cacheDir="": filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/
-      --config="": config file (default is path/config.yaml|json|toml)
+      --config="": config file (default is path/config.yml|json|toml)
   -d, --destination="": filesystem path to write files to
       --disableRSS=false: Do not build RSS files
       --disableSitemap=false: Do not build Sitemap file

--- a/docs/content/taxonomies/usage.md
+++ b/docs/content/taxonomies/usage.md
@@ -26,7 +26,7 @@ or <code><strong>singular key</strong>: &quot;<em>plural value</em>&quot;</code>
 <table class="table">
 <thead>
 <tr>
-<th>config.toml excerpt:</th><th>config.yaml excerpt:</th>
+<th>config.toml excerpt:</th><th>config.yml excerpt:</th>
 </tr>
 </thead>
 <tbody>

--- a/docs/content/templates/go-templates.md
+++ b/docs/content/templates/go-templates.md
@@ -374,7 +374,7 @@ Here is the corresponding code inside of the template:
 
 
 ## Using Site (config) Parameters
-In your top-level configuration file (e.g., `config.yaml`) you can define site
+In your top-level configuration file (e.g., `config.yml`) you can define site
 parameters, which are values which will be available to you in partials.
 
 For instance, you might declare:

--- a/docs/content/tutorials/create-a-multilingual-site.md
+++ b/docs/content/tutorials/create-a-multilingual-site.md
@@ -53,9 +53,9 @@ If you had more domains and languages, you would just create more config files. 
 
 ## Prep Translation Strings in `/data`
 
-Create `.yaml` (or `.json` or `.toml`) files for each language, under `/data/translations`.
+Create `.yml` (or `.json` or `.toml`) files for each language, under `/data/translations`.
 
-**English Strings `en-US.yaml`**:
+**English Strings `en-US.yml`**:
 
 ~~~yaml
 topslogan: Acme Inc.
@@ -63,7 +63,7 @@ topsubslogan: You'll love us
 ...
 ~~~
 
-**Japanese Strings `ja-JP.yaml`**:
+**Japanese Strings `ja-JP.yml`**:
 
 ~~~yaml
 topslogan: 有限会社アクミー
@@ -99,7 +99,7 @@ The above shows both techniques, using an `if eq` and `else if eq` to check the 
 
 ## Customize Dates
 
-At the time of this writing, Golang does not yet have support for internationalized locales, but if you do some work, you can simulate it. For example, if you want to use French month names, you can add a data file like ``data/mois.yaml`` with this content:
+At the time of this writing, Golang does not yet have support for internationalized locales, but if you do some work, you can simulate it. For example, if you want to use French month names, you can add a data file like ``data/mois.yml`` with this content:
 
 ~~~toml
 1: "janvier"

--- a/docs/content/tutorials/github-pages-blog.md
+++ b/docs/content/tutorials/github-pages-blog.md
@@ -29,9 +29,9 @@ As our goal is to host a website using GitHub Pages, it is natural for us to hos
 
 ## Create the Blog
 
-### Write a `config.yaml` File
+### Write a `config.yml` File
 
-The very first step in creating a new Hugo site is to [write the config file](/overview/configuration/). This config file is important for at least two reasons: (1) this is where site-wide settings (like the websites `baseurl`) go, and (2) the config file dictates to some extent how Hugo will generate the website. For the example website I created a file `config.yaml` with the following contents
+The very first step in creating a new Hugo site is to [write the config file](/overview/configuration/). This config file is important for at least two reasons: (1) this is where site-wide settings (like the websites `baseurl`) go, and (2) the config file dictates to some extent how Hugo will generate the website. For the example website I created a file `config.yml` with the following contents
 
     ---
     contentdir: "content"
@@ -46,7 +46,7 @@ The very first step in creating a new Hugo site is to [write the config file](/o
 
 > **Caveat:** Hugo's former default of `canonifyurls: true` has been changed
 > to `false` since this tutorial has written.  **Please make sure you manually
-> add `canonifyurls: true` to your `config.yaml`** if you are using Spencer's
+> add `canonifyurls: true` to your `config.yml`** if you are using Spencer's
 > https://github.com/spencerlyon2/hugo_gh_blog for this tutorial, or you *will*
 > run into problems such as the CSS files not loading.
 
@@ -97,7 +97,7 @@ Each of the files in the example repository is well commented with a description
 
 ### Add Some Content
 
-The final step in creating the blog is to add some actual blog posts. To do this, simply create one Markdown file (with extension `.md`) for each new blog post. At the top of each file you should include a metadata section that tells Hugo some things about the post (see [docs](/content/front-matter/)). For example, consider the yaml metadata section from the top of the file `/content/posts/newest.md` from the example repository:
+The final step in creating the blog is to add some actual blog posts. To do this, simply create one Markdown file (with extension `.md`) for each new blog post. At the top of each file you should include a metadata section that tells Hugo some things about the post (see [docs](/content/front-matter/)). For example, consider the YAML metadata section from the top of the file `/content/posts/newest.md` from the example repository:
 
     ---
     title: "Just another sample post"
@@ -115,7 +115,7 @@ The keys set in this section are the mandatory `title` and `date` as well as the
 
 Once the site is set up and working properly, we need to push it to the correct branch of a GitHub repository so the website can be served through GitHub Pages. There are many ways to do this. Here I will show the workflow I currently use to manage my websites that are hosted through GitHub Pages.
 
-GitHub Pages will serve up a website for any repository that has a branch called `gh-pages` with a valid `index.html` file at that branch's root. A typical workflow might be to keep the content of a website on the `master` branch of a repository and the generated website on the `gh-pages` branch. This provides nice separation between input and output, but can be very tedious to work with. As a workaround, we will use the `git subtree` family of commands to have the `public` directory (or whatever `publishdir` is set to in your `config.yaml`) mirror the root of the `gh-pages` branch of the repository. This will allow us to do all our work on the `master` branch, run Hugo to have the site output into the `public` directory, and then push that directory directly to the correct place for GitHub Pages to serve our site.
+GitHub Pages will serve up a website for any repository that has a branch called `gh-pages` with a valid `index.html` file at that branch's root. A typical workflow might be to keep the content of a website on the `master` branch of a repository and the generated website on the `gh-pages` branch. This provides nice separation between input and output, but can be very tedious to work with. As a workaround, we will use the `git subtree` family of commands to have the `public` directory (or whatever `publishdir` is set to in your `config.yml`) mirror the root of the `gh-pages` branch of the repository. This will allow us to do all our work on the `master` branch, run Hugo to have the site output into the `public` directory, and then push that directory directly to the correct place for GitHub Pages to serve our site.
 
 To get this properly set up, we will execute a series of commands at the terminal. I will include all of them in one place here for easy copy and paste, and will explain what each line does via comments. Note that this is to be run from the `<root>` directory (wherever the `content` and `layout` folders of your Hugo project live). Also note that you will need to change the commands that have the example repository GitHub address so that they point to your repo.
 

--- a/hugolib/datafiles_test.go
+++ b/hugolib/datafiles_test.go
@@ -54,10 +54,10 @@ func TestDataDirToml(t *testing.T) {
 func TestDataDirYAMLWithOverridenValue(t *testing.T) {
 	sources := []source.ByteSource{
 		// filepath.Walk walks the files in lexical order, '/' comes before '.'. Simulate this:
-		{Name: filepath.FromSlash("a.yaml"), Content: []byte("a: 1")},
-		{Name: filepath.FromSlash("test/v1.yaml"), Content: []byte("v1-2: 2")},
-		{Name: filepath.FromSlash("test/v2.yaml"), Content: []byte("v2:\n- 2\n- 3")},
-		{Name: filepath.FromSlash("test.yaml"), Content: []byte("v1: 1")},
+		{Name: filepath.FromSlash("a.yml"), Content: []byte("a: 1")},
+		{Name: filepath.FromSlash("test/v1.yml"), Content: []byte("v1-2: 2")},
+		{Name: filepath.FromSlash("test/v2.yml"), Content: []byte("v2:\n- 2\n- 3")},
+		{Name: filepath.FromSlash("test.yml"), Content: []byte("v1: 1")},
 	}
 
 	expected := map[string]interface{}{"a": map[string]interface{}{"a": 1},

--- a/parser/frontmatter.go
+++ b/parser/frontmatter.go
@@ -149,6 +149,13 @@ func FormatSanitize(kind string) string {
 	}
 }
 
+var ConfigBasename = func(kind string) string {
+	if kind == "yaml" {
+		return "config.yml"
+	}
+	return "config." + kind
+}
+
 // DetectFrontMatter detects the type of frontmatter analysing its first character.
 func DetectFrontMatter(mark rune) (f *frontmatterType) {
 	switch mark {

--- a/parser/frontmatter_test.go
+++ b/parser/frontmatter_test.go
@@ -14,8 +14,24 @@
 package parser
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
+
+func TestConfigBasename(t *testing.T) {
+	for _, this := range []struct {
+		kind   string
+		expect string
+	}{
+		{"toml", "config.toml"},
+		{"json", "config.json"},
+		{"yaml", "config.yml"},
+		{"other", "config.other"},
+	} {
+		result := ConfigBasename(this.kind)
+		assert.Equal(t, this.expect, result)
+	}
+}
 
 func TestFormatToLeadRune(t *testing.T) {
 	for i, this := range []struct {


### PR DESCRIPTION
As you may know, the conventional extension for YAML files is `.yml` (rather than `.yaml`).

`.yaml` remains supported, presumably because spf13/viper supports it (e.g. [here](https://github.com/spf13/viper/blob/a0cdbddebd2b4e614f360b2220f32055d1afe7dd/viper.go#L220) and [here](https://github.com/spf13/viper/blob/a0cdbddebd2b4e614f360b2220f32055d1afe7dd/viper.go#L181)).

Most changes are documentation, some are error messages.

(BTW, I found `git diff --word-diff=color` useful in showing these changes.)

See #2 and (for example) use of ".yml" in issue 162.
