### PR TITLE
Add new helper MakeTitleInitCaps

### DIFF
--- a/create/content_test.go
+++ b/create/content_test.go
@@ -82,6 +82,7 @@ func TestNewContentInitCaps(t *testing.T) {
 		path     string
 		expected []string
 	}{
+		// the first will have no changes since the archetype file overrides
 		{"post", "post/sample-one-1.md", []string{`title = "Post Arch title"`, `test = "test1"`, "date = \"2015-01-12T19:20:04-07:00\""}},
 		{"stump", "stump/sample-tWO-2.md", []string{`title = "Sample TWO 2"`}},       // no archetype file
 		{"", "sample-three-3.md", []string{`title = "Sample Three 3"`}},              // no archetype

--- a/create/content_test.go
+++ b/create/content_test.go
@@ -16,10 +16,14 @@ package create_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"fmt"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/hugo/create"
+	"github.com/spf13/hugo/helpers"
 	"github.com/spf13/hugo/hugofs"
 	"github.com/spf13/viper"
 )
@@ -33,14 +37,55 @@ func TestNewContent(t *testing.T) {
 	}
 
 	cases := []struct {
-		kind          string
-		path          string
-		resultStrings []string
+		kind     string
+		path     string
+		expected []string
 	}{
-		{"post", "post/sample-1.md", []string{`title = "sample 1"`, `test = "test1"`}},
+		{"post", "post/sample-1.md", []string{`title = "Post Arch title"`, `test = "test1"`, "date = \"2015-01-12T19:20:04-07:00\""}},
 		{"stump", "stump/sample-2.md", []string{`title = "sample 2"`}},     // no archetype file
 		{"", "sample-3.md", []string{`title = "sample 3"`}},                // no archetype
 		{"product", "product/sample-4.md", []string{`title = "sample 4"`}}, // empty archetype front matter
+	}
+
+	for i, c := range cases {
+		if i > 0 {
+			break
+		}
+		err = create.NewContent(hugofs.Source(), c.kind, c.path)
+		if err != nil {
+			t.Errorf("[%d] NewContent: %s", i, err)
+		}
+
+		fname := filepath.Join("content", filepath.FromSlash(c.path))
+		content := readFileFromFs(t, hugofs.Source(), fname)
+
+		for i, v := range c.expected {
+			found := strings.Contains(content, v)
+			if !found {
+				t.Errorf("[%d] %q missing from output:\n%q", i, v, content)
+			}
+		}
+	}
+}
+
+func TestNewContentInitCaps(t *testing.T) {
+	initViper()
+	viper.Set("coerceTitleFormat", "initCaps")
+
+	err := initFs()
+	if err != nil {
+		t.Fatalf("initialization error: %s", err)
+	}
+
+	cases := []struct {
+		kind     string
+		path     string
+		expected []string
+	}{
+		{"post", "post/sample-one-1.md", []string{`title = "Post Arch title"`, `test = "test1"`, "date = \"2015-01-12T19:20:04-07:00\""}},
+		{"stump", "stump/sample-tWO-2.md", []string{`title = "Sample TWO 2"`}},       // no archetype file
+		{"", "sample-three-3.md", []string{`title = "Sample Three 3"`}},              // no archetype
+		{"product", "product/sample-four-4.md", []string{`title = "Sample Four 4"`}}, // empty archetype front matter
 	}
 
 	for i, c := range cases {
@@ -49,19 +94,13 @@ func TestNewContent(t *testing.T) {
 			t.Errorf("[%d] NewContent: %s", i, err)
 		}
 
-		fname := filepath.Join(os.TempDir(), "content", filepath.FromSlash(c.path))
-		_, err = hugofs.Source().Stat(fname)
-		if err != nil {
-			t.Errorf("[%d] Stat: %s", i, err)
-		}
+		fname := filepath.Join("content", filepath.FromSlash(c.path))
+		content := readFileFromFs(t, hugofs.Source(), fname)
 
-		for _, v := range c.resultStrings {
-			found, err := afero.FileContainsBytes(hugofs.Source(), fname, []byte(v))
-			if err != nil {
-				t.Errorf("[%d] FileContainsBytes: %s", i, err)
-			}
+		for i, v := range c.expected {
+			found := strings.Contains(content, v)
 			if !found {
-				t.Errorf("content missing from output: %q", v)
+				t.Errorf("[%d] %q missing from output:\n%q", i, v, content)
 			}
 		}
 	}
@@ -70,14 +109,14 @@ func TestNewContent(t *testing.T) {
 func initViper() {
 	viper.Reset()
 	viper.Set("metaDataFormat", "toml")
-	viper.Set("archetypeDir", filepath.Join(os.TempDir(), "archetypes"))
-	viper.Set("contentDir", filepath.Join(os.TempDir(), "content"))
-	viper.Set("themesDir", filepath.Join(os.TempDir(), "themes"))
+	viper.Set("archetypeDir", "archetypes")
+	viper.Set("contentDir", "content")
+	viper.Set("themesDir", "themes")
 	viper.Set("theme", "sample")
 }
 
 func initFs() error {
-	hugofs.SetSource(new(afero.MemMapFs))
+	hugofs.InitMemFs()
 	perm := os.FileMode(0755)
 	var err error
 
@@ -88,7 +127,6 @@ func initFs() error {
 		filepath.Join("themes", "sample", "archetypes"),
 	}
 	for _, dir := range dirs {
-		dir = filepath.Join(os.TempDir(), dir)
 		err = hugofs.Source().Mkdir(dir, perm)
 		if err != nil {
 			return err
@@ -101,11 +139,11 @@ func initFs() error {
 		content string
 	}{
 		{
-			path:    filepath.Join(os.TempDir(), "archetypes", "post.md"),
-			content: "+++\ndate = \"2015-01-12T19:20:04-07:00\"\ntitle = \"post arch\"\ntest = \"test1\"\n+++\n",
+			path:    filepath.Join("archetypes", "post.md"),
+			content: "+++\ndate = \"2015-01-12T19:20:04-07:00\"\ntitle = \"Post Arch title\"\ntest = \"test1\"\n+++\n",
 		},
 		{
-			path:    filepath.Join(os.TempDir(), "archetypes", "product.md"),
+			path:    filepath.Join("archetypes", "product.md"),
 			content: "+++\n+++\n",
 		},
 	} {
@@ -122,4 +160,23 @@ func initFs() error {
 	}
 
 	return nil
+}
+
+// TODO(bep) extract common testing package with this and some others
+func readFileFromFs(t *testing.T, fs afero.Fs, filename string) string {
+	filename = filepath.FromSlash(filename)
+	b, err := afero.ReadFile(fs, filename)
+	if err != nil {
+		// Print some debug info
+		root := strings.Split(filename, helpers.FilePathSeparator)[0]
+		afero.Walk(fs, root, func(path string, info os.FileInfo, err error) error {
+			if info != nil && !info.IsDir() {
+				fmt.Println("    ", path)
+			}
+
+			return nil
+		})
+		t.Fatalf("Failed to read file: %s", err)
+	}
+	return string(b)
 }

--- a/helpers/path.go
+++ b/helpers/path.go
@@ -93,6 +93,17 @@ func MakeTitle(inpath string) string {
 	return strings.Replace(strings.TrimSpace(inpath), "-", " ", -1)
 }
 
+// MakeTitleInitCaps converts the path given to a suitable title, trimming whitespace
+// and replacing hyphens with whitespace, then forcing the first letter of each word
+// to uppercase. Issue #2743
+func MakeTitleInitCaps(inpath string) string {
+	s := strings.Split(strings.TrimSpace(inpath), "-")
+	for i, wordToCap := range s {
+		s[i] = FirstUpper(wordToCap)
+	}
+	return strings.Join(s, " ")
+}
+
 // From https://golang.org/src/net/url/url.go
 func ishex(c rune) bool {
 	switch {

--- a/helpers/path_test.go
+++ b/helpers/path_test.go
@@ -263,6 +263,25 @@ func TestMakeTitle(t *testing.T) {
 	}
 }
 
+// Issue #2743 - titles with initial caps
+func TestMakeTitleInitCaps(t *testing.T) {
+	type test struct {
+		input, expected string
+	}
+	data := []test{
+		{"Make-Title", "Make Title"},
+		{"make-title", "Make Title"},
+		{"MakeTitle", "MakeTitle"},
+		{"make_title", "Make_title"},
+	}
+	for i, d := range data {
+		output := MakeTitleInitCaps(d.input)
+		if d.expected != output {
+			t.Errorf("Test %d failed. Expected %q got %q", i, d.expected, output)
+		}
+	}
+}
+
 // Replace Extension is probably poorly named, but the intent of the
 // function is to accept a path and return only the file name with a
 // new extension. It's intentionally designed to strip out the path

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1768,7 +1768,7 @@ func (s *Site) renderAndWritePage(name string, dest string, d interface{}, layou
 
 	if outBuffer.Len() == 0 {
 
-		jww.WARN.Printf("%q is rendered empty\n", dest)
+		jww.WARN.Printf("%s is rendered empty\n", dest)
 		if dest == "/" {
 			debugAddend := ""
 			if !viper.GetBool("verbose") {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -196,10 +196,10 @@
 			"revisionTime": "2016-01-24T19:35:03Z"
 		},
 		{
-			"checksumSHA1": "t0BfeG6hvtsHUUY7UFzxyMUle6U=",
+			"checksumSHA1": "jIC6IQtpM2X84AUYISO/V7C9hQs=",
 			"path": "github.com/pelletier/go-toml",
-			"revision": "3ddb37c9445773dd46f5c17f1d7769114899b4f9",
-			"revisionTime": "2016-11-23T14:48:39Z"
+			"revision": "7cb988051d5045890cb91402a0b5fddc76c627bc",
+			"revisionTime": "2016-11-23T15:24:52Z"
 		},
 		{
 			"checksumSHA1": "zKKp5SZ3d3ycKe4EKMNT0BqAWBw=",


### PR DESCRIPTION
Updates the hugo new command to allow creating the title using
an initial capital letter format. Adds a new helper function,
MakeTitleInitCaps, and a new config file option, coerceTitleFormat.
If set to "initCaps", then createMetaData calls the new helper
instead of MakeTitle.

Implements #2743