### PR TITLE
docs: Add Extras > GitInfo

### DIFF
--- a/docs/content/extras/aliases.md
+++ b/docs/content/extras/aliases.md
@@ -9,9 +9,8 @@ menu:
   main:
     parent: extras
 next: /extras/analytics
-prev: /taxonomies/ordering
+prev: /taxonomies/methods
 title: Aliases
-weight: 10
 ---
 
 For people migrating existing published content to Hugo, there's a good chance you need a mechanism to handle redirecting old URLs.

--- a/docs/content/extras/analytics.md
+++ b/docs/content/extras/analytics.md
@@ -7,7 +7,6 @@ menu:
 next: /extras/builders
 prev: /extras/aliases
 title: Analytics in Hugo
-weight: 15
 ---
 
 Hugo ships with prebuilt internal templates for Google Analytics tracking, including both synchronous and asynchronous tracking codes.

--- a/docs/content/extras/builders.md
+++ b/docs/content/extras/builders.md
@@ -8,7 +8,6 @@ menu:
 next: /extras/comments
 prev: /extras/analytics
 title: Hugo Builders
-weight: 20
 ---
 
 Hugo provides the functionality to quickly get a site, theme or page

--- a/docs/content/extras/comments.md
+++ b/docs/content/extras/comments.md
@@ -8,7 +8,6 @@ menu:
 next: /extras/crossreferences
 prev: /extras/builders
 title: Comments in Hugo
-weight: 30
 ---
 
 As Hugo is a static site generator, the content produced is static and doesn’t interact with the users. The most common interaction people ask for is comment capability.

--- a/docs/content/extras/crossreferences.md
+++ b/docs/content/extras/crossreferences.md
@@ -4,11 +4,10 @@ date: 2014-11-25
 menu:
   main:
     parent: extras
-next: /extras/livereload
+next: /extras/robots-txt
 prev: /extras/comments
 title: Cross-References
 toc: true
-weight: 40
 ---
 
 Hugo makes it easy to link documents together with the `ref` and `relref` shortcodes. These shortcodes are also used to safely provide links to headings inside of your content, whether across documents or within a document. The only difference between `ref` and `relref` is whether the resulting URL is absolute (`http://1.com/about/`) or relative (`/about/`).

--- a/docs/content/extras/datadrivencontent.md
+++ b/docs/content/extras/datadrivencontent.md
@@ -6,10 +6,9 @@ date: 2015-02-14
 menu:
   main:
     parent: extras
-next: /extras/highlighting
+next: /extras/gitinfo
 prev: /extras/datafiles
 title: Data-driven Content
-weight: 91
 toc: true
 ---
 

--- a/docs/content/extras/datafiles.md
+++ b/docs/content/extras/datafiles.md
@@ -7,9 +7,8 @@ menu:
   main:
     parent: extras
 next: /extras/datadrivencontent
-prev: /extras/scratch
+prev: /extras/robots-txt
 title: Data Files
-weight: 90
 ---
 
 In addition to the [built-in variables](/templates/variables/) available from Hugo, you can specify your own custom data that can be accessed via templates or shortcodes.

--- a/docs/content/extras/gitinfo.md
+++ b/docs/content/extras/gitinfo.md
@@ -18,6 +18,8 @@ Hugo provides a way to integrate Git data into your site.
 
 1. The Hugo site must be in a Git-enabled directory.
 1. The Git executable must be installed and in your system `PATH`.
+1. Enable the GitInfo feature in Hugo by using `--enableGitInfo` on the command
+   line or by setting `enableGitInfo` to `true` in your site configuration.
 
 ## The GitInfo Object
 

--- a/docs/content/extras/gitinfo.md
+++ b/docs/content/extras/gitinfo.md
@@ -1,0 +1,48 @@
+---
+aliases:
+- /doc/gitinfo/
+lastmod: 2016-12-11
+date: 2016-12-11
+menu:
+  main:
+    parent: extras
+next: /extras/livereload
+prev: /extras/datadrivencontent
+title: GitInfo
+---
+
+Hugo provides a way to integrate Git data into your site.
+
+
+## Prerequisites
+
+1. The Hugo site must be in a Git-enabled directory.
+1. The Git executable must be installed and in your system `PATH`.
+
+## The GitInfo Object
+
+The `GitInfo` object contains the following fields:
+
+AbbreviatedHash
+: abbreviated commit hash, e.g. `866cbcc`
+
+AuthorName
+: author name, respecting `.mailmap`
+
+AuthorEmail
+: author email address, respecting `.mailmap`
+
+AuthorDate
+: the author date
+
+Hash
+: commit hash, e.g. `866cbccdab588b9908887ffd3b4f2667e94090c3`
+
+Subject
+: commit message subject, e.g. `tpl: Add custom index function`
+
+
+## Performance Considerations
+
+The Git integrations should be fairly performant, but it does add some time to the build, which depends somewhat on the Git history size.
+

--- a/docs/content/extras/highlighting.md
+++ b/docs/content/extras/highlighting.md
@@ -7,9 +7,8 @@ menu:
   main:
     parent: extras
 next: /extras/toc
-prev: /extras/datadrivencontent
+prev: /extras/shortcodes
 title: Syntax Highlighting
-weight: 90
 toc: true
 ---
 

--- a/docs/content/extras/livereload.md
+++ b/docs/content/extras/livereload.md
@@ -5,9 +5,8 @@ menu:
   main:
     parent: extras
 next: /extras/menus
-prev: /extras/crossreferences
+prev: /extras/gitinfo
 title: LiveReload
