### PR TITLE
command: fixes rendered empty msg for multiple architectures

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -2372,7 +2372,7 @@ func (s *Site) renderAndWritePage(name string, dest string, d interface{}, layou
 
 	if outBuffer.Len() == 0 {
 
-		jww.WARN.Printf("%q is rendered empty\n", dest)
+		jww.WARN.Printf("%s is rendered empty\n", dest)
 		if dest == "/" {
 			debugAddend := ""
 			if !viper.GetBool("Verbose") {


### PR DESCRIPTION
Changes `%q` to `%s`. `%q` was safely escaping the `\` in windows so that it was printing `\\`.

Fixes [this comment](https://github.com/spf13/hugo/issues/2401#issuecomment-252681480) in #2401.

cc @MarkDBlackwell 
