### PR TITLE
Fix paginator counter on x86-32

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -155,7 +155,14 @@ type targetList struct {
 
 type SiteInfo struct {
 	// atomic requires 64-bit alignment for struct field access
-	paginationPageCount   uint64
+	// According to the docs, " The first word in a global variable or in an
+	// allocated struct or slice can be relied upon to be 64-bit aligned."
+	// Moving paginationPageCount to the top of this struct didn't do the
+	// magic, maybe due to the way SiteInfo is embedded.
+	// Adding the 4 byte padding below does the trick.
+	_                   [4]byte
+	paginationPageCount uint64
+
 	BaseURL               template.URL
 	Taxonomies            TaxonomyList
 	Authors               AuthorList


### PR DESCRIPTION
Atomic operations with 64 bit values must be aligned for 64-bit on x86-32.

According to the spec:

"The first word in a global variable or in an allocated struct or slice can be relied upon to be 64-bit aligned."

The above wasn't enough for the `paginationPageCount` on `SiteInfo`, maybe due to how `SiteInfo` is embedded.

This commit adds a 4 byte padding before the `uint64` that creates the correct alignment.

Fixes #2415