### PR TITLE
Add appveyor.yaml to mirror .travis.yml and fix line ending issues

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,29 @@
+image: WMF 5
+clone_folder: c:\GOPATH\src\github.com\spf13\hugo
+init:
+- cmd: >-
+    set PATH=%PATH%;C:\MinGW\bin;C:\GOPATH\bin
+
+    copy c:\MinGW\bin\mingw32-make.exe c:\MinGW\bin\make.exe
+environment:
+  GOPATH: c:\GOPATH
+install:
+- cmd: >-
+    gem install asciidoctor
+
+    pip install docutils
+build_script:
+- cmd: make govendor
+test_script:
+- cmd: >-
+    make check
+
+    REM Test 64-bit alignment on 32-bit builds
+
+    set "GOARCH=386" & make test & set GOARCH=
+
+    go build -race
+
+    hugo -s docs/
+
+    hugo --renderToMemory -s docs/

--- a/helpers/general.go
+++ b/helpers/general.go
@@ -38,6 +38,11 @@ import (
 // FilePathSeparator as defined by os.Separator.
 const FilePathSeparator = string(filepath.Separator)
 
+// Strips carriage returns from third-party / external processes (useful for Windows)
+func normalizeExternalHelperLineFeeds(content []byte) []byte {
+	return bytes.Replace(content, []byte("\r"), []byte(""), -1)
+}
+
 // FindAvailablePort returns an available and valid TCP port.
 func FindAvailablePort() (*net.TCPAddr, error) {
 	l, err := net.Listen("tcp", ":0")

--- a/helpers/pygments.go
+++ b/helpers/pygments.go
@@ -112,7 +112,7 @@ func Highlight(code, lang, optsStr string) string {
 		return code
 	}
 
-	str := out.String()
+	str := string(normalizeExternalHelperLineFeeds([]byte(out.String())))
 
 	// inject code tag into Pygments output
 	if lang != "" && strings.Contains(str, "<pre>") {

--- a/hugolib/gitinfo.go
+++ b/hugolib/gitinfo.go
@@ -57,7 +57,7 @@ func (h *HugoSites) assembleGitInfo() {
 			continue
 		}
 		// Git normalizes file paths on this form:
-		filename := path.Join(contentRoot, contentDir, filepath.ToSlash(p.Path()))
+		filename := path.Join(filepath.ToSlash(contentRoot), contentDir, filepath.ToSlash(p.Path()))
 		g, ok := gitMap[filename]
 		if !ok {
 			jww.ERROR.Printf("Failed to find GitInfo for %q", filename)

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -324,7 +324,7 @@ void do();
 	}
 
 	if !matched {
-		t.Error("Hightlight mismatch, got\n", output)
+		t.Errorf("Hightlight mismatch, got (escaped to see invisible chars)\n%+q", output)
 	}
 }
 


### PR DESCRIPTION
Codified appveyor configuration and mirrored it to the travis configuration. This uncovered a few issues with the Windows build. First was GitInfo pathing was not normalized and second was, generally, external helpers did not properly return LF normalized files. These issues were uncovered by existing unit tests and fixed in this PR.

Fixes #1825 #2697 #920