### PR TITLE
Update highlight.js example to latest version

### DIFF
--- a/docs/content/extras/highlighting.md
+++ b/docs/content/extras/highlighting.md
@@ -129,8 +129,8 @@ This example uses the popular [Highlight.js] library, hosted by [Yandex], a popu
 In your `./layouts/partials/` (or `./layouts/chrome/`) folder, depending on your specific theme, there will be a snippet that will be included in every generated HTML page, such as `header.html` or `header.includes.html`. Simply add the css and js to initialize [Highlight.js]:
 
 ~~~
-<link rel="stylesheet" href="https://yandex.st/highlightjs/8.0/styles/default.min.css">
-<script src="https://yandex.st/highlightjs/8.0/highlight.min.js"></script>
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/default.min.css">
+<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 ~~~
 


### PR DESCRIPTION
Highlight.js has evolved quite a bit since it this doc was written. Updating the example to the latest 9.6 version of Highlight JS hosted by cloudflare