### PR TITLE
Feature-Request: Make absURL and relURL accept anything

### DIFF
--- a/tpl/template_funcs.go
+++ b/tpl/template_funcs.go
@@ -1803,7 +1803,7 @@ func htmlUnescape(in interface{}) (string, error) {
 
 func init() {
 	funcMap = template.FuncMap{
-		"absURL":       func(a string) template.HTML { return template.HTML(helpers.AbsURL(a)) },
+		"absURL":       func(a interface{}) template.HTML { return template.HTML(helpers.AbsURL(cast.ToString(a))) },
 		"add":          func(a, b interface{}) (interface{}, error) { return helpers.DoArithmetic(a, b, '+') },
 		"after":        after,
 		"apply":        apply,
@@ -1856,7 +1856,7 @@ func init() {
 		"readDir":      readDirFromWorkingDir,
 		"readFile":     readFileFromWorkingDir,
 		"ref":          ref,
-		"relURL":       func(a string) template.HTML { return template.HTML(helpers.RelURL(a)) },
+		"relURL":       func(a interface{}) template.HTML { return template.HTML(helpers.RelURL(cast.ToString(a))) },
 		"relref":       relRef,
 		"replace":      replace,
 		"replaceRE":    replaceRE,

--- a/tpl/template_funcs_test.go
+++ b/tpl/template_funcs_test.go
@@ -82,6 +82,7 @@ func TestFuncsInTemplate(t *testing.T) {
 	in :=
 		`absURL: {{ "http://gohugo.io/" | absURL }}
 absURL: {{ "mystyle.css" | absURL }}
+absURL: {{ 42 | absURL }}
 add: {{add 1 2}}
 base64Decode 1: {{ "SGVsbG8gd29ybGQ=" | base64Decode }}
 base64Decode 2: {{ 42 | base64Encode | base64Decode }}
@@ -121,6 +122,7 @@ readDir: {{ range (readDir ".") }}{{ .Name }}{{ end }}
 readFile: {{ readFile "README.txt" }}
 relURL 1: {{ "http://gohugo.io/" | relURL }}
 relURL 2: {{ "mystyle.css" | relURL }}
+relURL 2: {{ mul 2 21 | relURL }}
 replace: {{ replace "Batman and Robin" "Robin" "Catwoman" }}
 replaceRE: {{ "http://gohugo.io/docs" | replaceRE "^https?://([^/]+).*" "$1" }}
 safeCSS: {{ "Bat&Man" | safeCSS | safeCSS }}
@@ -146,6 +148,7 @@ urlize: {{ "Bat Man" | urlize }}
 
 	expected := `absURL: http://gohugo.io/
 absURL: http://mysite.com/hugo/mystyle.css
+absURL: http://mysite.com/hugo/42
 add: 3
 base64Decode 1: Hello world
 base64Decode 2: 42
@@ -185,6 +188,7 @@ readDir: README.txt
 readFile: Hugo Rocks!
 relURL 1: http://gohugo.io/
 relURL 2: /hugo/mystyle.css
+relURL 2: /hugo/42
 replace: Batman and Catwoman
 replaceRE: gohugo.io
 safeCSS: Bat&amp;Man


### PR DESCRIPTION
The template functions `relURL` and `absURL` currently only accept strings. However, after #889 many template functions like `safeHtml` were opened to accept more than strings. So I suggest that also `relURL` and `absURL` should share this behavior. For example the following code currently throws an error

    {{ .RSSLink | relURL }}

because `.RSSLink` is of type `template.HTML` (it throws an error with my version `Hugo Static Site Generator v0.16-DEV BuildDate: 2016-02-06T18:14:17+01:00` shipped with Ubuntu 16.04).

I followed 3a2a4c3b07f . Note that I never programmed in go before, so someone should check my changings :-) I am also not sure whether [code injections](https://en.wikipedia.org/wiki/Code_injection) are possible after the changes in my commit...