### PR TITLE
docs: Convert all uses of 'Params.notoc' to 'Params.toc'

### DIFF
--- a/docs/content/community/press.md
+++ b/docs/content/community/press.md
@@ -2,7 +2,6 @@
 lastmod: 2016-10-10
 date: 2014-03-24T20:00:00Z
 linktitle: Press
-notoc: true
 title: Press, Blogs and Media Coverage
 weight: 20
 ---

--- a/docs/content/content/example.md
+++ b/docs/content/content/example.md
@@ -9,7 +9,6 @@ menu:
     parent: content
 prev: /content/multilingual
 next: /themes/overview
-notoc: true
 title: Example Content File
 weight: 70
 ---

--- a/docs/content/content/sections.md
+++ b/docs/content/content/sections.md
@@ -5,7 +5,6 @@ menu:
   main:
     parent: content
 next: /content/types
-notoc: true
 prev: /content/front-matter
 title: Sections
 weight: 30

--- a/docs/content/content/summaries.md
+++ b/docs/content/content/summaries.md
@@ -4,7 +4,6 @@ date: 2013-07-01
 menu:
   main:
     parent: content
-notoc: true
 prev: /content/ordering
 next: /content/markdown-extras
 title: Summaries

--- a/docs/content/extras/localfiles.md
+++ b/docs/content/extras/localfiles.md
@@ -7,7 +7,6 @@ menu:
   main:
     parent: extras
 next: /extras/urls
-notoc: true
 prev: /extras/toc
 title: Traversing Local Files
 ---

--- a/docs/content/extras/permalinks.md
+++ b/docs/content/extras/permalinks.md
@@ -7,7 +7,6 @@ menu:
   main:
     parent: extras
 next: /extras/scratch
-notoc: true
 prev: /extras/pagination
 title: Permalinks
 ---

--- a/docs/content/extras/urls.md
+++ b/docs/content/extras/urls.md
@@ -7,7 +7,6 @@ menu:
   main:
     parent: extras
 next: /community/mailing-list
-notoc: true
 prev: /extras/localfiles
 title: URLs
 ---

--- a/docs/content/meta/roadmap.md
+++ b/docs/content/meta/roadmap.md
@@ -7,7 +7,6 @@ date: 2013-07-01
 menu:
   main:
     parent: about
-notoc: true
 title: Hugo Roadmap
 weight: 20
 ---

--- a/docs/content/overview/source-directory.md
+++ b/docs/content/overview/source-directory.md
@@ -7,7 +7,6 @@ menu:
   main:
     parent: getting started
 next: /content/organization
-notoc: true
 prev: /overview/configuration
 title: Source Organization
 weight: 50

--- a/docs/content/overview/usage.md
+++ b/docs/content/overview/usage.md
@@ -7,7 +7,6 @@ menu:
   main:
     parent: getting started
 next: /overview/configuration
-notoc: true
 prev: /overview/installing
 title: Using Hugo
 weight: 30

--- a/docs/content/templates/404.md
+++ b/docs/content/templates/404.md
@@ -8,7 +8,6 @@ menu:
   main:
     parent: layout
 next: /taxonomies/overview
-notoc: true
 next: /templates/debugging
 prev: /templates/sitemap
 title: 404.html Templates

--- a/docs/content/templates/go-templates.md
+++ b/docs/content/templates/go-templates.md
@@ -340,9 +340,11 @@ In each piece of content, you can provide variables to be used by the
 templates. This happens in the [front matter](/content/front-matter/).
 
 An example of this is used in this documentation site. Most of the pages
-benefit from having the table of contents provided. Sometimes the TOC just
-doesn't make a lot of sense. We've defined a variable in our front matter
-of some pages to turn off the TOC from being displayed.
+benefit from having the table of contents provided.
+However, sometimes having a TOC just doesn't make a lot of sense.
+In the front matter of some of our pages,
+we've defined a variable which enables the TOC. If you don't want the TOC,
+then just omit that variable. (Its value defaults to false.)
 
 Here is the example front matter:
 
@@ -355,13 +357,13 @@ aliases:
   - "/doc/permalinks/"
 groups: ["extras"]
 groups_weight: 30
-notoc: true
+toc: true
 ---
 ```
 
 Here is the corresponding code inside of the template:
 
-      {{ if not .Params.notoc }}
+      {{ if .Params.toc }}
         <div id="toc" class="well col-md-4 col-sm-6">
         {{ .TableOfContents }}
         </div>

--- a/docs/content/templates/homepage.md
+++ b/docs/content/templates/homepage.md
@@ -7,7 +7,6 @@ menu:
   main:
     parent: layout
 next: /templates/terms
-notoc: true
 prev: /templates/list
 title: Homepage
 weight: 50

--- a/docs/content/templates/rss.md
+++ b/docs/content/templates/rss.md
@@ -8,7 +8,6 @@ menu:
   main:
     parent: layout
 next: /templates/sitemap
-notoc: one
 prev: /templates/partials
 title: RSS (feed) Templates
 weight: 90

--- a/docs/content/templates/sitemap.md
+++ b/docs/content/templates/sitemap.md
@@ -8,7 +8,6 @@ menu:
   main:
     parent: layout
 next: /templates/404
-notoc: true
 prev: /templates/rss
 title: Sitemap Template
 weight: 95


### PR DESCRIPTION
Fixes #2866