### PR TITLE
add snapcraft.yaml file

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,22 @@
+name: hugo
+version: "v0.17-DEV"
+summary: Fast and Flexible Static Site Generator
+description: |
+  Hugo is a static HTML and CSS website generator written in Go. It is
+  optimized for speed, easy use and configurability. Hugo takes a directory
+  with content and templates and renders them into a full HTML website.
+confinement: strict
+grade: devel # use "stable" to assert the snap quality
+
+apps:
+  hugo:
+    command: bin/hugo
+    plugs: [home]
+
+parts:
+  hugo:
+    source: .
+    plugin: go
+    go-importpath: "github.com/spf13/hugo"
+    build-packages:
+      - git


### PR DESCRIPTION
In the last days I created a snap of `hugo` and this PR contains the `snapcraft.yaml` that's required to build it. I tested it to some degree, but to make sure it's working well enough to be published and distributed to users I need your help.

I'd love to hear if you are generally interested in your software being available as a snap and if you could imagine shipping the `snapcraft.yaml` file in your source repository for easier publishing.

### Background info
If you haven't heard of snaps yet, they are self-contained apps, which can be used on a [multitude of Linux systems](https://snapcraft.io). Via `seccomp`, `apparmor` and other Linux security features, they provide great security for users, uploads to the store are available within seconds and you have
full control over your relevant stack.

Snaps can be installed by millions of users: Ubuntu 16.04 LTS and later have `snapd` installed by default and many other Linux distributions, like Arch, Debian, Gentoo, Fedora, openSUSE, OpenEmbedded, Yocto and OpenWRT made `snapd` (which powers the snap experience) available as well.

### Publishing
Uploading to the store can be done via the command line and there are multiple release channels available, so users can choose between for example stable, beta and alpha releases. You could even hook up `snapcraft upload` with Travis to auto-publish release tags or nightly builds. The process for this is very simple:

 - Once:
  - Register an account at http://myapps.developer.ubuntu.com/
  - Run `snapcraft login`
  - Run `snapcraft register hugo`
 - `snapcraft push hugo_<version>.snap --release=beta`
