### PR TITLE
command/new: fixes hugo new for multiple architectures

### DIFF
--- a/commands/new.go
+++ b/commands/new.go
@@ -150,19 +150,31 @@ func doNewSite(basepath string, force bool) error {
 
 	createConfig(basepath, configFormat)
 
-	jww.FEEDBACK.Printf("Congratulations! Your new Hugo site is created in %q.\n\n", basepath)
-	jww.FEEDBACK.Println(`Just a few more steps and you're ready to go:
+	jww.FEEDBACK.Printf("Congratulations! Your new Hugo site is created in %s.\n\n", basepath)
+	jww.FEEDBACK.Println(nextStepsText())
+
+	return nil
+}
+
+func nextStepsText() string {
+	var nextStepsText bytes.Buffer
+
+	nextStepsText.WriteString(`Just a few more steps and you're ready to go:
 
 1. Download a theme into the same-named folder.
    Choose a theme from https://themes.gohugo.io/, or
    create your own with the "hugo new theme <THEMENAME>" command.
 2. Perhaps you want to add some content. You can add single files
-   with "hugo new <SECTIONNAME>/<FILENAME>.<FORMAT>".
+   with "hugo new `)
+
+	nextStepsText.WriteString(filepath.Join("<SECTIONNAME>", "<FILENAME>.<FORMAT>"))
+
+	nextStepsText.WriteString(`".
 3. Start the built-in live server via "hugo server".
 
 Visit https://gohugo.io/ for quickstart guide and full documentation.`)
 
-	return nil
+	return nextStepsText.String()
 }
 
 // NewSite creates a new Hugo site and initializes a structured Hugo directory.


### PR DESCRIPTION
Changes `%q` to `%s`. `%q` was safely escaping the `\` in windows so that it was printing `\\`. Uses `filepath.Join` for example filepath so that the output is OS specific and since this required splitting up the multiline string, it's refactored into a separate function..

Fixes #2401