### PR TITLE
Add .Site.Author map

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -165,6 +165,7 @@ type SiteInfo struct {
 
 	BaseURL               template.URL
 	Taxonomies            TaxonomyList
+	Author                map[string]interface{} // deprecated and will be removed in 0.18
 	Authors               Authors
 	Social                SiteSocial
 	Sections              Taxonomy


### PR DESCRIPTION
Not sure where to log out deprecation notices, since it isn't loaded by itself and access is through a map, not a function.

Fixes #2464