### PR TITLE
Add logging of asciidoc/-tor errors

### DIFF
--- a/helpers/content.go
+++ b/helpers/content.go
@@ -354,6 +354,7 @@ type RenderingContext struct {
 	Content        []byte
 	PageFmt        string
 	DocumentID     string
+	DocumentName   string
 	Config         *Blackfriday
 	RenderTOC      bool
 	FileResolver   FileResolverFunc
@@ -383,7 +384,7 @@ func RenderBytes(ctx *RenderingContext) []byte {
 	case "markdown":
 		return markdownRender(ctx)
 	case "asciidoc":
-		return getAsciidocContent(ctx.Content)
+		return getAsciidocContent(ctx)
 	case "mmark":
 		return mmarkRender(ctx)
 	case "rst":
@@ -533,7 +534,8 @@ func HasAsciidoc() bool {
 
 // getAsciidocContent calls asciidoctor or asciidoc as an external helper
 // to convert AsciiDoc content to HTML.
-func getAsciidocContent(content []byte) []byte {
+func getAsciidocContent(ctx *RenderingContext) []byte {
+	content := ctx.Content
 	cleanContent := bytes.Replace(content, SummaryDivider, []byte(""), 1)
 
 	path := getAsciidocExecPath()
@@ -555,7 +557,7 @@ func getAsciidocContent(content []byte) []byte {
 	for _, item := range strings.Split(string(cmderr.Bytes()), "\n") {
 		item := strings.TrimSpace(item)
 		if item != "" {
-			jww.ERROR.Println(item)
+			jww.ERROR.Println(strings.Replace(item, "<stdin>", ctx.DocumentName, 1))
 		}
 	}
 	if err != nil {

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -380,7 +380,8 @@ func (p *Page) renderContent(content []byte) []byte {
 	return helpers.RenderBytes(&helpers.RenderingContext{
 		Content: content, RenderTOC: true, PageFmt: p.determineMarkupType(),
 		ConfigProvider: p.Language(),
-		DocumentID:     p.UniqueID(), Config: p.getRenderingConfig(), LinkResolver: fn, FileResolver: fileFn})
+		DocumentID:     p.UniqueID(), DocumentName: p.Path(),
+		Config: p.getRenderingConfig(), LinkResolver: fn, FileResolver: fileFn})
 }
 
 func (p *Page) getRenderingConfig() *helpers.Blackfriday {

--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -243,7 +243,9 @@ func renderShortcode(sc shortcode, parent *ShortcodeWithPage, p *Page, t tpl.Tem
 			newInner := helpers.RenderBytes(&helpers.RenderingContext{
 				Content: []byte(inner), PageFmt: p.determineMarkupType(),
 				ConfigProvider: p.Language(),
-				DocumentID:     p.UniqueID(), Config: p.getRenderingConfig()})
+				DocumentID:     p.UniqueID(),
+				DocumentName:   p.Path(),
+				Config:         p.getRenderingConfig()})
 
 			// If the type is “unknown” or “markdown”, we assume the markdown
 			// generation has been performed. Given the input: `a line`, markdown


### PR DESCRIPTION
Add logging of the errors which asciidoc and asciidoctor output to their
stderr stream when converting asciidoc documents. Note that
asciidoctor's exit code may be SUCCESS even if there are ERROR messages
in its stderr output (tested with Asciidoctor 0.1.4 and 1.5.5).
Therefore log the stderr output whenever it is non-empty.

See #2399