### PR TITLE
Quickstart: add a note about disabling caching when changing images

### DIFF
--- a/docs/content/overview/quickstart.md
+++ b/docs/content/overview/quickstart.md
@@ -371,6 +371,8 @@ We will use the default image shown below.
 
 Hugo will sync the changes and reload the website to use new image as shown below.
 
+Note: if you don't see your changes applied immediately, restart your server with the `--ignoreCache` flag to disable caching.
+
 ![](/img/quickstart/bookshelf-new-default-image.png)
 
 Now, we need to change the layout of the index page so that only images are shown instead of the text. The index.html inside the layouts directory of the theme refer to partial `li` that renders the list view shown below.

--- a/docs/content/overview/quickstart.md
+++ b/docs/content/overview/quickstart.md
@@ -371,7 +371,7 @@ We will use the default image shown below.
 
 Hugo will sync the changes and reload the website to use new image as shown below.
 
-Note: if you don't see your changes applied immediately, restart your server with the `--ignoreCache` flag to disable caching.
+> _Note: if you don't see your changes applied immediately, restart your server with the `--ignoreCache` flag to disable caching._
 
 ![](/img/quickstart/bookshelf-new-default-image.png)
 


### PR DESCRIPTION
When applying changes to images, sometimes they're not immediately applied due to Hugo's caching being turned on by default. This commit adds a note about how to disable caching to be able to view changes immediately.