### PR TITLE
tpl: add now function

### DIFF
--- a/docs/content/templates/functions.md
+++ b/docs/content/templates/functions.md
@@ -804,6 +804,10 @@ For more information about string translations, see [Translation of strings]({{<
 * `{{ (time "2016-05-28").YearDay }}` → 149
 * `{{ mul 1000 (time "2016-05-28T10:30:00.00+10:00").Unix }}` → 1464395400000 (Unix time in milliseconds)
 
+### now
+
+`now` returns the current local time as a [`time.Time`](https://godoc.org/time#Time).
+
 ## URLs
 ### absLangURL, relLangURL
 These are similar to the `absURL` and `relURL` relatives below, but will add the correct language prefix when the site is configured with more than one language.

--- a/tpl/template_funcs.go
+++ b/tpl/template_funcs.go
@@ -2146,6 +2146,7 @@ func initFuncMap() {
 		"modBool":       modBool,
 		"mul":           func(a, b interface{}) (interface{}, error) { return helpers.DoArithmetic(a, b, '*') },
 		"ne":            ne,
+		"now":           func() time.Time { return time.Now() },
 		"partial":       partial,
 		"partialCached": partialCached,
 		"plainify":      plainify,


### PR DESCRIPTION
Add a timeNow template function that returns the current time as
time.Time. Also, update related docs.

Don't know what the right way to test this change is (if necessary), so I'm open to suggestions.

Personally, I'm looking to use use the unix timestamp of the current time in the [query string for cache busting](https://css-tricks.com/strategies-for-cache-busting-css/#article-header-id-1) in a theme. 

```
<link rel="stylesheet" href="/css/reset.css?t={{ timeNow.Unix }}">
```


I'm sure hugo users will come up with other creative uses for current time.