### PR TITLE
Prevent panic on empty authorlist

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -179,8 +179,11 @@ func (p *Page) Author() Author {
 
 func (p *Page) Authors() AuthorList {
 	authorKeys, ok := p.Params["authors"]
+	if !ok {
+		return AuthorList{}
+	}
 	authors := authorKeys.([]string)
-	if !ok || len(authors) < 1 || len(p.Site.Authors) < 1 {
+	if len(authors) < 1 || len(p.Site.Authors) < 1 {
 		return AuthorList{}
 	}
 


### PR DESCRIPTION
When Author was called on a Page with no "authors" set in the front-matter,
hugo would panic. This makes sure the "ok" check actually works.