### PR TITLE
Add truncate template function

### DIFF
--- a/docs/content/templates/functions.md
+++ b/docs/content/templates/functions.md
@@ -664,12 +664,13 @@ e.g.
 
 ### truncate
 
-Truncate a text to a max length without cutting words or HTML tags in half. Since go templates are HTML aware, truncate will handle normal strings vs HTML strings intelligently.
+Truncate a text to a max length without cutting words or leaving unclosed HTML tags. Since Go templates are HTML-aware, truncate will handle normal strings vs HTML strings intelligently. It's important to note that if you have a raw string that contains HTML tags that you want treated as HTML, you will need to convert the string to HTML using the safeHTML template function before sending the value to truncate; otherwise, the HTML tags will be escaped by truncate.
 
-e.q.
+e.g.
 
-* `{{ "this is a text" | truncate 10 " ..." }}` → this is a ...
-* `{{ "With [Markdown](#markdown) inside." | markdownify | truncate 10 }}` → With &lt;a href='#markdown'&gt;Markdown …&lt;/a&gt;
+* `{{ "this is a text" | truncate 10 " ..." }}` → `this is a ...`
+* `{{ "<em>Keep my HTML</em>" | safeHTML | truncate 10 }}` → `<em>Keep my …</em>`
+* `{{ "With [Markdown](#markdown) inside." | markdownify | truncate 10 }}` → `With <a href='#markdown'>Markdown …</a>`  
 
 ### split
 

--- a/docs/content/templates/functions.md
+++ b/docs/content/templates/functions.md
@@ -662,6 +662,15 @@ e.g.
 * `{{slicestr "BatMan" 3}}` → "Man"
 * `{{slicestr "BatMan" 0 3}}` → "Bat"
 
+### truncate
+
+Truncate a text to a max length without cutting words or HTML tags in half. Since go templates are HTML aware, truncate will handle normal strings vs HTML strings intelligently.
+
+e.q.
+
+* `{{ "this is a text" | truncate 10 " ..." }}` → this is a ...
+* `{{ "With [Markdown](#markdown) inside." | markdownify | truncate 10 }}` → With &lt;a href='#markdown'&gt;Markdown …&lt;/a&gt;
+
 ### split
 
 Split a string into substrings separated by a delimiter.

