### PR TITLE
Remove waffle.io graph from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,7 @@ organization, tutorials, blog posts, bug reports, issues, feature requests,
 feature implementations, pull requests, answering questions on the forum,
 helping to manage issues, etc.
 
-The Hugo community and maintainers are very active and helpful, and the project benefits greatly from this activity.
-
-[![Throughput Graph](https://graphs.waffle.io/spf13/hugo/throughput.svg)](https://waffle.io/spf13/hugo/metrics)
+The Hugo community and maintainers are [very active](https://github.com/spf13/hugo/pulse/monthly) and helpful, and the project benefits greatly from this activity.
 
 ### Asking Support Questions
 


### PR DESCRIPTION
Waffle.io's throughput graph appears to be broken.  Remove the graph and
simply link to GitHub's Pulse page.

Fixes #2865