### PR TITLE
hugolib: Avoid repeated Viper loads of sectionPagesMenu

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -1092,7 +1092,7 @@ func (p *Page) getParam(key string, stringToLower bool) interface{} {
 
 func (p *Page) HasMenuCurrent(menuID string, me *MenuEntry) bool {
 
-	sectionPagesMenu := helpers.Config().GetString("SectionPagesMenu")
+	sectionPagesMenu := p.Site.sectionPagesMenu
 
 	// page is labeled as "shadow-member" of the menu with the same identifier as the section
 	if sectionPagesMenu != "" && p.Section() != "" && sectionPagesMenu == menuID && p.Section() == me.Identifier {

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -191,6 +191,7 @@ type SiteInfo struct {
 	LanguagePrefix                 string
 	Languages                      helpers.Languages
 	defaultContentLanguageInSubdir bool
+	sectionPagesMenu               string
 
 	pathSpec *helpers.PathSpec
 }
@@ -937,6 +938,7 @@ func (s *Site) initializeSiteInfo() {
 		LanguagePrefix:                 languagePrefix,
 		Languages:                      languages,
 		defaultContentLanguageInSubdir: defaultContentInSubDir,
+		sectionPagesMenu:               lang.GetString("sectionPagesMenu"),
 		GoogleAnalytics:                lang.GetString("googleAnalytics"),
 		BuildDrafts:                    viper.GetBool("buildDrafts"),
 		canonifyURLs:                   viper.GetBool("canonifyURLs"),
@@ -1412,7 +1414,7 @@ func (s *Site) assembleMenus() {
 		}
 	}
 
-	sectionPagesMenu := s.Language.GetString("sectionPagesMenu")
+	sectionPagesMenu := s.Info.sectionPagesMenu
 	sectionPagesMenus := make(map[string]interface{})
 	//creating flat hash
 	pages := s.Pages


### PR DESCRIPTION
This is a significant performance win for menu heavy sites.

My benchmark tool doesn't show any difference in this area, I will try to add some more sites,  but it seems to shave off about 100 ms+ of the docs build.

See #2728