### PR TITLE
hugolib: Correct usage of "shortcode" in error messages

### DIFF
--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -446,7 +446,7 @@ func handleShortcodes(p *Page, t tpl.Template, rawContentCopy []byte) ([]byte, e
 		rawContentCopy, err = replaceShortcodeTokens(rawContentCopy, shortcodePlaceholderPrefix, shortcodes)
 
 		if err != nil {
-			jww.FATAL.Printf("Failed to replace short code tokens in %s:\n%s", p.BaseFileName(), err.Error())
+			jww.FATAL.Printf("Failed to replace shortcode tokens in %s:\n%s", p.BaseFileName(), err.Error())
 		}
 	}
 

--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -167,7 +167,7 @@ func HandleShortcodes(stringToParse string, page *Page, t tpl.Template) (string,
 		tmpContentWithTokensReplaced, err := replaceShortcodeTokens([]byte(tmpContent), shortcodePlaceholderPrefix, shortcodes)
 
 		if err != nil {
-			return "", fmt.Errorf("Fail to replace short code tokens in %s:\n%s", page.BaseFileName(), err.Error())
+			return "", fmt.Errorf("Failed to replace shortcode tokens in %s:\n%s", page.BaseFileName(), err.Error())
 		}
 		return string(tmpContentWithTokensReplaced), nil
 	}

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -441,7 +441,7 @@ func TestExtractShortcodes(t *testing.T) {
 		if this.expectShortCodes != "" {
 			shortCodesAsStr := fmt.Sprintf("map%q", collectAndSortShortcodes(shortCodes))
 			if !strings.Contains(shortCodesAsStr, this.expectShortCodes) {
-				t.Fatalf("[%d] %s: Short codes not as expected, got %s but expected %s", i, this.name, shortCodesAsStr, this.expectShortCodes)
+				t.Fatalf("[%d] %s: Shortcodes not as expected, got %s but expected %s", i, this.name, shortCodesAsStr, this.expectShortCodes)
 			}
 		}
 	}


### PR DESCRIPTION
Corrects "shortcode" usage for error messages.

Fixes #2889.