### PR TITLE
docs: Mention theme config option on Usage page

### DIFF
--- a/docs/content/themes/usage.md
+++ b/docs/content/themes/usage.md
@@ -13,15 +13,13 @@ weight: 30
 Please make certain you have installed the themes you want to use in the
 `/themes` directory.
 
-To use a theme for a site execute hugo with the following parameter:
+To use a theme for a site, execute Hugo with the following parameter:
 
     hugo -t ThemeName
 
 or add this line to your site configuration:
 
     theme:                      "ThemeName"
-
-
 
 The *ThemeName* must match the name of the directory inside `/themes`.
 

--- a/docs/content/themes/usage.md
+++ b/docs/content/themes/usage.md
@@ -13,9 +13,15 @@ weight: 30
 Please make certain you have installed the themes you want to use in the
 `/themes` directory.
 
-To use a theme for a site:
+To use a theme for a site execute hugo with the following parameter:
 
     hugo -t ThemeName
+
+or add this line to your site configuration:
+
+    theme:                      "ThemeName"
+
+
 
 The *ThemeName* must match the name of the directory inside `/themes`.
 


### PR DESCRIPTION
It took me a long time to realize that this could also be done by adding a line to the config file. I always expected it to be mentioned on this page, as it is the first thing you *really* have to do when testing out Hugo.