### PR TITLE
parser: Accept JSON frontmatter without leading "{\n"

### DIFF
--- a/docs/content/content/front-matter.md
+++ b/docs/content/content/front-matter.md
@@ -21,7 +21,7 @@ Supported formats:
 
   * **[TOML][]**, identified by '`+++`'.
   * **[YAML][]**, identified by '`---`'.
-  * **[JSON][]**, a single JSON object which is surrounded by '`{`' and '`}`', each on their own line.
+  * **[JSON][]**, a single JSON object which is surrounded by '`{`' and '`}`', followed by a newline.
 
 [TOML]: https://github.com/toml-lang/toml "Tom's Obvious, Minimal Language"
 [YAML]: http://www.yaml.org/ "YAML Ain't Markup Language"

--- a/parser/page.go
+++ b/parser/page.go
@@ -255,19 +255,12 @@ func isFrontMatterDelim(data []byte) bool {
 }
 
 func determineDelims(firstLine []byte) (left, right []byte) {
-	switch len(firstLine) {
-	case 5:
-		fallthrough
-	case 4:
-		if firstLine[0] == YAMLLead[0] {
-			return []byte(YAMLDelim), []byte(YAMLDelim)
-		}
+	switch firstLine[0] {
+	case YAMLLead[0]:
+		return []byte(YAMLDelim), []byte(YAMLDelim)
+	case TOMLLead[0]:
 		return []byte(TOMLDelim), []byte(TOMLDelim)
-	case 3:
-		fallthrough
-	case 2:
-		fallthrough
-	case 1:
+	case JSONLead[0]:
 		return []byte(JSONLead), []byte("}")
 	default:
 		panic(fmt.Sprintf("Unable to determine delims from %q", firstLine))

--- a/parser/parse_frontmatter_test.go
+++ b/parser/parse_frontmatter_test.go
@@ -26,20 +26,22 @@ import (
 )
 
 const (
-	contentNoFrontmatter                 = "a page with no front matter"
-	contentWithFrontmatter               = "---\ntitle: front matter\n---\nContent with front matter"
-	contentHTMLNoDoctype                 = "<html>\n\t<body>\n\t</body>\n</html>"
-	contentHTMLWithDoctype               = "<!doctype html><html><body></body></html>"
-	contentHTMLWithFrontmatter           = "---\ntitle: front matter\n---\n<!doctype><html><body></body></html>"
-	contentHTML                          = "    <html><body></body></html>"
-	contentLinefeedAndHTML               = "\n<html><body></body></html>"
-	contentIncompleteEndFrontmatterDelim = "---\ntitle: incomplete end fm delim\n--\nincomplete frontmatter delim"
-	contentMissingEndFrontmatterDelim    = "---\ntitle: incomplete end fm delim\nincomplete frontmatter delim"
-	contentSlugWorking                   = "---\ntitle: slug doc 2\nslug: slug-doc-2\n\n---\nslug doc 2 content"
-	contentSlugWorkingVariation          = "---\ntitle: slug doc 3\nslug: slug-doc 3\n---\nslug doc 3 content"
-	contentSlugBug                       = "---\ntitle: slug doc 2\nslug: slug-doc-2\n---\nslug doc 2 content"
-	contentSlugWithJSONFrontMatter       = "{\n  \"categories\": \"d\",\n  \"tags\": [\n    \"a\", \n    \"b\", \n    \"c\"\n  ]\n}\nJSON Front Matter with tags and categories"
-	contentWithJSONLooseFrontmatter      = "{\n  \"categories\": \"d\"\n  \"tags\": [\n    \"a\" \n    \"b\" \n    \"c\"\n  ]\n}\nJSON Front Matter with tags and categories"
+	contentNoFrontmatter                        = "a page with no front matter"
+	contentWithFrontmatter                      = "---\ntitle: front matter\n---\nContent with front matter"
+	contentHTMLNoDoctype                        = "<html>\n\t<body>\n\t</body>\n</html>"
+	contentHTMLWithDoctype                      = "<!doctype html><html><body></body></html>"
+	contentHTMLWithFrontmatter                  = "---\ntitle: front matter\n---\n<!doctype><html><body></body></html>"
+	contentHTML                                 = "    <html><body></body></html>"
+	contentLinefeedAndHTML                      = "\n<html><body></body></html>"
+	contentIncompleteEndFrontmatterDelim        = "---\ntitle: incomplete end fm delim\n--\nincomplete frontmatter delim"
+	contentMissingEndFrontmatterDelim           = "---\ntitle: incomplete end fm delim\nincomplete frontmatter delim"
+	contentSlugWorking                          = "---\ntitle: slug doc 2\nslug: slug-doc-2\n\n---\nslug doc 2 content"
+	contentSlugWorkingVariation                 = "---\ntitle: slug doc 3\nslug: slug-doc 3\n---\nslug doc 3 content"
+	contentSlugBug                              = "---\ntitle: slug doc 2\nslug: slug-doc-2\n---\nslug doc 2 content"
+	contentSlugWithJSONFrontMatter              = "{\n  \"categories\": \"d\",\n  \"tags\": [\n    \"a\", \n    \"b\", \n    \"c\"\n  ]\n}\nJSON Front Matter with tags and categories"
+	contentWithJSONLooseFrontmatter             = "{\n  \"categories\": \"d\"\n  \"tags\": [\n    \"a\" \n    \"b\" \n    \"c\"\n  ]\n}\nJSON Front Matter with tags and categories"
+	contentSlugWithJSONFrontMatterFirstLineOnly = "{\"categories\":\"d\",\"tags\":[\"a\",\"b\",\"c\"]}\nJSON Front Matter with tags and categories"
+	contentSlugWithJSONFrontMatterFirstLine     = "{\"categories\":\"d\",\n  \"tags\":[\"a\",\"b\",\"c\"]}\nJSON Front Matter with tags and categories"
 )
 
 var lineEndings = []string{"\n", "\r\n"}
@@ -117,6 +119,8 @@ func TestStandaloneCreatePageFrom(t *testing.T) {
 		{contentLinefeedAndHTML, false, true, "", "<html><body></body></html>"},
 		{contentSlugWithJSONFrontMatter, true, false, "{\n  \"categories\": \"d\",\n  \"tags\": [\n    \"a\", \n    \"b\", \n    \"c\"\n  ]\n}", "JSON Front Matter with tags and categories"},
 		{contentWithJSONLooseFrontmatter, true, false, "{\n  \"categories\": \"d\"\n  \"tags\": [\n    \"a\" \n    \"b\" \n    \"c\"\n  ]\n}", "JSON Front Matter with tags and categories"},
+		{contentSlugWithJSONFrontMatterFirstLineOnly, true, false, "{\"categories\":\"d\",\"tags\":[\"a\",\"b\",\"c\"]}", "JSON Front Matter with tags and categories"},
+		{contentSlugWithJSONFrontMatterFirstLine, true, false, "{\"categories\":\"d\",\n  \"tags\":[\"a\",\"b\",\"c\"]}", "JSON Front Matter with tags and categories"},
 		{contentSlugWorking, true, false, "---\ntitle: slug doc 2\nslug: slug-doc-2\n\n---\n", "slug doc 2 content"},
 		{contentSlugWorkingVariation, true, false, "---\ntitle: slug doc 3\nslug: slug-doc 3\n---\n", "slug doc 3 content"},
 		{contentSlugBug, true, false, "---\ntitle: slug doc 2\nslug: slug-doc-2\n---\n", "slug doc 2 content"},


### PR DESCRIPTION
Accept JSON frontmatter without leading "{\n" so that one line frontmatters such as `{"param":"paramvalue"}` no longer silently render empty html.

----------------------------
I ran `bench.sh` and there doesn't seem to be a performance difference even though `determineDelims(...)` no longer uses the length of the slice as a heuristic.

Stylistically, having `{` and `}` on their own line is probably better. However, I was following [this post](https://discuss.gohugo.io/t/creating-static-content-that-uses-partials/265/15) and became frustrated by the blank page generated with no error in the output or logs.