### PR TITLE
tpl: Fix Unix time test case in TestDateFormat()

### DIFF
--- a/tpl/template_funcs_test.go
+++ b/tpl/template_funcs_test.go
@@ -2272,7 +2272,8 @@ func TestDateFormat(t *testing.T) {
 		{"Monday, Jan 2, 2006", "2015-01-21", "Wednesday, Jan 21, 2015"},
 		{"Monday, Jan 2, 2006", time.Date(2015, time.January, 21, 0, 0, 0, 0, time.UTC), "Wednesday, Jan 21, 2015"},
 		{"This isn't a date layout string", "2015-01-21", "This isn't a date layout string"},
-		{"Monday, Jan 2, 2006", 1421733600, "Tuesday, Jan 20, 2015"},
+		// The following test case gives either "Tuesday, Jan 20, 2015" or "Monday, Jan 19, 2015" depending on the local time zone
+		{"Monday, Jan 2, 2006", 1421733600, time.Unix(1421733600, 0).Format("Monday, Jan 2, 2006")},
 		{"Monday, Jan 2, 2006", 1421733600.123, false},
 		{time.RFC3339, time.Date(2016, time.March, 3, 4, 5, 0, 0, time.UTC), "2016-03-03T04:05:00Z"},
 		{time.RFC1123, time.Date(2016, time.March, 3, 4, 5, 0, 0, time.UTC), "Thu, 03 Mar 2016 04:05:00 UTC"},


### PR DESCRIPTION
Fixes #2855