### PR TITLE
Docs: clarify using archetypes from a theme

### DIFF
--- a/docs/content/content/archetypes.md
+++ b/docs/content/content/archetypes.md
@@ -146,3 +146,5 @@ file name) and the `date` in RFC&nbsp;3339 format based on
 The content type is automatically detected based on the file path passed to the 
 Hugo CLI command <code>hugo new <em>[my-content-type/post-name]</em></code>. To 
 override the content type for a new post, include the `--kind` flag during creation.
+
+> *Note: if you wish to use archetypes that ship with a theme, the theme MUST be specified in your `config.toml`.*


### PR DESCRIPTION
Adding a clarification to archetype docs.

I spent a few hours bashing my head against this, because I was running `hugo server --theme=THEME`, but the `THEME` was not in my `config.toml`. So none of the theme archetypes would work. Eventually I found https://discuss.gohugo.io/t/help-with-archetypes/1118/5, and :bulb:.

Hopefully this helps someone.