### PR TITLE
Fix command for getting hugo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,13 +89,7 @@ started:
 1. Get the latest Hugo sources:
 
     ```
-    go get -u -t github.com/spf13/hugo
-    ```
-
-1. For running the test suite via `make test` you should also run:
-
-    ```
-    go get github.com/stretchr/testify
+    go get -u -t github.com/spf13/hugo/...
     ```
 
 1. Change to the Hugo source directory:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,12 @@ started:
     go get -u -t github.com/spf13/hugo
     ```
 
+1. For running the test suite via `make test` you should also run:
+
+    ```
+    go get github.com/stretchr/testify
+    ```
+
 1. Change to the Hugo source directory:
 
     ```


### PR DESCRIPTION
Small change to `CONTRIBUTING.md` because a command is missing for running the test suite. See https://discuss.gohugo.io/t/should-contributing-md-be-updated-cf-919-on-github/3885 and #919 for more details.