### PR TITLE
#2364 Exposed funcMap as FuncMap

### DIFF
--- a/tpl/template.go
+++ b/tpl/template.go
@@ -94,10 +94,10 @@ func New() Template {
 
 	localTemplates = &templates.Template
 
-	for k, v := range funcMap {
+	for k, v := range FuncMap {
 		amber.FuncMap[k] = v
 	}
-	templates.Funcs(funcMap)
+	templates.Funcs(FuncMap)
 	templates.LoadEmbedded()
 	return templates
 }

--- a/tpl/template_funcs.go
+++ b/tpl/template_funcs.go
@@ -48,7 +48,8 @@ import (
 	jww "github.com/spf13/jwalterweatherman"
 )
 
-var funcMap template.FuncMap
+// FuncMap is the map[string]func of the functions available within templates.
+var FuncMap template.FuncMap
 
 // eq returns the boolean truth of arg1 == arg2.
 func eq(x, y interface{}) bool {
@@ -871,7 +872,7 @@ func apply(seq interface{}, fname string, args ...interface{}) (interface{}, err
 		return nil, errors.New("can't iterate over a nil value")
 	}
 
-	fn, found := funcMap[fname]
+	fn, found := FuncMap[fname]
 	if !found {
 		return nil, errors.New("can't find function " + fname)
 	}
@@ -1802,7 +1803,7 @@ func htmlUnescape(in interface{}) (string, error) {
 }
 
 func init() {
-	funcMap = template.FuncMap{
+	FuncMap = template.FuncMap{
 		"absURL":       func(a interface{}) template.HTML { return template.HTML(helpers.AbsURL(cast.ToString(a))) },
 		"add":          func(a, b interface{}) (interface{}, error) { return helpers.DoArithmetic(a, b, '+') },
 		"after":        after,


### PR DESCRIPTION
This allows other Go projects to use the template functions from Hugo whilst
still allowing those projects to load and manage templates however they wish.

Would resolve #2364 