### PR TITLE
Fix alignment of go gets in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN go get github.com/stretchr/testify/assert \
 	&& go get golang.org/x/text/unicode/norm \
 	&& go get github.com/yosssi/ace \
 	&& go get github.com/spf13/nitro \
-    && go get github.com/fortytw2/leaktest \
+	&& go get github.com/fortytw2/leaktest \
 	&& go get github.com/fsnotify/fsnotify
 
 COPY . /go/src/github.com/spf13/hugo


### PR DESCRIPTION
Just noticed while browsing this was using spaces while everything else in here was using tabs :-)