### PR TITLE
Implement support for alias templates

### DIFF
--- a/docs/content/extras/aliases.md
+++ b/docs/content/extras/aliases.md
@@ -94,3 +94,11 @@ Assuming a baseurl of `mysite.tld`, the contents of the html file will look some
 ```
 
 The `http-equiv="refresh"` line is what performs the redirect, in 0 seconds in this case.
+
+## Customizing
+
+You may customize this alias page by creating an alias.html template in the
+layouts folder of your site.  In this case, the data passed to the template is
+
+* Permalink - the link to the page being aliased
+* Page - the Page data for the page being aliased

--- a/docs/content/templates/overview.md
+++ b/docs/content/templates/overview.md
@@ -71,4 +71,6 @@ Used to render the XML sitemap
 ### [404](/templates/404/)
 This template will create a 404.html page used when hosting on GitHub Pages
 
+### [Alias](/extras/aliases/#customizing)
+This template will override the default page used to create aliases of pages.
 

--- a/hugolib/alias_test.go
+++ b/hugolib/alias_test.go
@@ -1,0 +1,60 @@
+// Copyright 2015 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hugolib
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+const pageWithAlias = `---
+title: Has Alias
+aliases: ["foo/bar/"]
+---
+For some moments the old man did not reply. He stood with bowed head, buried in deep thought. But at last he spoke.
+`
+
+const basicTemplate = "<html><body>{{.Content}}</body></html>"
+const aliasTemplate = "<html><body>ALIASTEMPLATE</body></html>"
+
+func TestAlias(t *testing.T) {
+	testCommonResetState()
+	writeSource(t, filepath.Join("content", "page.md"), pageWithAlias)
+	writeSource(t, filepath.Join("layouts", "_default", "single.html"), basicTemplate)
+
+	if err := buildAndRenderSite(newSiteDefaultLang()); err != nil {
+		t.Fatalf("Failed to build site: %s", err)
+	}
+
+	// the real page
+	assertFileContent(t, filepath.Join("public", "page", "index.html"), false, "For some moments the old man")
+	// the alias redirector
+	assertFileContent(t, filepath.Join("public", "foo", "bar", "index.html"), false, "<meta http-equiv=\"refresh\" content=\"0; ")
+}
+
+func TestAliasTemplate(t *testing.T) {
+	testCommonResetState()
+	writeSource(t, filepath.Join("content", "page.md"), pageWithAlias)
+	writeSource(t, filepath.Join("layouts", "_default", "single.html"), basicTemplate)
+	writeSource(t, filepath.Join("layouts", "alias.html"), aliasTemplate)
+
+	if err := buildAndRenderSite(newSiteDefaultLang()); err != nil {
+		t.Fatalf("Failed to build site: %s", err)
+	}
+
+	// the real page
+	assertFileContent(t, filepath.Join("public", "page", "index.html"), false, "For some moments the old man")
+	// the alias redirector
+	assertFileContent(t, filepath.Join("public", "foo", "bar", "index.html"), false, "ALIASTEMPLATE")
+}

--- a/target/htmlredirect.go
+++ b/target/htmlredirect.go
@@ -39,7 +39,7 @@ func init() {
 
 type AliasPublisher interface {
 	Translator
-	Publish(string, string) error
+	Publish(path string, permalink string, page interface{}) error
 }
 
 type HTMLRedirectAlias struct {
@@ -121,9 +121,10 @@ func (h *HTMLRedirectAlias) Translate(alias string) (aliasPath string, err error
 
 type AliasNode struct {
 	Permalink string
+	Page      interface{}
 }
 
-func (h *HTMLRedirectAlias) Publish(path string, permalink string) (err error) {
+func (h *HTMLRedirectAlias) Publish(path string, permalink string, page interface{}) (err error) {
 	if path, err = h.Translate(path); err != nil {
 		jww.ERROR.Printf("%s, skipping.", err)
 		return nil
@@ -137,10 +138,11 @@ func (h *HTMLRedirectAlias) Publish(path string, permalink string) (err error) {
 	template := defaultAliasTemplates
 	if h.Templates != nil {
 		template = h.Templates
+		t = "alias.html"
 	}
 
 	buffer := new(bytes.Buffer)
-	err = template.ExecuteTemplate(buffer, t, &AliasNode{permalink})
+	err = template.ExecuteTemplate(buffer, t, &AliasNode{permalink, page})
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
> 
> This change adds a canonical alias.html template that is used for page
> redirects, and passes the page as data to the template under .Page