### PR TITLE
Allow to set cache dir in config file

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -370,6 +370,11 @@ func InitializeConfig(subCmdVs ...*cobra.Command) error {
 	}
 
 	if cacheDir != "" {
+		viper.Set("CacheDir", cacheDir)
+	}
+
+	cacheDir = viper.GetString("cacheDir")
+	if cacheDir != "" {
 		if helpers.FilePathSeparator != cacheDir[len(cacheDir)-1:] {
 			cacheDir = cacheDir + helpers.FilePathSeparator
 		}

--- a/docs/content/extras/datadrivencontent.md
+++ b/docs/content/extras/datadrivencontent.md
@@ -103,6 +103,8 @@ temporary directory.
 With the command-line flag `--cacheDir`, you can specify any folder on
 your system as a caching directory.
 
+You can also set `cacheDir` in the main configuration file.
+
 If you don't like caching at all, you can fully disable caching with the
 command line flag `--ignoreCache`.
 


### PR DESCRIPTION
Use case:
I'm using `pygments`, so after every reboot, `hugo` re-runs `pygments` for _every_ code snippet in _any_ page of the blog, which takes quite some time.

Granted, I could set `TPMDIR` before running hugo, or use the command line flag, but I find it convenient to just have `cacheDir = cache` in the config file.
(And of course a matching entry in my blog's `.gitignore`)

Going further, maybe this could be the default? 