### PR TITLE
Bugfix: The baseof.ace and baseof.html are not avalible when they are not contained by the theme

### DIFF
--- a/helpers/path.go
+++ b/helpers/path.go
@@ -163,6 +163,12 @@ func GetStaticDirPath() string {
 	return AbsPathify(viper.GetString("staticDir"))
 }
 
+// GetLayoutDirPath returns the absolute path to the layout file dir
+// for the current Hugo project.
+func GetLayoutDirPath() string {
+	return AbsPathify(viper.GetString("layoutDir"))
+}
+
 // GetThemeDir gets the root directory of the current theme, if there is one.
 // If there is no theme, returns the empty string.
 func GetThemeDir() string {

--- a/tpl/template.go
+++ b/tpl/template.go
@@ -451,8 +451,8 @@ func (t *GoHTMLTemplate) loadTemplates(absPath string, prefix string) {
 					pathsToCheck := []string{
 						filepath.Join(templateDir, currBaseFilename),
 						filepath.Join(templateDir, baseFileName),
-						filepath.Join(absPath, "_default", currBaseFilename),
-						filepath.Join(absPath, "_default", baseFileName),
+						filepath.Join(helpers.GetLayoutDirPath(), "_default", currBaseFilename),
+						filepath.Join(helpers.GetLayoutDirPath(), "_default", baseFileName),
 						filepath.Join(themeDir, "layouts", "_default", currBaseFilename),
 						filepath.Join(themeDir, "layouts", "_default", baseFileName),
 					}


### PR DESCRIPTION
```
In Hugo the base template will be chosen in the following order:

1. <current-path>/<template-name>-baseof.ace, e.g. list-baseof.ace
2. <current-path>/baseof.ace
3. _default/<template-name>-baseof.ace, e.g. list-baseof.ace.
4. _default/baseof.ace
5. <themedir>/layouts/_default/<template-name>-baseof.ace
6. <themedir>/layouts/_default/baseof.ace
```

The 3 and 4 is not avaible even when the theme remove theirs.

