### PR TITLE
Fix typo in Quickstart doc

### DIFF
--- a/docs/content/overview/quickstart.md
+++ b/docs/content/overview/quickstart.md
@@ -455,7 +455,7 @@ These are a few of the books that I have read within the last year.
 
 So far all the posts that we have written are in draft status.
 To make a draft public, you can either run a command
-or manually change the draft status in the post to `true`.
+or manually change the draft status in the post to `false`.
 
 ```bash
 $ hugo undraft content/post/good-to-great.md


### PR DESCRIPTION
To publish a post, draft status should be changed to `false`.