### PR TITLE
Add new helper MakeTitleInitCaps

### DIFF
--- a/create/content.go
+++ b/create/content.go
@@ -107,12 +107,19 @@ func createMetadata(archetype parser.Page, name string) (map[string]interface{},
 		return nil, err
 	}
 
+	// Issue #2743 allow user to override default format
+	coerceTitleFormat := viper.GetString("coerceTitleFormat")
+
 	for k := range metadata {
 		switch strings.ToLower(k) {
 		case "date":
 			metadata[k] = time.Now()
 		case "title":
-			metadata[k] = helpers.MakeTitle(helpers.Filename(name))
+			if coerceTitleFormat == "initCaps" {
+				metadata[k] = helpers.MakeTitleInitCaps(helpers.Filename(name))
+			} else {
+				metadata[k] = helpers.MakeTitle(helpers.Filename(name))
+			}
 		}
 	}
 
@@ -134,7 +141,11 @@ func createMetadata(archetype parser.Page, name string) (map[string]interface{},
 	}
 
 	if !caseimatch(metadata, "title") {
-		metadata["title"] = helpers.MakeTitle(helpers.Filename(name))
+		if coerceTitleFormat == "initCaps" {
+			metadata["title"] = helpers.MakeTitleInitCaps(helpers.Filename(name))
+		} else {
+			metadata["title"] = helpers.MakeTitle(helpers.Filename(name))
+		}
 	}
 
 	if x := parser.FormatSanitize(viper.GetString("metaDataFormat")); x == "json" || x == "yaml" || x == "toml" {

--- a/create/content_test.go
+++ b/create/content_test.go
@@ -82,8 +82,8 @@ func TestNewContentInitCaps(t *testing.T) {
 		resultStrings []string
 	}{
 		{"post", "post/sample-one-1.md", []string{`title = "Sample One 1"`, `test = "test1"`}},
-		{"stump", "stump/sample-two-2.md", []string{`title = "Sample Two 2"`}},     // no archetype file
-		{"", "sample-three-3.md", []string{`title = "Sample Three 3"`}},                // no archetype
+		{"stump", "stump/sample-two-2.md", []string{`title = "Sample Two 2"`}},       // no archetype file
+		{"", "sample-three-3.md", []string{`title = "Sample Three 3"`}},              // no archetype
 		{"product", "product/sample-four-4.md", []string{`title = "Sample Four 4"`}}, // empty archetype front matter
 	}
 

--- a/helpers/path.go
+++ b/helpers/path.go
@@ -93,6 +93,18 @@ func MakeTitle(inpath string) string {
 	return strings.Replace(strings.TrimSpace(inpath), "-", " ", -1)
 }
 
+// Issue #2743
+// MakeTitleInitCaps converts the path given to a suitable title, trimming whitespace
+// and replacing hyphens with whitespace, then forcing the first letter of each word
+// to uppercase.
+func MakeTitleInitCaps(inpath string) string {
+	s := strings.Split(strings.TrimSpace(inpath), "-")
+	for i, wordToCap := range s {
+		s[i] = FirstUpper(wordToCap)
+	}
+	return strings.Join(s, " ")
+}
+
 // From https://golang.org/src/net/url/url.go
 func ishex(c rune) bool {
 	switch {

--- a/helpers/path_test.go
+++ b/helpers/path_test.go
@@ -263,6 +263,25 @@ func TestMakeTitle(t *testing.T) {
 	}
 }
 
+// Issue #2743 - titles with initial caps
+func TestMakeTitleInitCaps(t *testing.T) {
+	type test struct {
+		input, expected string
+	}
+	data := []test{
+		{"Make-Title", "Make Title"},
+		{"make-title", "Make Title"},
+		{"MakeTitle", "MakeTitle"},
+		{"make_title", "Make_title"},
+	}
+	for i, d := range data {
+		output := MakeTitleInitCaps(d.input)
+		if d.expected != output {
+			t.Errorf("Test %d failed. Expected %q got %q", i, d.expected, output)
+		}
+	}
+}
+
 // Replace Extension is probably poorly named, but the intent of the
 // function is to accept a path and return only the file name with a
 // new extension. It's intentionally designed to strip out the path


### PR DESCRIPTION
Updates the `hugo new` command to allow creating the title using
an initial capital letter format. Adds a new helper function,
MakeTitleInitCaps, and a new config file option, coerceTitleFormat.
If set to "initCaps", then createMetaData calls the new helper
instead of MakeTitle.

Implements #2743 