### PR TITLE
Fixes/docs mobile theme

### DIFF
--- a/docs/static/css/style-responsive.css
+++ b/docs/static/css/style-responsive.css
@@ -21,6 +21,10 @@
         position: none !important;
     }
 
+    .wrapper {
+        padding: inherit;
+    }
+
     #sidebar > ul > li {
         margin: 0 10px 5px 10px;
     }

--- a/docs/static/css/style-responsive.css
+++ b/docs/static/css/style-responsive.css
@@ -55,10 +55,3 @@
         display: none;
     }
 }
-
-@media (max-width:320px) {
-
-    .notification-row {
-        display: none;
-    }
-}

--- a/docs/static/css/style-responsive.css
+++ b/docs/static/css/style-responsive.css
@@ -51,6 +51,10 @@
         margin-bottom: 5px;
     }
 
+    .navigation.next {
+        display: none;
+    }
+
 }
 
 @media (max-width: 480px) {

--- a/docs/static/css/style-responsive.css
+++ b/docs/static/css/style-responsive.css
@@ -55,3 +55,10 @@
         display: none;
     }
 }
+
+@media (max-width:360px) {
+
+    h1 {
+        font-size: 1.9em;
+    }
+}

--- a/docs/static/css/style-responsive.css
+++ b/docs/static/css/style-responsive.css
@@ -21,10 +21,6 @@
         position: none !important;
     }
 
-    #sidebar > ul > li > a > span {
-        line-height: 35px;
-    }
-
     #sidebar > ul > li {
         margin: 0 10px 5px 10px;
     }


### PR DESCRIPTION
Some fixes on mobile theme for the Hugo documentation.

Fixes apply to mobile only with the following changes : 

* Menu arrows that look like "stairs"

![hugo - menu](https://cloud.githubusercontent.com/assets/1499325/21356046/956143dc-c6d0-11e6-98ba-c0f12d980219.png)

* Title size is to big on some screen sizes and the search box or texts are hidden

![hugo - search](https://cloud.githubusercontent.com/assets/1499325/21356047/956a5d82-c6d0-11e6-9d2b-ce2fb840a500.png)

* Space at the right on main content is removed

![hugo - right space](https://cloud.githubusercontent.com/assets/1499325/21356194/05361eb2-c6d1-11e6-938a-547e15e3a668.png)

* Next page arrow is now hidden 