### PR TITLE
show truncated error message instead of discarding it

### DIFF
--- a/tpl/template.go
+++ b/tpl/template.go
@@ -140,8 +140,12 @@ func (t *GoHTMLTemplate) executeTemplate(context interface{}, w io.Writer, layou
 
 		if templ != nil {
 			if err := templ.Execute(w, context); err != nil {
-				// Printing the err is spammy, see https://github.com/golang/go/issues/17414
-				helpers.DistinctErrorLog.Println(layout, "is an incomplete or empty template")
+				errmsg := err.Error()
+				// Clip overly long error messages, see https://github.com/golang/go/issues/17414
+				if len(errmsg) > 512 {
+					errmsg = errmsg[:512] + "..."
+				}
+				helpers.DistinctErrorLog.Println(layout, errmsg)
 			}
 			worked = true
 			break


### PR DESCRIPTION
As a followup [this discussion](https://discuss.gohugo.io/t/why-is-this-template-incomplete/5027/4), I'm proposing that when a template gets executed and produces an error, the error is logged with a limit of 512 bytes in length (that length is arbitrary, but I think it should be about right to accommodate most common errors without being screen-fulls of output).

Before this PR the code discards the error altogether, citing [this issue](https://github.com/golang/go/issues/17414) with the Go template engine.  The trouble is, there are a lot of other things that can go wrong, and the template author needs to be able to see what happened.  The issue above is talking about a specific individual error that can be reported by the template engine - but in many cases, this isn't the error being returned at all, it's something else, something the user needs to know.  In my case: `template: theme/partials/article_header.html:10:87: executing "theme/partials/article_header.html" at <.Site.Params.date_fo...>: invalid value; expected string`  Now I know I'm missing a Param that is supposed to be a string. Compare that to "...is an incomplete or empty template".

Using this PR, by simply logging the output, it told me in seconds what otherwise took me 45 minutes to debug.  My experience with Hugo is somewhat limited, but I've run into this problem a number of times and it greatly increases my frustration and the length of time required to debug, because something simple is going wrong but I can't tell what.  This PR fixes that, while still limiting the amount of output so it doesn't get overly verbose.  I think it solves both problems sufficiently (showing the important info, without being spammy).