### PR TITLE
Add ability to sort by frontmatter parameters

### DIFF
--- a/docs/content/templates/list.md
+++ b/docs/content/templates/list.md
@@ -237,6 +237,18 @@ your list templates:
     </li>
     {{ end }}
 
+### Order by Parameter
+Order based on the specified frontmatter parameter. Pages without that
+parameter will use the site's `.Site.Params` default. If the parameter is not
+found at all in some entries, those entries will appear together at the end
+of the ordering.
+
+The below example sorts a list of posts by their rating.
+
+    {{ range (.Data.Pages.ByParam "rating") }}
+      <!-- ... -->
+    {{ end }}
+
 ### Reverse Order
 Can be applied to any of the above. Using Date for an example.
 

--- a/hugolib/pageSort.go
+++ b/hugolib/pageSort.go
@@ -278,7 +278,7 @@ func (p Pages) Reverse() Pages {
 	return pages
 }
 
-func (p Pages) ByParam(paramsKeyStr string) Pages {
+func (p Pages) ByParam(paramsKey interface{}) Pages {
 	paramsKeyStr := cast.ToString(paramsKey)
 	key := "pageSort.ByParam." + paramsKeyStr
 

--- a/hugolib/pageSort.go
+++ b/hugolib/pageSort.go
@@ -288,6 +288,13 @@ func (p Pages) ByParam(paramsKey interface{}) Pages {
 		s1 := cast.ToString(v1)
 		s2 := cast.ToString(v2)
 
+		// Sort nils last.
+		if s1 == "" {
+			return false
+		} else if s2 == "" {
+			return true
+		}
+
 		return s1 < s2
 	}
 

--- a/hugolib/pageSort.go
+++ b/hugolib/pageSort.go
@@ -14,6 +14,7 @@
 package hugolib
 
 import (
+	"fmt"
 	"sort"
 )
 
@@ -272,6 +273,23 @@ func (p Pages) Reverse() Pages {
 	}
 
 	pages, _ := spc.get(key, p, reverseFunc)
+
+	return pages
+}
+
+func (p Pages) ByParam(paramsKeyStr string) Pages {
+	key := "pageSort.ByParam." + paramsKeyStr
+
+	paramsKeyComparator := func(p1, p2 *Page) bool {
+		v1, _ := p1.Param(paramsKeyStr)
+		v2, _ := p2.Param(paramsKeyStr)
+		s1 := fmt.Sprintf("%v", v1)
+		s2 := fmt.Sprintf("%v", v2)
+
+		return s1 < s2
+	}
+
+	pages, _ := spc.get(key, p, pageBy(paramsKeyComparator).Sort)
 
 	return pages
 }

--- a/hugolib/pageSort.go
+++ b/hugolib/pageSort.go
@@ -14,8 +14,9 @@
 package hugolib
 
 import (
-	"fmt"
 	"sort"
+
+	"github.com/spf13/cast"
 )
 
 var spc = newPageCache()
@@ -278,13 +279,14 @@ func (p Pages) Reverse() Pages {
 }
 
 func (p Pages) ByParam(paramsKeyStr string) Pages {
+	paramsKeyStr := cast.ToString(paramsKey)
 	key := "pageSort.ByParam." + paramsKeyStr
 
 	paramsKeyComparator := func(p1, p2 *Page) bool {
 		v1, _ := p1.Param(paramsKeyStr)
 		v2, _ := p2.Param(paramsKeyStr)
-		s1 := fmt.Sprintf("%v", v1)
-		s2 := fmt.Sprintf("%v", v2)
+		s1 := cast.ToString(v1)
+		s2 := cast.ToString(v2)
 
 		return s1 < s2
 	}

--- a/hugolib/pageSort_test.go
+++ b/hugolib/pageSort_test.go
@@ -113,6 +113,26 @@ func TestPageSortReverse(t *testing.T) {
 	assert.True(t, probablyEqualPages(p2, p1.Reverse()))
 }
 
+func TestPageSortByParam(t *testing.T) {
+	unsorted := createSortTestPages(10)
+	firstValue, _ := unsorted[0].Param("arbitrary")
+	secondValue, _ := unsorted[1].Param("arbitrary")
+	lastValue, _ := unsorted[9].Param("arbitrary")
+
+	assert.Equal(t, "xyz100", firstValue)
+	assert.Equal(t, "xyz99", secondValue)
+	assert.Equal(t, "xyz91", lastValue)
+
+	sorted := unsorted.ByParam("arbitrary")
+	firstSortedValue, _ := sorted[0].Param("arbitrary")
+	secondSortedValue, _ := sorted[1].Param("arbitrary")
+	lastSortedValue, _ := sorted[9].Param("arbitrary")
+
+	assert.Equal(t, firstValue, firstSortedValue)
+	assert.Equal(t, secondValue, lastSortedValue)
+	assert.Equal(t, lastValue, secondSortedValue)
+}
+
 func BenchmarkSortByWeightAndReverse(b *testing.B) {
 
 	p := createSortTestPages(300)
@@ -154,6 +174,9 @@ func createSortTestPages(num int) Pages {
 			},
 			Site:   &info,
 			Source: Source{File: *source.NewFile(filepath.FromSlash(fmt.Sprintf("/x/y/p%d.md", i)))},
+			Params: map[string]interface{}{
+				"arbitrary": "xyz" + fmt.Sprintf("%v", 100-i),
+			},
 		}
 		w := 5
 

--- a/hugolib/pageSort_test.go
+++ b/hugolib/pageSort_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/cast"
 	"github.com/spf13/hugo/helpers"
 	"github.com/spf13/hugo/source"
 	"github.com/stretchr/testify/assert"
@@ -114,23 +115,31 @@ func TestPageSortReverse(t *testing.T) {
 }
 
 func TestPageSortByParam(t *testing.T) {
-	unsorted := createSortTestPages(10)
-	firstValue, _ := unsorted[0].Param("arbitrary")
-	secondValue, _ := unsorted[1].Param("arbitrary")
-	lastValue, _ := unsorted[9].Param("arbitrary")
+	var k interface{} = "arbitrary"
 
-	assert.Equal(t, "xyz100", firstValue)
-	assert.Equal(t, "xyz99", secondValue)
-	assert.Equal(t, "xyz91", lastValue)
+	unsorted := createSortTestPages(10)
+	delete(unsorted[9].Params, cast.ToString(k))
+
+	firstSetValue, _ := unsorted[0].Param(k)
+	secondSetValue, _ := unsorted[1].Param(k)
+	lastSetValue, _ := unsorted[8].Param(k)
+	unsetValue, _ := unsorted[9].Param(k)
+
+	assert.Equal(t, "xyz100", firstSetValue)
+	assert.Equal(t, "xyz99", secondSetValue)
+	assert.Equal(t, "xyz92", lastSetValue)
+	assert.Equal(t, nil, unsetValue)
 
 	sorted := unsorted.ByParam("arbitrary")
-	firstSortedValue, _ := sorted[0].Param("arbitrary")
-	secondSortedValue, _ := sorted[1].Param("arbitrary")
-	lastSortedValue, _ := sorted[9].Param("arbitrary")
+	firstSetSortedValue, _ := sorted[0].Param(k)
+	secondSetSortedValue, _ := sorted[1].Param(k)
+	lastSetSortedValue, _ := sorted[8].Param(k)
+	unsetSortedValue, _ := sorted[9].Param(k)
 
-	assert.Equal(t, firstValue, firstSortedValue)
-	assert.Equal(t, secondValue, lastSortedValue)
-	assert.Equal(t, lastValue, secondSortedValue)
+	assert.Equal(t, firstSetValue, firstSetSortedValue)
+	assert.Equal(t, secondSetValue, lastSetSortedValue)
+	assert.Equal(t, lastSetValue, secondSetSortedValue)
+	assert.Equal(t, unsetValue, unsetSortedValue)
 }
 
 func BenchmarkSortByWeightAndReverse(b *testing.B) {


### PR DESCRIPTION
This allows users to sort by the value of a specified frontmatter key, including anything that would otherwise be available in `.Params`. Comparisons (and thus the resulting sorting) are done on a string basis, so, for example, `xyz123` comes before and not after `xyz23`.

This is useful for general-purpose sorting for which `weight` is either not sufficient or where it duplicates information that's already present in the frontmatter. See discussions [here](https://discuss.gohugo.io/t/can-a-sections-pages-be-sorted-by-arbitrary-frontmatter-variables/5358).

If the committers are happy with this implementation, I'll also add the correspondingly necessary documentation for this feature.