### PR TITLE
helpers: fix invalid pagination links

### DIFF
--- a/helpers/path.go
+++ b/helpers/path.go
@@ -412,8 +412,17 @@ func prettifyPath(in string, b filepathPathBridge) string {
 		// /section/name/index.html -> /section/name/index.html
 		return b.Clean(in)
 	}
+
 	// /section/name.html -> /section/name/index.html
-	return b.Join(b.Dir(in), name, "index"+ext)
+	// /.xml -> /index.xml
+	// /node.js/page/2 -> /node.js/page/2
+	r := regexp.MustCompile("[.html|.xml]$")
+	if r.MatchString(ext) {
+		return b.Join(b.Dir(in), name, "index"+ext)
+	} else {
+		return b.Clean(in)
+	}
+
 }
 
 // ExtractRootPaths extracts the root paths from the supplied list of paths.

--- a/helpers/url_test.go
+++ b/helpers/url_test.go
@@ -214,6 +214,8 @@ func TestPretty(t *testing.T) {
 	assert.Equal(t, PrettifyURL("/section/name/index.html"), "/section/name")
 	assert.Equal(t, PrettifyURL("/index.html"), "/")
 	assert.Equal(t, PrettifyURL("/name.xml"), "/name/index.xml")
+	assert.Equal(t, PrettifyURL("/node.js/page/2"), "/node.js/page/2")
+	assert.Equal(t, PrettifyURL("/index.html/page/2"), "/index.html/page/2")
 	assert.Equal(t, PrettifyURL("/"), "/")
 	assert.Equal(t, PrettifyURL(""), "/")
 }


### PR DESCRIPTION
The path helper incorrectly transforms valid urls causing issues with
pagination. One example is `.net`

http://localhost:1313/tags/.net/
to
http://localhost:1313/tags/index.net/page/2

The commit adds a regex test to check for `.xml` or `.html` extensions
and applies the transformation on a match.

This allows valid URLs like /foo/index.html/bar to also be passed
through.

Fixes #2110
