### PR TITLE
Add new helper MakeTitleInitCaps

### DIFF
--- a/create/content.go
+++ b/create/content.go
@@ -132,7 +132,13 @@ func createMetadata(archetype parser.Page, name string) (map[string]interface{},
 	}
 
 	if _, ok := metadata["title"]; !ok {
-		metadata["title"] = helpers.MakeTitle(helpers.Filename(name))
+		// Issue #2743 allow user to override default format
+		coerceTitleFormat := viper.GetString("coerceTitleFormat")
+		if coerceTitleFormat == "initCaps" {
+			metadata["title"] = helpers.MakeTitleInitCaps(helpers.Filename(name))
+		} else {
+			metadata["title"] = helpers.MakeTitle(helpers.Filename(name))
+		}
 	}
 
 	// TOD(bep) what is this?

--- a/create/content_test.go
+++ b/create/content_test.go
@@ -65,6 +65,44 @@ func TestNewContent(t *testing.T) {
 	}
 }
 
+func TestNewContentInitCaps(t *testing.T) {
+	initViper()
+	viper.Set("coerceTitleFormat", "initCaps")
+
+	err := initFs()
+	if err != nil {
+		t.Fatalf("initialization error: %s", err)
+	}
+
+	cases := []struct {
+		kind     string
+		path     string
+		expected []string
+	}{
+		{"post", "post/sample-one-1.md", []string{`title = "Post Arch title"`, `test = "test1"`, "date = \"2015-01-12T19:20:04-07:00\""}},
+		{"stump", "stump/sample-tWO-2.md", []string{`title = "Sample TWO 2"`}},       // no archetype file
+		{"", "sample-three-3.md", []string{`title = "Sample Three 3"`}},              // no archetype
+		{"product", "product/sample-four-4.md", []string{`title = "Sample Four 4"`}}, // empty archetype front matter
+	}
+
+	for i, c := range cases {
+		err = create.NewContent(hugofs.Source(), c.kind, c.path)
+		if err != nil {
+			t.Errorf("[%d] NewContent: %s", i, err)
+		}
+
+		fname := filepath.Join("content", filepath.FromSlash(c.path))
+		content := readFileFromFs(t, hugofs.Source(), fname)
+
+		for i, v := range c.expected {
+			found := strings.Contains(content, v)
+			if !found {
+				t.Errorf("[%d] %q missing from output:\n%q", i, v, content)
+			}
+		}
+	}
+}
+
 func initViper() {
 	viper.Reset()
 	viper.Set("metaDataFormat", "toml")

--- a/helpers/path.go
+++ b/helpers/path.go
@@ -93,6 +93,13 @@ func MakeTitle(inpath string) string {
 	return strings.Replace(strings.TrimSpace(inpath), "-", " ", -1)
 }
 
+// MakeTitleInitCaps converts the path given to a suitable title, trimming whitespace
+// and replacing hyphens with whitespace, then forcing the first letter of each word
+// to uppercase. Issue #2743
+func MakeTitleInitCaps(inpath string) string {
+	return strings.Title(strings.Join(strings.Split(strings.TrimSpace(inpath), "-"), " "))
+}
+
 // From https://golang.org/src/net/url/url.go
 func ishex(c rune) bool {
 	switch {

--- a/helpers/path_test.go
+++ b/helpers/path_test.go
@@ -263,6 +263,23 @@ func TestMakeTitle(t *testing.T) {
 	}
 }
 
+func TestMakeTitleInitCaps(t *testing.T) {
+	type test struct {
+		input, expected string
+	}
+	data := []test{
+		{"Make-Title", "Make Title"},
+		{"MakeTitle", "MakeTitle"},
+		{"make_title", "Make_title"},
+	}
+	for i, d := range data {
+		output := MakeTitleInitCaps(d.input)
+		if d.expected != output {
+			t.Errorf("Test %d failed. Expected %q got %q", i, d.expected, output)
+		}
+	}
+}
+
 // Replace Extension is probably poorly named, but the intent of the
 // function is to accept a path and return only the file name with a
 // new extension. It's intentionally designed to strip out the path


### PR DESCRIPTION
Updates the hugo new command to allow creating the title using an
initial capital letter format. Adds a new helper function,
MakeTitleInitCaps, and a new config file option, coerceTitleFormat.
If set to "initCaps", then createMetaData calls the new helper
instead of MakeTitle.

Implements #2743 