### PR TITLE
Improve jekyll import date format

### DIFF
--- a/commands/import_jekyll.go
+++ b/commands/import_jekyll.go
@@ -371,7 +371,7 @@ func parseJekyllFilename(filename string) (time.Time, string, error) {
 		return time.Now(), "", errors.New("filename not match")
 	}
 
-	postDate, err := time.Parse("2006-01-02", r[0][1])
+	postDate, err := time.Parse("2006-1-2", r[0][1])
 	if err != nil {
 		return time.Now(), "", err
 	}


### PR DESCRIPTION
Issue: #2738

Allow both yyyy-mm-dd and yyyy-m-d formats in jekyll markdown
file names.