### PR TITLE
tpl: fix crash when using imageConfig

### DIFF
--- a/tpl/template_funcs.go
+++ b/tpl/template_funcs.go
@@ -378,19 +378,23 @@ func ResetCaches() {
 
 // imageConfigCache is a lockable cache for image.Config objects. It must be
 // locked before reading or writing to config.
-var imageConfigCache struct {
-	sync.RWMutex
+type imageConfigCache struct {
 	config map[string]image.Config
+	sync.RWMutex
+}
+
+var defaultImageConfigCache = imageConfigCache{
+	config: map[string]image.Config{},
 }
 
 // resetImageConfigCache initializes and resets the imageConfig cache for the
 // imageConfig template function. This should be run once before every batch of
 // template renderers so the cache is cleared for new data.
 func resetImageConfigCache() {
-	imageConfigCache.Lock()
-	defer imageConfigCache.Unlock()
+	defaultImageConfigCache.Lock()
+	defer defaultImageConfigCache.Unlock()
 
-	imageConfigCache.config = map[string]image.Config{}
+	defaultImageConfigCache.config = map[string]image.Config{}
 }
 
 // imageConfig returns the image.Config for the specified path relative to the
@@ -406,9 +410,9 @@ func imageConfig(path interface{}) (image.Config, error) {
 	}
 
 	// Check cache for image config.
-	imageConfigCache.RLock()
-	config, ok := imageConfigCache.config[filename]
-	imageConfigCache.RUnlock()
+	defaultImageConfigCache.RLock()
+	config, ok := defaultImageConfigCache.config[filename]
+	defaultImageConfigCache.RUnlock()
 
 	if ok {
 		return config, nil
@@ -421,9 +425,9 @@ func imageConfig(path interface{}) (image.Config, error) {
 
 	config, _, err = image.DecodeConfig(f)
 
-	imageConfigCache.Lock()
-	imageConfigCache.config[filename] = config
-	imageConfigCache.Unlock()
+	defaultImageConfigCache.Lock()
+	defaultImageConfigCache.config[filename] = config
+	defaultImageConfigCache.Unlock()
 
 	return config, err
 }

--- a/tpl/template_funcs_test.go
+++ b/tpl/template_funcs_test.go
@@ -629,6 +629,17 @@ func TestImageConfig(t *testing.T) {
 		input      []byte
 		expected   image.Config
 	}{
+		// Make sure that the cache is initialized by default.
+		{
+			resetCache: false,
+			path:       "a.png",
+			input:      blankImage(10, 10),
+			expected: image.Config{
+				Width:      10,
+				Height:     10,
+				ColorModel: color.NRGBAModel,
+			},
+		},
 		{
 			resetCache: true,
 			path:       "a.png",
@@ -685,8 +696,8 @@ func TestImageConfig(t *testing.T) {
 			t.Errorf("[%d] imageConfig: expected '%v', got '%v'", i, this.expected, result)
 		}
 
-		if len(imageConfigCache.config) == 0 {
-			t.Error("imageConfigCache should have at least 1 item")
+		if len(defaultImageConfigCache.config) == 0 {
+			t.Error("defaultImageConfigCache should have at least 1 item")
 		}
 	}
 
@@ -705,8 +716,8 @@ func TestImageConfig(t *testing.T) {
 	// test cache clearing
 	ResetCaches()
 
-	if len(imageConfigCache.config) != 0 {
-		t.Error("ResetCaches should have cleared imageConfigCache")
+	if len(defaultImageConfigCache.config) != 0 {
+		t.Error("ResetCaches should have cleared defaultImageConfigCache")
 	}
 }
 


### PR DESCRIPTION
defaultImageConfigCache is now initialized statically instead of relying on it
being initialized in the reset function.

Fixes #2806