### PR TITLE
tpl: Add template function 'asciidocify'

### DIFF
--- a/tpl/template_funcs.go
+++ b/tpl/template_funcs.go
@@ -1218,6 +1218,18 @@ func markdownify(in interface{}) (template.HTML, error) {
 	return template.HTML(m), nil
 }
 
+// asciidocify renders a given string from Markdown to HTML.
+func asciidocify(in interface{}) (template.HTML, error) {
+	text, err := cast.ToStringE(in)
+	if err != nil {
+		return "", err
+	}
+	m := helpers.RenderBytes(&helpers.RenderingContext{Content: []byte(text), PageFmt: "asciidoc"})
+	//m = bytes.TrimPrefix(m, markdownTrimPrefix)
+	//m = bytes.TrimSuffix(m, markdownTrimSuffix)
+	return template.HTML(m), nil
+}
+
 // jsonify encodes a given object to JSON.
 func jsonify(v interface{}) (template.HTML, error) {
 	b, err := json.Marshal(v)
@@ -1843,6 +1855,7 @@ func init() {
 		"add":          func(a, b interface{}) (interface{}, error) { return helpers.DoArithmetic(a, b, '+') },
 		"after":        after,
 		"apply":        apply,
+		"asciidocify":  asciidocify,
 		"base64Decode": base64Decode,
 		"base64Encode": base64Encode,
 		"chomp":        chomp,

--- a/tpl/template_funcs_test.go
+++ b/tpl/template_funcs_test.go
@@ -84,6 +84,7 @@ func TestFuncsInTemplate(t *testing.T) {
 absURL: {{ "mystyle.css" | absURL }}
 absURL: {{ 42 | absURL }}
 add: {{add 1 2}}
+asciidocify: {{ .Title | asciidocify }}
 base64Decode 1: {{ "SGVsbG8gd29ybGQ=" | base64Decode }}
 base64Decode 2: {{ 42 | base64Encode | base64Decode }}
 base64Encode: {{ "Hello world" | base64Encode }}
@@ -110,7 +111,7 @@ humanize 4: {{ humanize 103 }}
 in: {{ if in "this string contains a substring" "substring" }}Substring found!{{ end }}
 jsonify: {{ (slice "A" "B" "C") | jsonify }}
 lower: {{lower "BatMan"}}
-markdownify: {{ .Title | markdownify}}
+markdownify: {{ .Title | markdownify }}
 md5: {{ md5 "Hello world, gophers!" }}
 mod: {{mod 15 3}}
 modBool: {{modBool 15 3}}
@@ -150,6 +151,7 @@ urlize: {{ "Bat Man" | urlize }}
 absURL: http://mysite.com/hugo/mystyle.css
 absURL: http://mysite.com/hugo/42
 add: 3
+asciidocify: <strong>BatMan</strong>
 base64Decode 1: Hello world
 base64Decode 2: 42
 base64Encode: SGVsbG8gd29ybGQ=
@@ -1746,6 +1748,25 @@ func TestMarkdownify(t *testing.T) {
 		}
 		if !reflect.DeepEqual(result, this.expect) {
 			t.Errorf("[%d] markdownify got %v (type %v) but expected %v (type %v)", i, result, reflect.TypeOf(result), this.expect, reflect.TypeOf(this.expect))
+		}
+	}
+
+}
+
+func TestAsciidocify(t *testing.T) {
+	for i, this := range []struct {
+		in     interface{}
+		expect interface{}
+	}{
+		{"Hello *World!*", template.HTML("Hello <strong>World!</strong>")},
+		{[]byte("Hello Bytes *World!*"), template.HTML("Hello Bytes <strong>World!</strong>")},
+	} {
+		result, err := asciidocify(this.in)
+		if err != nil {
+			t.Fatalf("[%d] unexpected error in markdownify: %s", i, err)
+		}
+		if !reflect.DeepEqual(result, this.expect) {
+			t.Errorf("[%d] asciidocify got %v (type %v) but expected %v (type %v)", i, result, reflect.TypeOf(result), this.expect, reflect.TypeOf(this.expect))
 		}
 	}
 


### PR DESCRIPTION
I added the template function according to 'markdownify'. Also the tests. But the command
`go test ./...
`
throws some errors where I think, that don't come from what I changed. Here is what I see:

```
?   	github.com/lafisrap/hugo	[no test files]
ok  	github.com/lafisrap/hugo/bufferpool	0.025s
# github.com/lafisrap/hugo/hugolib
hugolib/site.go:839: too many arguments in call to source.NewLazyFileReader
hugolib/site_show_plan_test.go:60: undefined: helpers.DiffStringSlices
ok  	github.com/lafisrap/hugo/commands	0.025s
ok  	github.com/lafisrap/hugo/create	0.050s
ok  	github.com/lafisrap/hugo/helpers	0.025s
ok  	github.com/lafisrap/hugo/hugofs	0.011s
FAIL	github.com/lafisrap/hugo/hugolib [build failed]
?   	github.com/lafisrap/hugo/livereload	[no test files]
# github.com/lafisrap/hugo/tpl
tpl/template_funcs_test.go:242: undefined: helpers.DiffStringSlices
ok  	github.com/lafisrap/hugo/parser	0.031s
ok  	github.com/lafisrap/hugo/source	0.008s
ok  	github.com/lafisrap/hugo/target	0.013s
FAIL	github.com/lafisrap/hugo/tpl [build failed]
ok  	github.com/lafisrap/hugo/transform	0.008s
?   	github.com/lafisrap/hugo/utils	[no test files]
?   	github.com/lafisrap/hugo/watcher	[no test files]

```