--- a/tpl/template_func_truncate.go
+++ b/tpl/template_func_truncate.go
@@ -92,7 +92,7 @@ func truncate(a interface{}, options ...interface{}) (template.HTML, error) {
 
 		if isHTML {
 			// Make sure we keep tag of HTML tags
-			slice := string(text[i:])
+			slice := text[i:]
 			m := tagRE.FindStringSubmatchIndex(slice)
 			if len(m) > 0 && m[0] == 0 {
 				nextTag = i + m[1]

--- a/tpl/template_func_truncate.go
+++ b/tpl/template_func_truncate.go
@@ -108,8 +108,8 @@ func truncateHTML(length int, ellipsis, text template.HTML) (template.HTML, erro
 	}
 
 	openTags := []openTag{}
-
 	var lastWordIndex, lastNonSpace, currentLen, endTextPos, nextTag int
+
 	for i, r := range text {
 		if i < nextTag {
 			continue
@@ -119,6 +119,7 @@ func truncateHTML(length int, ellipsis, text template.HTML) (template.HTML, erro
 		if len(m) > 0 && m[0] == 0 {
 			nextTag = i + m[1]
 			tagname := slice[m[4]:m[5]]
+			lastWordIndex = lastNonSpace
 			_, singlet := htmlSinglets[tagname]
 			if singlet || m[6] != -1 {
 				continue

--- a/tpl/template_func_truncate.go
+++ b/tpl/template_func_truncate.go
@@ -1,0 +1,164 @@
+// Copyright 2016 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tpl
+
+import (
+	"errors"
+	"html"
+	"html/template"
+	"regexp"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/spf13/cast"
+)
+
+var (
+	tagRE        = regexp.MustCompile(`^<(/)?([^ ]+?)(?:(\s*/)| .*?)?>`)
+	htmlSinglets = map[string]bool{
+		"br": true, "col": true, "link": true,
+		"base": true, "img": true, "param": true,
+		"area": true, "hr": true, "input": true,
+	}
+)
+
+type openTag struct {
+	name string
+	pos  int
+}
+
+func truncate(a interface{}, options ...interface{}) (template.HTML, error) {
+	length, err := cast.ToIntE(a)
+	if err != nil {
+		return "", err
+	}
+	var textParam interface{}
+	var ellipsis template.HTML
+
+	switch len(options) {
+	case 0:
+		return "", errors.New("truncate requires a length and a string")
+	case 1:
+		textParam = options[0]
+		ellipsis = " …"
+	case 2:
+		textParam = options[1]
+		var ok bool
+		if ellipsis, ok = options[0].(template.HTML); !ok {
+			s, e := cast.ToStringE(options[0])
+			if e != nil {
+				return "", errors.New("ellipsis must be a string")
+			}
+			ellipsis = template.HTML(html.EscapeString(s))
+		}
+	default:
+		return "", errors.New("too many arguments passed to truncate")
+	}
+	if err != nil {
+		return "", errors.New("text to truncate must be a string")
+	}
+	text, err := cast.ToStringE(textParam)
+	if err != nil {
+		return "", errors.New("text must be a string")
+	}
+
+	if html, ok := textParam.(template.HTML); ok {
+		return truncateHTML(length, ellipsis, html)
+	}
+
+	if utf8.RuneCountInString(text) <= length {
+		return template.HTML(html.EscapeString(text)), nil
+	}
+
+	var lastWordIndex, lastNonSpace, currentLen int
+	for i, r := range text {
+		currentLen++
+		if unicode.IsSpace(r) {
+			lastWordIndex = lastNonSpace
+		} else if unicode.In(r, unicode.Han, unicode.Hangul, unicode.Hiragana, unicode.Katakana) {
+			lastWordIndex = i
+		} else {
+			lastNonSpace = i + utf8.RuneLen(r)
+		}
+		if currentLen > length {
+			if lastWordIndex == 0 {
+				return template.HTML(html.EscapeString(text[0:i])) + ellipsis, nil
+			}
+			return template.HTML(html.EscapeString(text[0:lastWordIndex])) + ellipsis, nil
+		}
+	}
+
+	return template.HTML(html.EscapeString(text)), nil
+}
+
+func truncateHTML(length int, ellipsis, text template.HTML) (template.HTML, error) {
+	if utf8.RuneCountInString(string(text)) <= length {
+		return text, nil
+	}
+
+	openTags := []openTag{}
+
+	var lastWordIndex, lastNonSpace, currentLen, endTextPos, nextTag int
+	for i, r := range text {
+		if i < nextTag {
+			continue
+		}
+		slice := string(text[i:])
+		m := tagRE.FindStringSubmatchIndex(slice)
+		if len(m) > 0 && m[0] == 0 {
+			tagname := slice[m[4]:m[5]]
+			if m[2] == -1 {
+				openTags = append(openTags, openTag{name: tagname, pos: i})
+			} else {
+				// SGML: An end tag closes, back to the matching start tag,
+				// all unclosed intervening start tags with omitted end tags
+				for i, tag := range openTags {
+					if tag.name == tagname {
+						openTags = openTags[i:]
+						break
+					}
+				}
+			}
+			nextTag = i + m[1]
+			continue
+		}
+
+		currentLen++
+		if unicode.IsSpace(r) {
+			lastWordIndex = lastNonSpace
+		} else if unicode.In(r, unicode.Han, unicode.Hangul, unicode.Hiragana, unicode.Katakana) {
+			lastWordIndex = i
+		} else {
+			lastNonSpace = i + utf8.RuneLen(r)
+		}
+		if currentLen > length {
+			if lastWordIndex == 0 {
+				endTextPos = i
+			} else {
+				endTextPos = lastWordIndex
+			}
+			out := text[0:endTextPos] + ellipsis
+			for _, tag := range openTags {
+				if tag.pos > endTextPos {
+					break
+				}
+				out += ("</" + template.HTML(tag.name) + ">")
+			}
+
+			return out, nil
+		}
+	}
+
+	return text, nil
+}

--- a/tpl/template_func_truncate.go
+++ b/tpl/template_func_truncate.go
@@ -117,7 +117,12 @@ func truncateHTML(length int, ellipsis, text template.HTML) (template.HTML, erro
 		slice := string(text[i:])
 		m := tagRE.FindStringSubmatchIndex(slice)
 		if len(m) > 0 && m[0] == 0 {
+			nextTag = i + m[1]
 			tagname := slice[m[4]:m[5]]
+			_, singlet := htmlSinglets[tagname]
+			if singlet || m[6] != -1 {
+				continue
+			}
 			if m[2] == -1 {
 				openTags = append(openTags, openTag{name: tagname, pos: i})
 			} else {
@@ -130,7 +135,6 @@ func truncateHTML(length int, ellipsis, text template.HTML) (template.HTML, erro
 					}
 				}
 			}
-			nextTag = i + m[1]
 			continue
 		}
 

--- a/tpl/template_func_truncate_test.go
+++ b/tpl/template_func_truncate_test.go
@@ -1,0 +1,76 @@
+// Copyright 2016 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tpl
+
+import (
+	"html/template"
+	"reflect"
+	"testing"
+)
+
+func TestTruncate(t *testing.T) {
+	var err error
+	cases := []struct {
+		v1    interface{}
+		v2    interface{}
+		v3    interface{}
+		want  interface{}
+		isErr bool
+	}{
+		{10, "I am a test sentence", nil, template.HTML("I am a …"), false},
+		{10, "", "I am a test sentence", template.HTML("I am a"), false},
+		{10, "", "a b c d e f g h i j k", template.HTML("a b c d e"), false},
+		{12, "", "<b>Should be escaped</b>", template.HTML("&lt;b&gt;Should be"), false},
+		{10, template.HTML(" <a href='#'>Read more</a>"), "I am a test sentence", template.HTML("I am a <a href='#'>Read more</a>"), false},
+		{20, template.HTML("I have a <a href='/markdown'>Markdown link</a> inside."), nil, template.HTML("I have a <a href='/markdown'>Markdown …</a>"), false},
+		{10, "IamanextremelylongwordthatjustgoesonandonandonjusttoannoyyoualmostasifIwaswritteninGermanActuallyIbettheresagermanwordforthis", nil, template.HTML("Iamanextre …"), false},
+		{10, template.HTML("<p>IamanextremelylongwordthatjustgoesonandonandonjusttoannoyyoualmostasifIwaswritteninGermanActuallyIbettheresagermanwordforthis</p>"), nil, template.HTML("<p>Iamanextre …</p>"), false},
+		{13, template.HTML("With <a href=\"/markdown\">Markdown</a> inside."), nil, template.HTML("With <a href=\"/markdown\">Markdown …</a>"), false},
+		{14, "Hello中国 Good 好的", nil, template.HTML("Hello中国 Good 好 …"), false},
+		{14, template.HTML("<p>Hello中国 Good 好的</p>"), nil, template.HTML("<p>Hello中国 Good 好 …</p>"), false},
+		{10, nil, nil, template.HTML(""), true},
+		{nil, nil, nil, template.HTML(""), true},
+	}
+	for i, c := range cases {
+		var result template.HTML
+		if c.v2 == nil {
+			result, err = truncate(c.v1)
+		} else if c.v3 == nil {
+			result, err = truncate(c.v1, c.v2)
+		} else {
+			result, err = truncate(c.v1, c.v2, c.v3)
+		}
+
+		if c.isErr {
+			if err == nil {
+				t.Errorf("[%d] Slice didn't return an expected error", i)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("[%d] failed: %s", i, err)
+				continue
+			}
+			if !reflect.DeepEqual(result, c.want) {
+				t.Errorf("[%d] got '%s' but expected '%s'", i, result, c.want)
+			}
+		}
+	}
+
+	// Too many arguments
+	_, err = truncate(10, " ...", "I am a test sentence", "wrong")
+	if err == nil {
+		t.Errorf("Should have errored")
+	}
+
+}

--- a/tpl/template_func_truncate_test.go
+++ b/tpl/template_func_truncate_test.go
@@ -38,6 +38,7 @@ func TestTruncate(t *testing.T) {
 		{10, template.HTML("<p>IamanextremelylongwordthatjustgoesonandonandonjusttoannoyyoualmostasifIwaswritteninGermanActuallyIbettheresagermanwordforthis</p>"), nil, template.HTML("<p>Iamanextre …</p>"), false},
 		{13, template.HTML("With <a href=\"/markdown\">Markdown</a> inside."), nil, template.HTML("With <a href=\"/markdown\">Markdown …</a>"), false},
 		{14, "Hello中国 Good 好的", nil, template.HTML("Hello中国 Good 好 …"), false},
+		{15, "", template.HTML("A <br> tag that's not closed"), template.HTML("A <br> tag that's"), false},
 		{14, template.HTML("<p>Hello中国 Good 好的</p>"), nil, template.HTML("<p>Hello中国 Good 好 …</p>"), false},
 		{10, nil, nil, template.HTML(""), true},
 		{nil, nil, nil, template.HTML(""), true},

--- a/tpl/template_func_truncate_test.go
+++ b/tpl/template_func_truncate_test.go
@@ -16,6 +16,7 @@ package tpl
 import (
 	"html/template"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -41,6 +42,9 @@ func TestTruncate(t *testing.T) {
 		{15, "", template.HTML("A <br> tag that's not closed"), template.HTML("A <br> tag that's"), false},
 		{14, template.HTML("<p>Hello中国 Good 好的</p>"), nil, template.HTML("<p>Hello中国 Good 好 …</p>"), false},
 		{2, template.HTML("<p>P1</p><p>P2</p>"), nil, template.HTML("<p>P1 …</p>"), false},
+		{3, template.HTML(strings.Repeat("<p>P</p>", 20)), nil, template.HTML("<p>P</p><p>P</p><p>P …</p>"), false},
+		{18, template.HTML("<p>test <b>hello</b> test something</p>"), nil, template.HTML("<p>test <b>hello</b> test …</p>"), false},
+		{4, template.HTML("<p>a<b><i>b</b>c d e</p>"), nil, template.HTML("<p>a<b><i>b</b>c …</p>"), false},
 		{10, nil, nil, template.HTML(""), true},
 		{nil, nil, nil, template.HTML(""), true},
 	}

--- a/tpl/template_func_truncate_test.go
+++ b/tpl/template_func_truncate_test.go
@@ -40,6 +40,7 @@ func TestTruncate(t *testing.T) {
 		{14, "Hello中国 Good 好的", nil, template.HTML("Hello中国 Good 好 …"), false},
 		{15, "", template.HTML("A <br> tag that's not closed"), template.HTML("A <br> tag that's"), false},
 		{14, template.HTML("<p>Hello中国 Good 好的</p>"), nil, template.HTML("<p>Hello中国 Good 好 …</p>"), false},
+		{2, template.HTML("<p>P1</p><p>P2</p>"), nil, template.HTML("<p>P1 …</p>"), false},
 		{10, nil, nil, template.HTML(""), true},
 		{nil, nil, nil, template.HTML(""), true},
 	}

--- a/tpl/template_funcs.go
+++ b/tpl/template_funcs.go
@@ -38,7 +38,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unicode"
 	"unicode/utf8"
 
 	"github.com/bep/inflect"
@@ -56,14 +55,7 @@ import (
 )
 
 var (
-	funcMap      template.FuncMap
-	tagRE        = regexp.MustCompile(`(?s)<(/)?([^ ]+?)(?:(\s*/)| .*?)?>`)
-	htmlRE       = regexp.MustCompile(`(?s)<.*?>|((?:\w[-\w]*|&.*?;)+)`)
-	htmlSinglets = map[string]bool{
-		"br": true, "col": true, "link": true,
-		"base": true, "img": true, "param": true,
-		"area": true, "hr": true, "input": true,
-	}
+	funcMap template.FuncMap
 )
 
 // eq returns the boolean truth of arg1 == arg2.
@@ -245,130 +237,6 @@ func slicestr(a interface{}, startEnd ...interface{}) (string, error) {
 		return string(asRunes[:]), nil
 	}
 
-}
-
-func truncate(a interface{}, options ...interface{}) (template.HTML, error) {
-	length, err := cast.ToIntE(a)
-	if err != nil {
-		return "", err
-	}
-	var textParam interface{}
-	var ellipsis template.HTML
-
-	switch len(options) {
-	case 0:
-		return "", errors.New("truncate requires a length and a string")
-	case 1:
-		textParam = options[0]
-		ellipsis = " …"
-	case 2:
-		textParam = options[1]
-		var ok bool
-		if ellipsis, ok = options[0].(template.HTML); !ok {
-			s, e := cast.ToStringE(options[0])
-			if e != nil {
-				return "", errors.New("ellipsis must be a string")
-			}
-			ellipsis = template.HTML(html.EscapeString(s))
-		}
-	default:
-		return "", errors.New("too many arguments passed to truncate")
-	}
-	if err != nil {
-		return "", errors.New("text to truncate must be a string")
-	}
-	text, err := cast.ToStringE(textParam)
-	if err != nil {
-		return "", errors.New("text must be a string")
-	}
-
-	if html, ok := textParam.(template.HTML); ok {
-		return truncateHTML(length, ellipsis, html)
-	}
-
-	if len(text) <= length {
-		return template.HTML(html.EscapeString(text)), nil
-	}
-
-	var lastWordIndex int
-	var lastNonSpace int
-	for i, r := range text {
-		if unicode.IsSpace(r) {
-			lastWordIndex = lastNonSpace
-		} else {
-			lastNonSpace = i
-		}
-		if i >= length {
-			return template.HTML(html.EscapeString(text[0:lastWordIndex+1])) + ellipsis, nil
-		}
-	}
-
-	return template.HTML(html.EscapeString(text)), nil
-}
-
-func truncateHTML(length int, ellipsis, text template.HTML) (template.HTML, error) {
-	if len(text) <= length {
-		return text, nil
-	}
-
-	var pos, endTextPos, currentLen int
-	openTags := []string{}
-
-	for currentLen < length {
-		slice := string(text[pos:])
-		m := htmlRE.FindStringSubmatchIndex(slice)
-		if len(m) == 0 {
-			// Checked through whole string
-			break
-		}
-
-		pos += m[1]
-		if len(m) == 4 && m[3]-m[2] > 0 {
-			// It's an actual non-HTML word or char
-			currentLen += (m[3] - m[2]) + 1 // 1 space between each word
-			if currentLen >= length {
-				endTextPos = pos
-			}
-			continue
-		}
-
-		tag := tagRE.FindStringSubmatch(slice[m[0]:m[1]])
-		if len(tag) == 0 || currentLen >= length {
-			// Don't worry about non tags or tags after our truncate point
-			continue
-		}
-		closingTag := tag[1]
-		tagname := strings.ToLower(tag[2])
-		selfClosing := tag[3]
-
-		_, singlet := htmlSinglets[tagname]
-		if !singlet && selfClosing == "" {
-			if closingTag == "" {
-				// Add it to the start of the open tags list
-				openTags = append([]string{tagname}, openTags...)
-			} else {
-				for i, tag := range openTags {
-					if tag == tagname {
-						// SGML: An end tag closes, back to the matching start tag,
-						// all unclosed intervening start tags with omitted end tags
-						openTags = openTags[i+1:]
-						break
-					}
-				}
-			}
-		}
-	}
-
-	if currentLen < length {
-		return text, nil
-	}
-
-	out := text[0:endTextPos]
-	out += ellipsis
-	for _, tag := range openTags {
-		out += ("</" + template.HTML(tag) + ">")
-	}
-	return out, nil
 }
 
 // hasPrefix tests whether the input s begins with prefix.

--- a/tpl/template_funcs_test.go
+++ b/tpl/template_funcs_test.go
@@ -158,7 +158,7 @@ title: {{title "Bat man"}}
 time: {{ (time "2015-01-21").Year }}
 trim: {{ trim "++Batman--" "+-" }}
 truncate: {{ "this is a very long text" | truncate 10 " ..." }}
-truncate: {{ "With [Markdown](/markdown) inside." | markdownify | truncate 10 }}
+truncate: {{ "With [Markdown](/markdown) inside." | markdownify | truncate 14 }}
 upper: {{upper "BatMan"}}
 urlize: {{ "Bat Man" | urlize }}
 `
@@ -817,57 +817,6 @@ func TestSlicestr(t *testing.T) {
 	if err == nil {
 		t.Errorf("Should have errored")
 	}
-}
-
-func TestTruncate(t *testing.T) {
-	var err error
-	cases := []struct {
-		v1    interface{}
-		v2    interface{}
-		v3    interface{}
-		want  interface{}
-		isErr bool
-	}{
-		{10, "I am a test sentence", nil, template.HTML("I am a …"), false},
-		{10, "", "I am a test sentence", template.HTML("I am a"), false},
-		{10, "", "a b c d e f g h i j k", template.HTML("a b c d e"), false},
-		{12, "", "<b>Should be escaped</b>", template.HTML("&lt;b&gt;Should be"), false},
-		{10, template.HTML(" <a href='#'>Read more</a>"), "I am a test sentence", template.HTML("I am a <a href='#'>Read more</a>"), false},
-		{10, template.HTML("I have a <a href='/markdown'>Markdown</a> link inside."), nil, template.HTML("I have a <a href='/markdown'>Markdown …</a>"), false},
-		{10, nil, nil, template.HTML(""), true},
-		{nil, nil, nil, template.HTML(""), true},
-	}
-	for i, c := range cases {
-		var result template.HTML
-		if c.v2 == nil {
-			result, err = truncate(c.v1)
-		} else if c.v3 == nil {
-			result, err = truncate(c.v1, c.v2)
-		} else {
-			result, err = truncate(c.v1, c.v2, c.v3)
-		}
-
-		if c.isErr {
-			if err == nil {
-				t.Errorf("[%d] Slice didn't return an expected error", i)
-			}
-		} else {
-			if err != nil {
-				t.Errorf("[%d] failed: %s", i, err)
-				continue
-			}
-			if !reflect.DeepEqual(result, c.want) {
-				t.Errorf("[%d] got '%s' but expected '%s'", i, result, c.want)
-			}
-		}
-	}
-
-	// Too many arguments
-	_, err = truncate(10, " ...", "I am a test sentence", "wrong")
-	if err == nil {
-		t.Errorf("Should have errored")
-	}
-
 }
 
 func TestHasPrefix(t *testing.T) {

--- a/tpl/template_funcs_test.go
+++ b/tpl/template_funcs_test.go
@@ -157,6 +157,8 @@ substr: {{substr "BatMan" 3 3}}
 title: {{title "Bat man"}}
 time: {{ (time "2015-01-21").Year }}
 trim: {{ trim "++Batman--" "+-" }}
+truncate: {{ "this is a very long text" | truncate 10 " ..." }}
+truncate: {{ "With [Markdown](/markdown) inside." | markdownify | truncate 10 }}
 upper: {{upper "BatMan"}}
 urlize: {{ "Bat Man" | urlize }}
 `
@@ -228,6 +230,8 @@ substr: Man
 title: Bat Man
 time: 2015
 trim: Batman
+truncate: this is a ...
+truncate: With <a href="/markdown">Markdown …</a>
 upper: BATMAN
 urlize: bat-man
 `
@@ -813,6 +817,57 @@ func TestSlicestr(t *testing.T) {
 	if err == nil {
 		t.Errorf("Should have errored")
 	}
+}
+
+func TestTruncate(t *testing.T) {
+	var err error
+	cases := []struct {
+		v1    interface{}
+		v2    interface{}
+		v3    interface{}
+		want  interface{}
+		isErr bool
+	}{
+		{10, "I am a test sentence", nil, template.HTML("I am a …"), false},
+		{10, "", "I am a test sentence", template.HTML("I am a"), false},
+		{10, "", "a b c d e f g h i j k", template.HTML("a b c d e"), false},
+		{12, "", "<b>Should be escaped</b>", template.HTML("&lt;b&gt;Should be"), false},
+		{10, template.HTML(" <a href='#'>Read more</a>"), "I am a test sentence", template.HTML("I am a <a href='#'>Read more</a>"), false},
+		{10, template.HTML("I have a <a href='/markdown'>Markdown</a> link inside."), nil, template.HTML("I have a <a href='/markdown'>Markdown …</a>"), false},
+		{10, nil, nil, template.HTML(""), true},
+		{nil, nil, nil, template.HTML(""), true},
+	}
+	for i, c := range cases {
+		var result template.HTML
+		if c.v2 == nil {
+			result, err = truncate(c.v1)
+		} else if c.v3 == nil {
+			result, err = truncate(c.v1, c.v2)
+		} else {
+			result, err = truncate(c.v1, c.v2, c.v3)
+		}
+
+		if c.isErr {
+			if err == nil {
+				t.Errorf("[%d] Slice didn't return an expected error", i)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("[%d] failed: %s", i, err)
+				continue
+			}
+			if !reflect.DeepEqual(result, c.want) {
+				t.Errorf("[%d] got '%s' but expected '%s'", i, result, c.want)
+			}
+		}
+	}
+
+	// Too many arguments
+	_, err = truncate(10, " ...", "I am a test sentence", "wrong")
+	if err == nil {
+		t.Errorf("Should have errored")
+	}
+
 }
 
 func TestHasPrefix(t *testing.T) {


### PR DESCRIPTION
This commit adds a truncate template function for safely truncating text without
breaking words. The truncate function is HTML aware, so if the input text is a
template.HTML it will be truncated without leaving broken or unclosed HTML tags.

    {{ "this is a very long text" | truncate 10 " ..." }}
    {{ "With [Markdown](/markdown) inside." | markdownify | truncate 10 }}

The HTML truncation is based on Django's truncatehtml template helper, so while I would normally be really cautious about doing anything regexp based with HTML, this is a very battle tested implementation. I've also tested it on a corpus of 2600+ blog posts from a large publication.


