### PR TITLE
hugolib: discard current language based on .Lang()

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -818,7 +818,7 @@ func (p *Page) IsTranslated() bool {
 func (p *Page) Translations() Pages {
 	translations := make(Pages, 0)
 	for _, t := range p.translations {
-		if t != p {
+		if t.Lang() != p.Lang() {
 			translations = append(translations, t)
 		}
 	}


### PR DESCRIPTION
Otherwise we fail to skip the current language in translations
for paginated pages.

Fixes #2972