### PR TITLE
source, tpl: fix staticcheck complaints

### DIFF
--- a/source/lazy_file_reader.go
+++ b/source/lazy_file_reader.go
@@ -62,8 +62,7 @@ func (l *LazyFileReader) Read(p []byte) (n int, err error) {
 		}
 		l.contents = bytes.NewReader(b)
 	}
-	l.contents.Seek(l.pos, 0)
-	if err != nil {
+	if _, err = l.contents.Seek(l.pos, 0); err != nil {
 		return 0, errors.New("failed to set read position: " + err.Error())
 	}
 	n, err = l.contents.Read(p)

--- a/tpl/template_funcs.go
+++ b/tpl/template_funcs.go
@@ -1010,13 +1010,13 @@ func delimit(seq, delimiter interface{}, last ...interface{}) (template.HTML, er
 	}
 
 	var dLast *string
-	for _, l := range last {
+	if len(last) > 0 {
+		l := last[0]
 		dStr, err := cast.ToStringE(l)
 		if err != nil {
 			dLast = nil
 		}
 		dLast = &dStr
-		break
 	}
 
 	seqv := reflect.ValueOf(seq)


### PR DESCRIPTION
tpl/template_funcs.go:1019:3: the surrounding loop is unconditionally terminated
source/lazy_file_reader.go:66:5: err != nil is always true for all possible
values ([nil:error] != [nil:error])