### PR TITLE
Make summary, wordcount etc. more effective

### DIFF
--- a/helpers/content.go
+++ b/helpers/content.go
@@ -138,19 +138,28 @@ func StripHTML(s string) string {
 	// Walk through the string removing all tags
 	b := bp.GetBuffer()
 	defer bp.PutBuffer(b)
-
-	inTag := false
+	var inTag, isSpace, wasSpace bool
 	for _, r := range s {
-		switch r {
-		case '<':
+		if !inTag {
+			isSpace = false
+		}
+
+		switch {
+		case r == '<':
 			inTag = true
-		case '>':
+		case r == '>':
 			inTag = false
+		case unicode.IsSpace(r):
+			isSpace = true
+			fallthrough
 		default:
-			if !inTag {
+			if !inTag && (!isSpace || (isSpace && !wasSpace)) {
 				b.WriteRune(r)
 			}
 		}
+
+		wasSpace = isSpace
+
 	}
 	return b.String()
 }

--- a/helpers/content.go
+++ b/helpers/content.go
@@ -384,8 +384,25 @@ func RenderBytes(ctx *RenderingContext) []byte {
 	}
 }
 
-// TotalWords returns an int of the total number of words in a given content.
+// TotalWords counts instance of one or more consecutive white space
+// characters, as defined by unicode.IsSpace, in s.
+// This is a cheaper way of word counting than the obvious len(strings.Fields(s)).
 func TotalWords(s string) int {
+	n := 0
+	inWord := false
+	for _, r := range s {
+		wasInWord := inWord
+		inWord = !unicode.IsSpace(r)
+		if inWord && !wasInWord {
+			n++
+		}
+	}
+	return n
+}
+
+// Old implementation only kept for benchmark comparison.
+// TODO(bep) remove
+func totalWordsOld(s string) int {
 	return len(strings.Fields(s))
 }
 

--- a/helpers/content_test.go
+++ b/helpers/content_test.go
@@ -34,11 +34,22 @@ func TestStripHTML(t *testing.T) {
 	}
 	data := []test{
 		{"<h1>strip h1 tag <h1>", "strip h1 tag "},
-		{"<p> strip p tag </p>", " strip p tag \n"},
+		{"<p> strip p tag </p>", " strip p tag "},
 		{"</br> strip br<br>", " strip br\n"},
 		{"</br> strip br2<br />", " strip br2\n"},
 		{"This <strong>is</strong> a\nnewline", "This is a newline"},
 		{"No Tags", "No Tags"},
+		{`<p>Summary Next Line. 
+<figure >
+    
+        <img src="/not/real" />
+    
+    
+</figure>
+.
+More text here.</p>
+
+<p>Some more text</p>`, "Summary Next Line.  . More text here.\nSome more text\n"},
 	}
 	for i, d := range data {
 		output := StripHTML(d.input)

--- a/helpers/content_test.go
+++ b/helpers/content_test.go
@@ -408,12 +408,45 @@ func TestExtractNoTOC(t *testing.T) {
 	}
 }
 
-func TestTotalWords(t *testing.T) {
-	testString := "Two, Words!"
-	actualWordCount := TotalWords(testString)
+var totalWordsBenchmarkString = strings.Repeat("Hugo Rocks ", 200)
 
-	if actualWordCount != 2 {
-		t.Errorf("Actual word count (%d) for test string (%s) did not match 2.", actualWordCount, testString)
+func TestTotalWords(t *testing.T) {
+
+	for i, this := range []struct {
+		s     string
+		words int
+	}{
+		{"Two, Words!", 2},
+		{"Word", 1},
+		{"", 0},
+		{"One, Two,      Three", 3},
+		{totalWordsBenchmarkString, 400},
+	} {
+		actualWordCount := TotalWords(this.s)
+
+		if actualWordCount != this.words {
+			t.Errorf("[%d] Actual word count (%d) for test string (%s) did not match %d", i, actualWordCount, this.s, this.words)
+		}
+	}
+}
+
+func BenchmarkTotalWords(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		wordCount := TotalWords(totalWordsBenchmarkString)
+		if wordCount != 400 {
+			b.Fatal("Wordcount error")
+		}
+	}
+}
+
+func BenchmarkTotalWordsOld(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		wordCount := totalWordsOld(totalWordsBenchmarkString)
+		if wordCount != 400 {
+			b.Fatal("Wordcount error")
+		}
 	}
 }
 

--- a/helpers/content_test.go
+++ b/helpers/content_test.go
@@ -64,6 +64,22 @@ func TestBytesToHTML(t *testing.T) {
 	assert.Equal(t, template.HTML("dobedobedo"), BytesToHTML([]byte("dobedobedo")))
 }
 
+var benchmarkTruncateString = strings.Repeat("This is a sentence about nothing.", 20)
+
+func BenchmarkTestTruncateWordsToWholeSentence(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		TruncateWordsToWholeSentence(benchmarkTruncateString, SummaryLength)
+	}
+}
+
+func BenchmarkTestTruncateWordsToWholeSentenceOld(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		truncateWordsToWholeSentenceOld(benchmarkTruncateString, SummaryLength)
+	}
+}
+
 func TestTruncateWordsToWholeSentence(t *testing.T) {
 	type test struct {
 		input, expected string
@@ -77,10 +93,11 @@ func TestTruncateWordsToWholeSentence(t *testing.T) {
 		{"This is a sentence.", "This is a sentence.", 5, false},
 		{"This is also a sentence!", "This is also a sentence!", 1, false},
 		{"To be. Or not to be. That's the question.", "To be.", 1, true},
-		{" \nThis is not a sentence\n ", "This is not a", 4, true},
+		{" \nThis is not a sentence\nAnd this is another", "This is not a sentence", 4, true},
+		{"", "", 10, false},
 	}
 	for i, d := range data {
-		output, truncated := TruncateWordsToWholeSentence(strings.Fields(d.input), d.max)
+		output, truncated := TruncateWordsToWholeSentence(d.input, d.max)
 		if d.expected != output {
 			t.Errorf("Test %d failed. Expected %q got %q", i, d.expected, output)
 		}

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -486,10 +486,6 @@ func (p *Page) ReadFrom(buf io.Reader) (int64, error) {
 }
 
 func (p *Page) analyzePage() {
-	// TODO(bep)
-	if true {
-		return
-	}
 	if p.isCJKLanguage {
 		p.WordCount = 0
 		for _, word := range p.PlainWords() {

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -107,9 +107,10 @@ type Source struct {
 	source.File
 }
 type PageMeta struct {
-	WordCount      int
-	FuzzyWordCount int
-	ReadingTime    int
+	wordCount      int
+	fuzzyWordCount int
+	readingTime    int
+	pageMetaInit   sync.Once
 	Weight         int
 }
 
@@ -485,28 +486,48 @@ func (p *Page) ReadFrom(buf io.Reader) (int64, error) {
 	return int64(len(p.rawContent)), nil
 }
 
+func (p *Page) WordCount() int {
+	p.analyzePage()
+	return p.wordCount
+}
+
+func (p *Page) ReadingTime() int {
+	p.analyzePage()
+	return p.readingTime
+}
+
+func (p *Page) FuzzyWordCount() int {
+	p.analyzePage()
+	return p.fuzzyWordCount
+}
+
 func (p *Page) analyzePage() {
-	if p.isCJKLanguage {
-		p.WordCount = 0
-		for _, word := range p.PlainWords() {
-			runeCount := utf8.RuneCountInString(word)
-			if len(word) == runeCount {
-				p.WordCount++
-			} else {
-				p.WordCount += runeCount
+	p.pageMetaInit.Do(func() {
+		if p.isCJKLanguage {
+			p.wordCount = 0
+			for _, word := range p.PlainWords() {
+				runeCount := utf8.RuneCountInString(word)
+				if len(word) == runeCount {
+					p.wordCount++
+				} else {
+					p.wordCount += runeCount
+				}
 			}
+		} else {
+			p.wordCount = helpers.TotalWords(p.Plain())
 		}
-	} else {
-		p.WordCount = len(p.PlainWords())
-	}
 
-	p.FuzzyWordCount = (p.WordCount + 100) / 100 * 100
+		// TODO(bep) is set in a test. Fix that.
+		if p.fuzzyWordCount == 0 {
+			p.fuzzyWordCount = (p.wordCount + 100) / 100 * 100
+		}
 
-	if p.isCJKLanguage {
-		p.ReadingTime = (p.WordCount + 500) / 501
-	} else {
-		p.ReadingTime = (p.WordCount + 212) / 213
-	}
+		if p.isCJKLanguage {
+			p.readingTime = (p.wordCount + 500) / 501
+		} else {
+			p.readingTime = (p.wordCount + 212) / 213
+		}
+	})
 }
 
 func (p *Page) permalink() (*url.URL, error) {

--- a/hugolib/pageSort_test.go
+++ b/hugolib/pageSort_test.go
@@ -95,11 +95,11 @@ func TestLimit(t *testing.T) {
 
 func TestPageSortReverse(t *testing.T) {
 	p1 := createSortTestPages(10)
-	assert.Equal(t, 0, p1[0].FuzzyWordCount)
-	assert.Equal(t, 9, p1[9].FuzzyWordCount)
+	assert.Equal(t, 0, p1[0].fuzzyWordCount)
+	assert.Equal(t, 9, p1[9].fuzzyWordCount)
 	p2 := p1.Reverse()
-	assert.Equal(t, 9, p2[0].FuzzyWordCount)
-	assert.Equal(t, 0, p2[9].FuzzyWordCount)
+	assert.Equal(t, 9, p2[0].fuzzyWordCount)
+	assert.Equal(t, 0, p2[9].fuzzyWordCount)
 	// cached
 	assert.True(t, probablyEqualPages(p2, p1.Reverse()))
 }
@@ -149,7 +149,7 @@ func createSortTestPages(num int) Pages {
 		if i%2 == 0 {
 			w = 10
 		}
-		pages[i].FuzzyWordCount = i
+		pages[i].fuzzyWordCount = i
 		pages[i].Weight = w
 		pages[i].Description = "initial"
 	}

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -504,10 +504,13 @@ func checkPageContent(t *testing.T, page *Page, content string, msg ...interface
 }
 
 func normalizeContent(c string) string {
-	norm := strings.Replace(c, "\n", "", -1)
+	norm := c
+	norm = strings.Replace(norm, "\n", " ", -1)
 	norm = strings.Replace(norm, "    ", " ", -1)
 	norm = strings.Replace(norm, "   ", " ", -1)
 	norm = strings.Replace(norm, "  ", " ", -1)
+	norm = strings.Replace(norm, "p> ", "p>", -1)
+	norm = strings.Replace(norm, ">  <", "> <", -1)
 	return strings.TrimSpace(norm)
 }
 
@@ -710,8 +713,8 @@ func TestPageWithShortCodeInSummary(t *testing.T) {
 
 	assertFunc := func(t *testing.T, ext string, p *Page) {
 		checkPageTitle(t, p, "Simple")
-		checkPageContent(t, p, normalizeExpected(ext, "<p>Summary Next Line. <figure > <img src=\"/not/real\" /> </figure>.\nMore text here.</p><p>Some more text</p>"), ext)
-		checkPageSummary(t, p, "Summary Next Line. . More text here. Some more text", ext)
+		checkPageContent(t, p, normalizeExpected(ext, "<p>Summary Next Line. \n<figure >\n    \n        <img src=\"/not/real\" />\n    \n    \n</figure>\n.\nMore text here.</p>\n\n<p>Some more text</p>\n"))
+		checkPageSummary(t, p, "Summary Next Line.  . More text here. Some more text")
 		checkPageType(t, p, "page")
 		checkPageLayout(t, p, "page/single.html", "_default/single.html", "theme/page/single.html", "theme/_default/single.html")
 	}
@@ -793,7 +796,7 @@ func TestWordCountWithAllCJKRunesWithoutHasCJKLanguage(t *testing.T) {
 	testCommonResetState()
 
 	assertFunc := func(t *testing.T, ext string, p *Page) {
-		if p.WordCount != 8 {
+		if p.WordCount() != 8 {
 			t.Fatalf("[%s] incorrect word count for content '%s'. expected %v, got %v", ext, p.plain, 8, p.WordCount)
 		}
 	}
@@ -806,11 +809,10 @@ func TestWordCountWithAllCJKRunesHasCJKLanguage(t *testing.T) {
 	viper.Set("HasCJKLanguage", true)
 
 	assertFunc := func(t *testing.T, ext string, p *Page) {
-		if p.WordCount != 15 {
+		if p.WordCount() != 15 {
 			t.Fatalf("[%s] incorrect word count for content '%s'. expected %v, got %v", ext, p.plain, 15, p.WordCount)
 		}
 	}
-
 	testAllMarkdownEnginesForPage(t, assertFunc, "simple", simplePageWithAllCJKRunes)
 }
 
@@ -820,7 +822,7 @@ func TestWordCountWithMainEnglishWithCJKRunes(t *testing.T) {
 	viper.Set("HasCJKLanguage", true)
 
 	assertFunc := func(t *testing.T, ext string, p *Page) {
-		if p.WordCount != 74 {
+		if p.WordCount() != 74 {
 			t.Fatalf("[%s] incorrect word count for content '%s'. expected %v, got %v", ext, p.plain, 74, p.WordCount)
 		}
 
@@ -828,7 +830,6 @@ func TestWordCountWithMainEnglishWithCJKRunes(t *testing.T) {
 			t.Fatalf("[%s] incorrect Summary for content '%s'. expected %v, got %v", ext, p.plain,
 				simplePageWithMainEnglishWithCJKRunesSummary, p.Summary)
 		}
-
 	}
 
 	testAllMarkdownEnginesForPage(t, assertFunc, "simple", simplePageWithMainEnglishWithCJKRunes)
@@ -839,7 +840,7 @@ func TestWordCountWithIsCJKLanguageFalse(t *testing.T) {
 	viper.Set("HasCJKLanguage", true)
 
 	assertFunc := func(t *testing.T, ext string, p *Page) {
-		if p.WordCount != 75 {
+		if p.WordCount() != 75 {
 			t.Fatalf("[%s] incorrect word count for content '%s'. expected %v, got %v", ext, p.plain, 74, p.WordCount)
 		}
 
@@ -847,7 +848,6 @@ func TestWordCountWithIsCJKLanguageFalse(t *testing.T) {
 			t.Fatalf("[%s] incorrect Summary for content '%s'. expected %v, got %v", ext, p.plain,
 				simplePageWithIsCJKLanguageFalseSummary, p.Summary)
 		}
-
 	}
 
 	testAllMarkdownEnginesForPage(t, assertFunc, "simple", simplePageWithIsCJKLanguageFalse)
@@ -857,15 +857,15 @@ func TestWordCountWithIsCJKLanguageFalse(t *testing.T) {
 func TestWordCount(t *testing.T) {
 
 	assertFunc := func(t *testing.T, ext string, p *Page) {
-		if p.WordCount != 483 {
+		if p.WordCount() != 483 {
 			t.Fatalf("[%s] incorrect word count. expected %v, got %v", ext, 483, p.WordCount)
 		}
 
-		if p.FuzzyWordCount != 500 {
+		if p.FuzzyWordCount() != 500 {
 			t.Fatalf("[%s] incorrect word count. expected %v, got %v", ext, 500, p.WordCount)
 		}
 
-		if p.ReadingTime != 3 {
+		if p.ReadingTime() != 3 {
 			t.Fatalf("[%s] incorrect min read. expected %v, got %v", ext, 3, p.ReadingTime)
 		}
 

--- a/hugolib/pagination_test.go
+++ b/hugolib/pagination_test.go
@@ -55,7 +55,7 @@ func TestSplitPageGroups(t *testing.T) {
 			// first group 10 in weight
 			assert.Equal(t, 10, pg.Key)
 			for _, p := range pg.Pages {
-				assert.True(t, p.FuzzyWordCount%2 == 0) // magic test
+				assert.True(t, p.fuzzyWordCount%2 == 0) // magic test
 			}
 		}
 	} else {
@@ -70,7 +70,7 @@ func TestSplitPageGroups(t *testing.T) {
 			// last should have 5 in weight
 			assert.Equal(t, 5, pg.Key)
 			for _, p := range pg.Pages {
-				assert.True(t, p.FuzzyWordCount%2 != 0) // magic test
+				assert.True(t, p.fuzzyWordCount%2 != 0) // magic test
 			}
 		}
 	} else {
@@ -443,10 +443,10 @@ func TestPage(t *testing.T) {
 	page21, _ := f2.page(1)
 	page2Nil, _ := f2.page(3)
 
-	assert.Equal(t, 1, page11.FuzzyWordCount)
+	assert.Equal(t, 3, page11.fuzzyWordCount)
 	assert.Nil(t, page1Nil)
 
-	assert.Equal(t, 1, page21.FuzzyWordCount)
+	assert.Equal(t, 3, page21.fuzzyWordCount)
 	assert.Nil(t, page2Nil)
 }
 
@@ -468,7 +468,7 @@ func createTestPages(num int) Pages {
 		if i%2 == 0 {
 			w = 10
 		}
-		pages[i].FuzzyWordCount = i
+		pages[i].fuzzyWordCount = i + 2
 		pages[i].Weight = w
 	}
 

--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -33,6 +33,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func init() {
+	//There are expected ERROR logging in tests that produces a lot of noise.
+	jww.SetStdoutThreshold(jww.LevelCritical)
+}
+
 const (
 	pageSimpleTitle = `---
 title: simple template


### PR DESCRIPTION
In total, the effect with this branch compared with master:

```
benchmark           old ns/op      new ns/op      delta
BenchmarkHugo-4     3166246627     3038050615     -4.05%

benchmark           old allocs     new allocs     delta
BenchmarkHugo-4     10557420       10540152       -0.16%

benchmark           old bytes      new bytes      delta
BenchmarkHugo-4     1621203992     1605716520     -0.96%
```

See: https://github.com/bep/hugo-benchmark

Word counting benchmark:

``` 
BenchmarkTotalWords-4            100000         18795 ns/op           0  B/op           0 allocs/op 
BenchmarkTotalWordsOld-4          30000         46751 ns/op           6400 B/op           1 allocs/op
```

New auto-summary benchmark:

``` 
BenchmarkTestTruncateWordsToWholeSentence-4            300000         4720 ns/op         0 B/op              0 allocs/op
BenchmarkTestTruncateWordsToWholeSentenceOld-4         100000         17699 ns/op        3072 B/op           3 allocs/op
```