### PR TITLE
tpl: Remove twitter:domain tag from internal shortcode

### DIFF
--- a/tpl/tplimpl/template_embedded.go
+++ b/tpl/tplimpl/template_embedded.go
@@ -216,7 +216,6 @@ func (t *GoHTMLTemplate) EmbedTemplates() {
 <meta name="twitter:title" content="{{ .Title }}"/>
 <meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}"/>
 {{ with .Site.Social.twitter }}<meta name="twitter:site" content="@{{ . }}"/>{{ end }}
-{{ with .Site.Social.twitter_domain }}<meta name="twitter:domain" content="{{ . }}"/>{{ end }}
 {{ range .Site.Authors }}
   {{ with .twitter }}<meta name="twitter:creator" content="@{{ . }}"/>{{ end }}
 {{ end }}{{ end }}`)


### PR DESCRIPTION
It seems this metadata tag is no longer used by Twitter, as it has been removed from their official [Cards Markup Tag Reference](https://dev.twitter.com/cards/markup). There is a reference to this on the [W3 mailing list in 2013 as well](https://lists.w3.org/Archives/Public/www-validator/2013Oct/0025.html).

Users should remove `.Site.Social.twitter_domain` from their configuration as well.