### PR TITLE
Fix a more summary corner case

### DIFF
--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -482,7 +482,7 @@ func (s *Site) preparePagesForRender(cfg BuildCfg, changed whatChanged) {
 					summaryContent, err := p.setUserDefinedSummaryIfProvided()
 
 					if err != nil {
-						jww.ERROR.Printf("Failed to set use defined summary: %s", err)
+						jww.ERROR.Printf("Failed to set user defined summary for page %q: %s", p.Path(), err)
 					} else if summaryContent != nil {
 						p.rawContentCopy = summaryContent.content
 					}


### PR DESCRIPTION
Also refactor the rendering pages test to accept more than one page source per test run, which wasn't really needed for this issue, but may be in the future.

Closes #2586
Fixes #2538