### PR TITLE
docs: Fix markdown in content/extras/scratch.md

### DIFF
--- a/docs/content/extras/scratch.md
+++ b/docs/content/extras/scratch.md
@@ -15,6 +15,7 @@ weight: 80
 `Scratch` -- a "scratchpad" for your node- or page-scoped variables. In most cases you can do well without `Scratch`, but there are some use cases that aren't solvable with Go's templates without `Scratch`'s help, due to scoping issues.
 
 `Scratch` is added to both `Node` and `Page` and `Shortcode` -- with following methods:
+
 * `Set` and `Add` takes a `key` and the `value` to add.
 * `Get` returns the `value` for the `key` given.
 * `SetInMap` takes a `key`, `mapKey` and `value`


### PR DESCRIPTION
With hugo's markdown generator a newline is required before a list. Fixing it changes this:

<img width="720" alt="screen shot 2016-09-15 at 11 35 03 am" src="https://cloud.githubusercontent.com/assets/2027263/18558484/e791176a-7b38-11e6-8cee-995a5ebc7aca.png">

To this

<img width="720" alt="screen shot 2016-09-15 at 11 35 14 am" src="https://cloud.githubusercontent.com/assets/2027263/18558488/ef8511ce-7b38-11e6-844c-4a6cdef21fef.png">