-weight: 50
 ---
 
 Hugo may not be the first static site generator to utilize LiveReload

--- a/docs/content/extras/localfiles.md
+++ b/docs/content/extras/localfiles.md
@@ -6,11 +6,10 @@ date: 2015-06-12
 menu:
   main:
     parent: extras
-next: /community/mailing-list
+next: /extras/urls
 notoc: true
-prev: /extras/urls
+prev: /extras/toc
 title: Traversing Local Files
-weight: 110
 ---
 ## Traversing Local Files
 

--- a/docs/content/extras/menus.md
+++ b/docs/content/extras/menus.md
@@ -5,10 +5,9 @@ toc: true
 menu:
   main:
     parent: extras
-next: /extras/permalinks
+next: /extras/pagination
 prev: /extras/livereload
 title: Menus
-weight: 60
 ---
 
 Hugo has a simple yet powerful menu system that permits content to be

--- a/docs/content/extras/pagination.md
+++ b/docs/content/extras/pagination.md
@@ -6,10 +6,9 @@ date: 2014-01-01
 menu:
   main:
     parent: extras
-next: /extras/scratch
-prev: /extras/shortcodes
+next: /extras/permalinks
+prev: /extras/menus
 title: Pagination
-weight: 80
 ---
 
 Hugo supports pagination for the home page, sections and taxonomies. It's built to be easy use, but with loads of flexibility when needed. The real power shines when you combine it with [`where`](/templates/functions/), with its SQL-like operators, `first` and others --- you can even [order the content](/templates/list/) the way you've become used to with Hugo.

--- a/docs/content/extras/permalinks.md
+++ b/docs/content/extras/permalinks.md
@@ -6,11 +6,10 @@ date: 2013-11-18
 menu:
   main:
     parent: extras
-next: /extras/shortcodes
+next: /extras/scratch
 notoc: true
-prev: /extras/menus
+prev: /extras/pagination
 title: Permalinks
-weight: 70
 ---
 
 By default, content is laid out into the target `publishdir` (public)

--- a/docs/content/extras/robots-txt.md
+++ b/docs/content/extras/robots-txt.md
@@ -4,10 +4,9 @@ date: 2015-12-08
 menu:
   main:
     parent: extras
-next: /community/mailing-list
-prev: /extras/urls
+next: /extras/datafiles
+prev: /extras/crossreferences
 title: Custom robots.txt
-weight: 120
 ---
 
 Hugo can generated a customized [robots.txt](http://www.robotstxt.org/) in the

--- a/docs/content/extras/scratch.md
+++ b/docs/content/extras/scratch.md
@@ -6,10 +6,9 @@ date: 2015-01-22
 menu:
   main:
     parent: extras
-next: /extras/datafiles
-prev: /extras/pagination
+next: /extras/shortcodes
+prev: /extras/permalinks
 title: Scratch
-weight: 80
 ---
 
 `Scratch` -- a "scratchpad" for your page-scoped variables. In most cases you can do well without `Scratch`, but there are some use cases that aren't solvable with Go's templates without `Scratch`'s help, due to scoping issues.
@@ -21,7 +20,7 @@ weight: 80
 * `SetInMap` takes a `key`, `mapKey` and `value`
 * `GetSortedMapValues` returns array of values from `key` sorted by `mapKey`
 
-`Set` and `SetInMap` can store values of any type. 
+`Set` and `SetInMap` can store values of any type.
 
 For single values, `Add` accepts values that support Go's `+` operator. If the first `Add` for a key is an array or slice, the following adds will be appended to that list.
 

--- a/docs/content/extras/shortcodes.md
+++ b/docs/content/extras/shortcodes.md
@@ -6,10 +6,9 @@ date: 2013-07-01
 menu:
   main:
     parent: extras
-next: /extras/pagination
-prev: /extras/permalinks
+next: /extras/highlighting
+prev: /extras/scratch
 title: Shortcodes
-weight: 80
 toc: false
 ---
 

--- a/docs/content/extras/toc.md
+++ b/docs/content/extras/toc.md
@@ -4,10 +4,9 @@ date: 2013-07-09
 menu:
   main:
     parent: extras
-next: /extras/urls
+next: /extras/localfiles
 prev: /extras/highlighting
 title: Table of Contents
-weight: 100
 ---
 
 Hugo will automatically parse the Markdown for your content and create

--- a/docs/content/extras/urls.md
+++ b/docs/content/extras/urls.md
@@ -6,11 +6,10 @@ date: 2014-01-03
 menu:
   main:
     parent: extras
-next: /extras/robots-txt
+next: /community/mailing-list
 notoc: true
-prev: /extras/toc
+prev: /extras/localfiles
 title: URLs
-weight: 110
 ---
 
 ## Pretty URLs

--- a/docs/content/overview/configuration.md
+++ b/docs/content/overview/configuration.md
@@ -124,6 +124,8 @@ along with their current, default values:
     disableRSS:                 false
     # Do not build Sitemap file
     disableSitemap:             false
+    # Enable GitInfo feature
+    enableGitInfo:              false
     # Build robots.txt file
     enableRobotsTXT:            false
     # Do not render 404 page


### PR DESCRIPTION
This PR contains an additional commit to cleanup the Extras menu ordering.  It was an ugly mess.  I removed the weights from the pages to allow the sorter to use the Title so that we don't need manage weights by hand.  Make sure I didn't break something by doing that.

PS - Notice the definition list in the GitInfo page.  I'd much rather see us use that structure in pages such as Template Variables.

Fixes #2670

