### PR TITLE
tpl: Adds imageConfig function which calls image.DecodeConfig and returns the height, width and color mode of the image.

### DIFF
--- a/docs/content/templates/functions.md
+++ b/docs/content/templates/functions.md
@@ -356,7 +356,7 @@ e.g.
        {{ .Content }}
     {{ end }}
 
-## Files    
+## Files
 
 ### readDir
 
@@ -371,6 +371,16 @@ Reads a file from disk and converts it into a string. Note that the filename mus
  So, if you have a file with the name `README.txt` in the root of your project with the content `Hugo Rocks!`:
 
  `{{readFile "README.txt"}}` → `"Hugo Rocks!"`
+
+### imageConfig
+Parses the image and returns the height, width and color model.
+
+e.g.
+```
+{{ with (imageConfig "favicon.ico") }}
+favicon.ico: {{.Width}} x {{.Height}}
+{{ end }}
+```
 
 ## Math
 

--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -120,12 +120,14 @@ func (h *HugoSites) getNodes(nodeID string) Nodes {
 	return Nodes{}
 }
 
-// Reset resets the sites, making it ready for a full rebuild.
+// Reset resets the sites and template caches, making it ready for a full rebuild.
 func (h *HugoSites) reset() {
 	h.nodeMap = make(map[string]Nodes)
 	for i, s := range h.Sites {
 		h.Sites[i] = s.reset()
 	}
+
+	tpl.ResetCaches()
 }
 
 func (h *HugoSites) reCreateFromConfig() error {

--- a/tpl/template_funcs_test.go
+++ b/tpl/template_funcs_test.go
@@ -19,6 +19,9 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"image"
+	"image/color"
+	"image/png"
 	"math/rand"
 	"path"
 	"path/filepath"
@@ -593,6 +596,109 @@ func TestDictionary(t *testing.T) {
 				t.Errorf("[%d] got %v but expected %v", i, r, this.expectedValue)
 			}
 		}
+	}
+}
+
+func blankImage(width, height int) []byte {
+	var buf bytes.Buffer
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	if err := png.Encode(&buf, img); err != nil {
+		panic(err)
+	}
+	return buf.Bytes()
+}
+
+func TestImageConfig(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+
+	workingDir := "/home/hugo"
+
+	viper.Set("workingDir", workingDir)
+
+	fs := &afero.MemMapFs{}
+	hugofs.InitFs(fs)
+
+	for i, this := range []struct {
+		resetCache bool
+		path       string
+		input      []byte
+		expected   image.Config
+	}{
+		{
+			resetCache: true,
+			path:       "a.png",
+			input:      blankImage(10, 10),
+			expected: image.Config{
+				Width:      10,
+				Height:     10,
+				ColorModel: color.NRGBAModel,
+			},
+		},
+		{
+			resetCache: false,
+			path:       "b.png",
+			input:      blankImage(20, 15),
+			expected: image.Config{
+				Width:      20,
+				Height:     15,
+				ColorModel: color.NRGBAModel,
+			},
+		},
+		{
+			resetCache: false,
+			path:       "a.png",
+			input:      blankImage(20, 15),
+			expected: image.Config{
+				Width:      10,
+				Height:     10,
+				ColorModel: color.NRGBAModel,
+			},
+		},
+		{
+			resetCache: true,
+			path:       "a.png",
+			input:      blankImage(20, 15),
+			expected: image.Config{
+				Width:      20,
+				Height:     15,
+				ColorModel: color.NRGBAModel,
+			},
+		},
+	} {
+		afero.WriteFile(fs, filepath.Join(workingDir, this.path), this.input, 0755)
+
+		if this.resetCache {
+			resetImageConfigCache()
+		}
+
+		result, err := imageConfig(this.path)
+		if err != nil {
+			t.Errorf("imageConfig returned error: %s", err)
+		}
+
+		if !reflect.DeepEqual(result, this.expected) {
+			t.Errorf("[%d] imageConfig: expected '%v', got '%v'", i, this.expected, result)
+		}
+
+		if len(imageConfigCache.config) == 0 {
+			t.Error("imageConfigCache should have at least 1 item")
+		}
+	}
+
+	if _, err := imageConfig(t); err == nil {
+		t.Error("Expected error from imageConfig when passed invalid path")
+	}
+
+	if _, err := imageConfig("non-existant.png"); err == nil {
+		t.Error("Expected error from imageConfig when passed non-existant file")
+	}
+
+	// test cache clearing
+	ResetCaches()
+
+	if len(imageConfigCache.config) != 0 {
+		t.Error("ResetCaches should have cleared imageConfigCache")
 	}
 }
 


### PR DESCRIPTION
This allows for more advanced image shortcodes and templates such as those required by AMP.

layouts/shortcodes/amp-img.html
```html
{{ $src := .Get "src" }}
{{ $img := readFile (printf "/static/%s" $src) }}
{{ $config := imageConfig $img }}

<amp-img src="{{$src}}"
           height="{{$config.Height}}"
           width="{{$config.Width}}"
           layout="responsive">
</amp-img>
```

```html
{{< amp-img src="/foo.png" >}}
```