### PR TITLE
Minor issue in htmlredirect.go - reservedNames in Windows - COM0 and LPT0 are also invalid on Windows 7

### DIFF
--- a/target/htmlredirect.go
+++ b/target/htmlredirect.go
@@ -70,7 +70,7 @@ func (h *HTMLRedirectAlias) Translate(alias string) (aliasPath string, err error
 	// See "Naming Files, Paths, and Namespaces" on MSDN
 	// https://msdn.microsoft.com/en-us/library/aa365247%28v=VS.85%29.aspx?f=255&MSPPError=-2147217396
 	msgs := []string{}
-	reservedNames := []string{"CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"}
+	reservedNames := []string{"CON", "PRN", "AUX", "NUL", "COM0", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"}
 
 	if strings.ContainsAny(alias, ":*?\"<>|") {
 		msgs = append(msgs, fmt.Sprintf("Alias \"%s\" contains invalid characters on Windows: : * ? \" < > |", originalAlias))


### PR DESCRIPTION
Fixes #2883 