### PR TITLE
tpl: Add reflection functions

### DIFF
--- a/docs/content/templates/functions.md
+++ b/docs/content/templates/functions.md
@@ -356,7 +356,7 @@ e.g.
        {{ .Content }}
     {{ end }}
 
-## Files    
+## Files
 
 ### readDir
 
@@ -757,6 +757,64 @@ This can be useful if you want to use Gravatar for generating a unique avatar:
 {{ sha1 "Hello world, gophers!" }}
 <!-- returns the string "c8b5b0e33d408246e30f53e32b8f7627a7a649d4" -->
 ```
+
+## Reflection
+
+### typeOf
+
+Takes an interface and returns a string representation of the type. For pointers, this will return a type prefixed with an asterisk(`*`). So a pointer to type `Foo` will be `*Foo`.
+
+`{{ typeOf "Bat Man" }}`
+
+returns `string`
+
+`{{ typeOf (slice "A" "B") }}`
+
+returns `[]interface {}`
+
+`{{ typeOf (dict "one" "two" "foo" "bar" ) }}`
+
+returns `map[string]interface {}`
+
+### typeIs
+
+Compares an interface with a string name, and returns true if they match. Note that a pointer will not match a reference. For example `*Foo` will not match `Foo`.
+
+`{{ typeIs "string" "Bat Man" }}`
+
+returns `true`
+
+### typeIsLike
+
+Returns true if the interface is of the given type, or is a pointer to the given type.
+
+`{{ typeIsLike "string" "Bat Man" }}`
+
+returns `true`
+
+### kindOf
+
+Takes an interface and returns a string representation of its kind.
+
+`{{ kindOf "Bat Man" }}`
+
+returns `string`
+
+`{{ kindOf (slice "A" "B") }}`
+
+returns `slice`
+
+`{{ kindOf (dict "one" "two" "foo" "bar" ) }}`
+
+returns `map`
+
+### kindIs
+
+Returns true if the given string matches the kind of the given interface.
+
+`{{ kindIs "string" "Bat Man" }}`
+
+returns `true`
 
 ## Internationalization
 

--- a/tpl/template_funcs.go
+++ b/tpl/template_funcs.go
@@ -1850,6 +1850,28 @@ func relURL(a interface{}) (template.HTML, error) {
 	return template.HTML(helpers.RelURL(s, false)), nil
 }
 
+// typeIs returns true if the src is the type named in target.
+func typeIs(target string, src interface{}) bool {
+	return target == typeOf(src)
+}
+
+func typeIsLike(target string, src interface{}) bool {
+	t := typeOf(src)
+	return target == t || "*"+target == t
+}
+
+func typeOf(src interface{}) string {
+	return fmt.Sprintf("%T", src)
+}
+
+func kindIs(target string, src interface{}) bool {
+	return target == kindOf(src)
+}
+
+func kindOf(src interface{}) string {
+	return reflect.ValueOf(src).Kind().String()
+}
+
 func init() {
 	funcMap = template.FuncMap{
 		"absURL":       absURL,
@@ -1937,5 +1959,10 @@ func init() {
 		"where":        where,
 		"i18n":         I18nTranslate,
 		"T":            I18nTranslate,
+		"typeOf":       typeOf,
+		"typeIs":       typeIs,
+		"typeIsLike":   typeIsLike,
+		"kindOf":       kindOf,
+		"kindIs":       kindIs,
 	}
 }

--- a/tpl/template_funcs_test.go
+++ b/tpl/template_funcs_test.go
@@ -149,6 +149,11 @@ time: {{ (time "2015-01-21").Year }}
 trim: {{ trim "++Batman--" "+-" }}
 upper: {{upper "BatMan"}}
 urlize: {{ "Bat Man" | urlize }}
+typeIs: {{ typeIs "string" "Bat Man" }}
+typeIsLike: {{ typeIsLike "string" "Bat Man" }}
+typeOf: {{ typeOf "Bat Man" }}
+kindIs: {{ kindIs "string" "Bat Man" }}
+kindOf: {{ kindOf (slice "A" "B" "C") }}
 `
 
 	expected := `absLangURL: http://mysite.com/hugo/en/index.html
@@ -218,6 +223,11 @@ time: 2015
 trim: Batman
 upper: BATMAN
 urlize: bat-man
+typeIs: true
+typeIsLike: true
+typeOf: string
+kindIs: true
+kindOf: slice
 `
 
 	var b bytes.Buffer


### PR DESCRIPTION
This adds template functions to check types. Originally from https://github.com/Masterminds/sprig#reflection

**`typeOf`**: Takes an interface and returns a string representation of the type. For pointers, this will return a type prefixed with an asterisk(*). So a pointer to type Foo will be *Foo.

**`typeIs`**: Compares an interface with a string name, and returns true if they match. Note that a pointer will not match a reference. For example *Foo will not match Foo.

**`typeIsLike`**: returns true if the interface is of the given type, or is a pointer to the given type.

**`kindOf`**: Takes an interface and returns a string representation of its kind.

**`kindIs`**: Returns true if the given string matches the kind of the given interface.
