### PR TITLE
hugolib: Fix IsTranslated for "old" node types

### DIFF
--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -180,7 +180,7 @@ func (h *HugoSites) assignMissingTranslations() error {
 		// Assign translations
 		for _, t1 := range nodes {
 			for _, t2 := range nodes {
-				if t2.isNewTranslation(t1) {
+				if t1.isNewTranslation(t2) {
 					t1.translations = append(t1.translations, t2)
 				}
 			}

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -1626,16 +1626,13 @@ func (p *Page) Lang() string {
 }
 
 func (p *Page) isNewTranslation(candidate *Page) bool {
-	if p == candidate || p.Kind != candidate.Kind {
+
+	if p.Kind != candidate.Kind {
 		return false
 	}
 
 	if p.Kind == KindPage || p.Kind == kindUnknown {
 		panic("Node type not currently supported for this op")
-	}
-
-	if p.language.Lang == candidate.language.Lang {
-		return false
 	}
 
 	// At this point, we know that this is a traditional Node (home page, section, taxonomy)
@@ -1651,8 +1648,8 @@ func (p *Page) isNewTranslation(candidate *Page) bool {
 	}
 
 	// Finally check that it is not already added.
-	for _, translation := range candidate.translations {
-		if p == translation {
+	for _, translation := range p.translations {
+		if candidate == translation {
 			return false
 		}
 	}


### PR DESCRIPTION
The new logic for creating Page objects from old node types
didn't include itself in the translation logic, so
`IsTranslated` returned falsely false for sites with only two languages.

The `AllTranslations` method also returned to few pages in that case.

This commit fixes that.

Fixes #2812