### PR TITLE
Add link to HugoPhotoSwipe tool

### DIFF
--- a/docs/content/tools/_index.md
+++ b/docs/content/tools/_index.md
@@ -132,3 +132,4 @@ And for all the other small things around Hugo:
 - [hugo-gallery](https://github.com/icecreammatt/hugo-gallery) lets you create an image gallery for Hugo sites.
 - [flickr-hugo-embed](https://github.com/nikhilm/flickr-hugo-embed) prints shortcodes to embed a set of images from an album on Flickr into Hugo.
 - [hugo-openapispec-shortcode](https://github.com/tenfourty/hugo-openapispec-shortcode) A shortcode which allows you to include [Open API Spec](https://openapis.org) (formerly known as Swagger Spec) in a page.
+- [HugoPhotoSwipe](https://github.com/GjjvdBurg/HugoPhotoSwipe) makes it easy to create image galleries using PhotoSwipe.


### PR DESCRIPTION
HugoPhotoSwipe is a command line tool to create and manage PhotoSwipe galleries with Hugo. It resizes images for responsive layouts in PhotoSwipe and generates the Markdown necessary for Hugo to create the gallery. I think this can be a useful tool for Hugo users.