### PR TITLE
Map weight into Author

### DIFF
--- a/hugolib/author.go
+++ b/hugolib/author.go
@@ -141,6 +141,8 @@ func mapToAuthor(id string, m map[string]interface{}) Author {
 			author.Social = normalizeSocial(cast.ToStringMapString(data))
 		case "params":
 			author.Params = cast.ToStringMapString(data)
+		case "weight":
+			author.Weight = cast.ToInt(data)
 		}
 	}
 


### PR DESCRIPTION
While the default sort uses Author.Weight to sort, it wasn't ever read in from the data file.