### PR TITLE
Use Page.Params more consistently when adding metadata

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -919,29 +919,37 @@ func (p *Page) update(f interface{}) error {
 		switch loki {
 		case "title":
 			p.Title = cast.ToString(v)
+			p.Params[loki] = p.Title
 		case "linktitle":
 			p.linkTitle = cast.ToString(v)
+			p.Params[loki] = p.linkTitle
 		case "description":
 			p.Description = cast.ToString(v)
-			p.Params["description"] = p.Description
+			p.Params[loki] = p.Description
 		case "slug":
 			p.Slug = cast.ToString(v)
+			p.Params[loki] = p.Slug
 		case "url":
 			if url := cast.ToString(v); strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
 				return fmt.Errorf("Only relative URLs are supported, %v provided", url)
 			}
 			p.URLPath.URL = cast.ToString(v)
+			p.Params[loki] = p.URLPath.URL
 		case "type":
 			p.contentType = cast.ToString(v)
+			p.Params[loki] = p.contentType
 		case "extension", "ext":
 			p.extension = cast.ToString(v)
+			p.Params[loki] = p.extension
 		case "keywords":
 			p.Keywords = cast.ToStringSlice(v)
+			p.Params[loki] = p.Keywords
 		case "date":
 			p.Date, err = cast.ToTimeE(v)
 			if err != nil {
 				p.s.Log.ERROR.Printf("Failed to parse date '%v' in page %s", v, p.File.Path())
 			}
+			p.Params[loki] = p.Date
 		case "lastmod":
 			p.Lastmod, err = cast.ToTimeE(v)
 			if err != nil {
@@ -965,10 +973,13 @@ func (p *Page) update(f interface{}) error {
 			*published = cast.ToBool(v)
 		case "layout":
 			p.Layout = cast.ToString(v)
+			p.Params[loki] = p.Layout
 		case "markup":
 			p.Markup = cast.ToString(v)
+			p.Params[loki] = p.Markup
 		case "weight":
 			p.Weight = cast.ToInt(v)
+			p.Params[loki] = p.Weight
 		case "aliases":
 			p.Aliases = cast.ToStringSlice(v)
 			for _, alias := range p.Aliases {
@@ -976,10 +987,13 @@ func (p *Page) update(f interface{}) error {
 					return fmt.Errorf("Only relative aliases are supported, %v provided", alias)
 				}
 			}
+			p.Params[loki] = p.Aliases
 		case "status":
 			p.Status = cast.ToString(v)
+			p.Params[loki] = p.Status
 		case "sitemap":
 			p.Sitemap = parseSitemap(cast.ToStringMap(v))
+			p.Params[loki] = p.Sitemap
 		case "iscjklanguage":
 			isCJKLanguage = new(bool)
 			*isCJKLanguage = cast.ToBool(v)
@@ -1034,17 +1048,20 @@ func (p *Page) update(f interface{}) error {
 	} else if published != nil {
 		p.Draft = !*published
 	}
+	p.Params["draft"] = p.Draft
 
 	if p.Date.IsZero() && p.s.Cfg.GetBool("useModTimeAsFallback") {
 		fi, err := p.s.Fs.Source.Stat(filepath.Join(p.s.PathSpec.AbsPathify(p.s.Cfg.GetString("contentDir")), p.File.Path()))
 		if err == nil {
 			p.Date = fi.ModTime()
+			p.Params["date"] = p.Date
 		}
 	}
 
 	if p.Lastmod.IsZero() {
 		p.Lastmod = p.Date
 	}
+	p.Params["lastmod"] = p.Lastmod
 
 	if isCJKLanguage != nil {
 		p.isCJKLanguage = *isCJKLanguage
@@ -1055,6 +1072,7 @@ func (p *Page) update(f interface{}) error {
 			p.isCJKLanguage = false
 		}
 	}
+	p.Params["iscjklanguage"] = p.isCJKLanguage
 
 	return nil
 

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -1336,7 +1336,7 @@ some content
 func TestPageParams(t *testing.T) {
 	t.Parallel()
 	s := newTestSite(t)
-	want := map[string]interface{}{
+	wantedMap := map[string]interface{}{
 		"tags": []string{"hugo", "web"},
 		// Issue #2752
 		"social": []interface{}{
@@ -1348,7 +1348,9 @@ func TestPageParams(t *testing.T) {
 	for i, c := range pagesParamsTemplate {
 		p, err := s.NewPageFrom(strings.NewReader(c), "content/post/params.md")
 		require.NoError(t, err, "err during parse", "#%d", i)
-		assert.Equal(t, want, p.Params, "#%d", i)
+		for key, _ := range wantedMap {
+			assert.Equal(t, wantedMap[key], p.Params[key], "#%d", key)
+		}
 	}
 }
 


### PR DESCRIPTION
Right now, `.Params` is documented as being "everything you put into the frontmatter, except for a long list of specific variables". In particular, values which are otherwise subsumed by `Page` fields generally don't wind up in `.Params`. But this has exceptions -- for instance, `Description` is both a `Page` field and will be present in `Params`, even though the documentation says it _won't_ be present in `Params`.

The net result is that it's a little confusing and inconsistent about what does or does not wind up in `Params`.

This problem makes it difficult to use certain other Hugo functions in your templates. For example, one cannot do `{{ .Param "date" }}` because there is no `date` stored in `Params`, even though `date` is in your frontmatter. That means that if you invoke such values dynamically, e.g., `{{ .Param $k }}`, you can't be sure if it will work, even if `$k` is the name of a valid key in your frontmatter.

I think a more consistent and less surprising result is that `Params` should match your frontmatter as closely as possible. This PR attempts to fix this by making sure such assignments always happen.