### PR TITLE
Whitelist startinline pygments option

### DIFF
--- a/helpers/pygments.go
+++ b/helpers/pygments.go
@@ -155,6 +155,7 @@ func init() {
 	pygmentsKeywords["lineanchors"] = true
 	pygmentsKeywords["linespans"] = true
 	pygmentsKeywords["anchorlinenos"] = true
+	pygmentsKeywords["startinline"] = true
 }
 
 func parseOptions(options map[string]string, in string) error {


### PR DESCRIPTION
The startinline option is a very handy option for PHP code highlighting (it makes the <?php line optional).

It seems to be removed in a previous commit 26d23f7f4becb2bbfa80d91ae9b27ffc76e13e3a but for no specific reason.