### PR TITLE
commands/server: fix for protocol relative baseurl

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -252,7 +252,7 @@ func fixURL(s string) (string, error) {
 	}
 
 	if useLocalhost {
-		if u.Scheme == "https" {
+		if u.Scheme != "http" {
 			u.Scheme = "http"
 		}
 		u.Host = "localhost"


### PR DESCRIPTION
fixURL() didn't add http scheme to protocol relativ baseurls resulting in
malformed server urls (something like //localhost//example.com/)