### PR TITLE
hugolib: Fix redundant URL file extension on taxonomy terms pages

### DIFF
--- a/hugolib/node_as_page_test.go
+++ b/hugolib/node_as_page_test.go
@@ -222,6 +222,19 @@ func doTestNodesWithNoContentFile(t *testing.T, ugly bool) {
 		"Taxonomy Terms Title: Categories",
 	)
 
+	pages := s.findPagesByKind(KindTaxonomyTerm)
+	for _, p := range pages {
+		var want string
+		if ugly {
+			want = "/" + p.Site.pathSpec.URLize(p.Title) + ".html"
+		} else {
+			want = "/" + p.Site.pathSpec.URLize(p.Title) + "/"
+		}
+		if p.URL() != want {
+			t.Errorf("Taxonomy term URL mismatch: want %q, got %q", want, p.URL())
+		}
+	}
+
 	// Sections
 	assertFileContent(t, expectedFilePath(ugly, "public", "sect1"), false,
 		"Section Title: Sect1s",

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -758,7 +758,7 @@ func (p *Page) createPermalink() (*url.URL, error) {
 		// No permalink config for nodes (currently)
 		pURL := strings.TrimSpace(p.Site.pathSpec.URLize(p.URLPath.URL))
 		pURL = p.addLangPathPrefix(pURL)
-		pURL = p.Site.pathSpec.URLPrep(path.Join(pURL, "index."+p.Extension()))
+		pURL = p.Site.pathSpec.URLPrep(pURL)
 		url := helpers.MakePermalink(baseURL, pURL)
 		return url, nil
 	}


### PR DESCRIPTION
Fixes #2819 
