### PR TITLE
Correct "it's" and "its"

### DIFF
--- a/docs/content/content/archetypes.md
+++ b/docs/content/content/archetypes.md
@@ -65,7 +65,7 @@ Congratulations!  We have successfully created an archetype and used it for our 
 
 ### Creating custom archetypes
 
-Earlier you created a new content type by adding a new subfolder to the content directory. In our case it's name would be `content/musician`. To use the corresponding archetype you just need to create a file named after the content type called `musician.md` in the `archetypes` directory, similar to the one below.
+Earlier you created a new content type by adding a new subfolder to the content directory. In our case its name would be `content/musician`. To use the corresponding archetype you just need to create a file named after the content type called `musician.md` in the `archetypes` directory, similar to the one below.
 
 #### archetypes/musician.md
 

--- a/docs/content/tutorials/how-to-contribute-to-hugo.md
+++ b/docs/content/tutorials/how-to-contribute-to-hugo.md
@@ -177,7 +177,7 @@ You can check on which branch your are with `git branch`. You should see a list 
 
 Perhaps you want to start contributing to the docs. Then you can ignore most of the following steps. You can find the documentation within the cloned repository in the subfolder `docs`. Change the directory with `cd docs`. Install the [latest release]({{< relref "overview/installing.md" >}}). Or read on and build Hugo from source. 
 
-You can start Hugo's built-in server via `hugo server`. Browse the documentation by entering [http://localhost:1313](http://localhost:1313) in the address bar of your browser. The server automatically updates the page if you change it's content.
+You can start Hugo's built-in server via `hugo server`. Browse the documentation by entering [http://localhost:1313](http://localhost:1313) in the address bar of your browser. The server automatically updates the page if you change its content.
 
 ### Building Hugo
 
@@ -195,7 +195,7 @@ Make sure the commands `go test ./...` passes, and `go build` completes.
 
 ### Formatting
 
-The Go code styleguide maybe is opiniated but it ensures that the codebase looks the same, regardless who wrote the code. Go comes with it's own formatting tool. Let's apply the styleguide to our addtions:
+The Go code styleguide maybe is opiniated but it ensures that the codebase looks the same, regardless who wrote the code. Go comes with its own formatting tool. Let's apply the styleguide to our addtions:
 
 ```sh
 go fmt ./...

--- a/helpers/url.go
+++ b/helpers/url.go
@@ -107,7 +107,7 @@ func URLize(uri string) string {
 	// escape unicode letters
 	parsedURI, err := url.Parse(sanitized)
 	if err != nil {
-		// if net/url can not parse URL it's meaning Sanitize works incorrect
+		// if net/url can not parse URL it means Sanitize works incorrectly
 		panic(err)
 	}
 	x := parsedURI.String()


### PR DESCRIPTION
Now in the entire repository all uses of "it's" and "its" are correct.