### PR TITLE
fix page names that contain dot

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -586,7 +586,7 @@ func (p *Page) permalink() (*url.URL, error) {
 			permalink = helpers.URLPrep(viper.GetBool("uglyURLs"), path.Join(dir, p.Slug+"."+p.Extension()))
 		} else {
 			t := p.Source.TranslationBaseName()
-			permalink = helpers.URLPrep(viper.GetBool("uglyURLs"), path.Join(dir, helpers.ReplaceExtension(strings.TrimSpace(t), p.Extension())))
+			permalink = helpers.URLPrep(viper.GetBool("uglyURLs"), path.Join(dir, (strings.TrimSpace(t)+"."+p.Extension())))
 		}
 	}
 
@@ -1163,7 +1163,7 @@ func (p *Page) TargetPath() (outfile string) {
 		outfile = strings.TrimSpace(p.Slug) + "." + p.Extension()
 	} else {
 		// Fall back to filename
-		outfile = helpers.ReplaceExtension(p.Source.TranslationBaseName(), p.Extension())
+		outfile = (p.Source.TranslationBaseName() + "." + p.Extension())
 	}
 
 	return p.addLangFilepathPrefix(filepath.Join(strings.ToLower(

--- a/source/file.go
+++ b/source/file.go
@@ -126,11 +126,14 @@ func NewFile(relpath string) *File {
 	f.ext = strings.TrimPrefix(filepath.Ext(f.LogicalName()), ".")
 	f.baseName = helpers.Filename(f.LogicalName())
 
-	f.lang = strings.TrimPrefix(filepath.Ext(f.baseName), ".")
-	if f.lang == "" {
+	lang := strings.TrimPrefix(filepath.Ext(f.baseName), ".")
+	if _, ok := viper.GetStringMap("languages")[lang]; lang == "" || !ok {
 		f.lang = viper.GetString("defaultContentLanguage")
+		f.translationBaseName = f.baseName
+	} else {
+		f.lang = lang
+		f.translationBaseName = helpers.Filename(f.baseName)
 	}
-	f.translationBaseName = helpers.Filename(f.baseName)
 
 	f.section = helpers.GuessSection(f.Dir())
 	f.uniqueID = helpers.Md5String(f.LogicalName())


### PR DESCRIPTION
changes:

- in hugolib/page.go, `func permalink` and `func TargetPath`
      Fixed the attempt to *replace* the extension of something
      that was *already* a basename (without extension) .
- in source/file.go, `func NewFile`
      added check for allowed languages before translating filename

Fixes #2555