### PR TITLE
docs: Don't use binary version in docs site

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -10,6 +10,7 @@ enableGitInfo = true
 [params]
   description = "Documentation of Hugo, a fast and flexible static site generator built with love by spf13, bep and friends in Go"
   author = "Steve Francia (spf13) and friends"
+  release = "0.18.1"
 
 [taxonomies]
   tag = "tags"

--- a/docs/layouts/partials/footer.html
+++ b/docs/layouts/partials/footer.html
@@ -1,7 +1,7 @@
                     <div class="row">
                         <div class="footer-panel">
 			  <p>Last revision: {{ .Lastmod.Format "January 2, 2006" }}{{ if .IsPage }}{{ with .GitInfo }} | <a href="https://github.com/spf13/hugo/commit/{{ .Hash }}">{{ .Subject }} ({{ .AbbreviatedHash }})</a>{{end }}{{ end }}
-                          <span style="float: right;">Hugo v{{ .Hugo.Version }} documentation</span>
+                          <span style="float: right;">Hugo v{{ .Site.Params.release }} documentation</span>
                         </p>
                         </div>
                     </div>

--- a/docs/layouts/partials/header.html
+++ b/docs/layouts/partials/header.html
@@ -35,7 +35,7 @@
             </div>
 
             <!--logo start-->
-            <a href="/" class="logo"><img src="/img/hugo-logo.png" style="height: 40px; vertical-align: bottom;"> <span style="font-size: small; text-transform: none;">v{{ .Hugo.Version }}</span></a>
+            <a href="/" class="logo"><img src="/img/hugo-logo.png" style="height: 40px; vertical-align: bottom;"> <span style="font-size: small; text-transform: none;">v{{ .Site.Params.release }}</span></a>
             <!--logo end-->
             <div class="top-nav notification-row">
                 <!-- notification dropdown end-->


### PR DESCRIPTION
Adds a "release" Site param that will be need to be updated for each
release.

Fixes #2857