### PR TITLE
hugolib: improve menu generation for section pages with content

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1460,7 +1460,7 @@ func (s *Site) assembleMenus() {
 	if sectionPagesMenu != "" {
 		// Create menu entries for section pages with content
 		for _, p := range pages {
-			if p.Section() != "" && p.Kind == KindSection {
+			if p.Kind == KindSection {
 				// menu with same id defined in config, let that one win
 				if _, ok := flat[twoD{sectionPagesMenu, p.Section()}]; ok {
 					continue

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1461,15 +1461,16 @@ func (s *Site) assembleMenus() {
 		// Create menu entries for section pages with content
 		for _, p := range pages {
 			if p.Section() != "" && p.Kind == KindSection {
+				// menu with same id defined in config, let that one win
+				if _, ok := flat[twoD{sectionPagesMenu, p.Section()}]; ok {
+					continue
+				}
+
 				me := MenuEntry{Identifier: p.Section(),
 					Name:   p.LinkTitle(),
 					Weight: p.Weight,
 					URL:    p.RelPermalink()}
 
-				// menu with same id defined in config, let that one win
-				if _, ok := flat[twoD{sectionPagesMenu, me.KeyName()}]; ok {
-					continue
-				}
 				flat[twoD{sectionPagesMenu, me.KeyName()}] = &me
 			}
 		}
@@ -1479,14 +1480,15 @@ func (s *Site) assembleMenus() {
 		for _, p := range pages {
 			if _, ok := sectionPagesMenus[p.Section()]; !ok {
 				if p.Section() != "" {
+					// menu with same id defined in config, let that one win
+					if _, ok := flat[twoD{sectionPagesMenu, p.Section()}]; ok {
+						continue
+					}
+
 					me := MenuEntry{Identifier: p.Section(),
 						Name: helpers.MakeTitle(helpers.FirstUpper(p.Section())),
 						URL:  s.Info.createNodeMenuEntryURL(p.addLangPathPrefix("/"+p.Section()) + "/")}
 
-					// menu with same id defined in config, let that one win
-					if _, ok := flat[twoD{sectionPagesMenu, me.KeyName()}]; ok {
-						continue
-					}
 					flat[twoD{sectionPagesMenu, me.KeyName()}] = &me
 					sectionPagesMenus[p.Section()] = true
 				}

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1446,6 +1446,7 @@ func (s *Site) assembleMenus() {
 	flat := map[twoD]*MenuEntry{}
 	children := map[twoD]Menu{}
 
+	// add menu entries from config to flat hash
 	menuConfig := s.getMenusFromConfig()
 	for name, menu := range menuConfig {
 		for _, me := range *menu {
@@ -1454,18 +1455,36 @@ func (s *Site) assembleMenus() {
 	}
 
 	sectionPagesMenu := s.Info.sectionPagesMenu
-	sectionPagesMenus := make(map[string]interface{})
-	//creating flat hash
 	pages := s.Pages
-	for _, p := range pages {
-		if sectionPagesMenu != "" {
+
+	if sectionPagesMenu != "" {
+		// Create menu entries for section pages with content
+		for _, p := range pages {
+			if p.Section() != "" && p.Kind == KindSection {
+				me := MenuEntry{Identifier: p.Section(),
+					Name:   p.LinkTitle(),
+					Weight: p.Weight,
+					URL:    p.RelPermalink()}
+
+				// menu with same id defined in config, let that one win
+				if _, ok := flat[twoD{sectionPagesMenu, me.KeyName()}]; ok {
+					continue
+				}
+				flat[twoD{sectionPagesMenu, me.KeyName()}] = &me
+			}
+		}
+
+		// Create entries for remaining content-less section pages
+		sectionPagesMenus := make(map[string]interface{})
+		for _, p := range pages {
 			if _, ok := sectionPagesMenus[p.Section()]; !ok {
 				if p.Section() != "" {
 					me := MenuEntry{Identifier: p.Section(),
 						Name: helpers.MakeTitle(helpers.FirstUpper(p.Section())),
 						URL:  s.Info.createNodeMenuEntryURL(p.addLangPathPrefix("/"+p.Section()) + "/")}
+
+					// menu with same id defined in config, let that one win
 					if _, ok := flat[twoD{sectionPagesMenu, me.KeyName()}]; ok {
-						// menu with same id defined in config, let that one win
 						continue
 					}
 					flat[twoD{sectionPagesMenu, me.KeyName()}] = &me
@@ -1473,7 +1492,10 @@ func (s *Site) assembleMenus() {
 				}
 			}
 		}
+	}
 
+	// Add menu entries provided by pages
+	for _, p := range pages {
 		for name, me := range p.Menus() {
 			if _, ok := flat[twoD{name, me.KeyName()}]; ok {
 				s.Log.ERROR.Printf("Two or more menu items have the same name/identifier in Menu %q: %q.\nRename or set an unique identifier.\n", name, me.KeyName())


### PR DESCRIPTION
When using the lazy blogger setting to automatically generate menu entries from section pages, we now recognize section pages that have content, and use the weight and linktitle configured in the frontmatter.

This way, we can use the lazy blogger automatic generation, and influence menu order and translations, directly from the frontmatter.

Fixes #2974