### PR TITLE
Enhance `.Param` to permit arbitrarily nested parameter references

### DIFF
--- a/docs/content/templates/list.md
+++ b/docs/content/templates/list.md
@@ -250,7 +250,7 @@ The below example sorts a list of posts by their rating.
       <!-- ... -->
     {{ end }}
 
-If the frontmatter field of interest is nested beneath another field you can
+If the frontmatter field of interest is nested beneath another field, you can
 also get it:
 
     {{ range (.Date.Pages.ByParam "author.last_name") }}

--- a/docs/content/templates/list.md
+++ b/docs/content/templates/list.md
@@ -238,6 +238,7 @@ your list templates:
     {{ end }}
 
 ### Order by Parameter
+
 Order based on the specified frontmatter parameter. Pages without that
 parameter will use the site's `.Site.Params` default. If the parameter is not
 found at all in some entries, those entries will appear together at the end
@@ -246,6 +247,13 @@ of the ordering.
 The below example sorts a list of posts by their rating.
 
     {{ range (.Data.Pages.ByParam "rating") }}
+      <!-- ... -->
+    {{ end }}
+
+If the frontmatter field of interest is nested beneath another field you can
+also get it:
+
+    {{ range (.Date.Pages.ByParam "author.last_name") }}
       <!-- ... -->
     {{ end }}
 

--- a/docs/content/templates/variables.md
+++ b/docs/content/templates/variables.md
@@ -103,10 +103,55 @@ which would render
 **See also:** [Archetypes]({{% ref "content/archetypes.md" %}}) for consistency of `Params` across pieces of content.
 
 ### Param method
-In Hugo you can declare params both for the site and the individual page.  A common use case is to have a general value for the site and a more specific value for some of the pages (i.e. an image).
+
+In Hugo you can declare params both for the site and the individual page. A
+common use case is to have a general value for the site and a more specific
+value for some of the pages (i.e. a header image):
+
 ```
-$.Param "image"
+{{ $.Param "header_image" }}
 ```
+
+Thee `.Param` method provides a way to resolve a single value whether it's
+in a page parameter or a site parameter.
+
+When frontmatter contains nested fields, like:
+
+```
+---
+author:
+  given_name: John
+  family_name: Feminella
+  display_name: John Feminella
+---
+```
+
+then `.Param` can access them by concatenating the field names together with a
+dot:
+
+```
+{{ $.Param "author.display_name" }}
+```
+
+If your frontmatter contains a top-level key that is ambiguous with a nested
+key, as in the following case,
+
+```
+---
+favorites.flavor: vanilla
+favorites:
+  flavor: chocolate
+---
+```
+
+then the top-level key will be preferred. In the previous example, this
+
+```
+{{ $.Param "favorites.flavor" }}
+```
+
+will print `vanilla`, not `chocolate`.
+
 ### Taxonomy Terms Page Variables
 
 [Taxonomy Terms](/templates/terms/) pages are of the type `Page` and have the following additional variables. These are available in `layouts/_defaults/terms.html` for example.

--- a/docs/content/templates/variables.md
+++ b/docs/content/templates/variables.md
@@ -112,7 +112,7 @@ value for some of the pages (i.e. a header image):
 {{ $.Param "header_image" }}
 ```
 
-Thee `.Param` method provides a way to resolve a single value whether it's
+The `.Param` method provides a way to resolve a single value whether it's
 in a page parameter or a site parameter.
 
 When frontmatter contains nested fields, like:

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -324,14 +324,9 @@ func (p *Page) Param(key interface{}) (interface{}, error) {
 	keySegments := strings.Split(keyStr, ".")
 	if len(keySegments) == 1 {
 		return nil, nil
-	} else {
-		result, _ = p.traverseNested(keySegments)
-		if result != nil {
-			return result, nil
-		}
 	}
 
-	return nil, nil
+	return p.traverseNested(keySegments)
 }
 
 func (p *Page) traverseDirect(key string) (interface{}, error) {

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -322,9 +322,13 @@ func (p *Page) Param(key interface{}) (interface{}, error) {
 	}
 
 	keySegments := strings.Split(keyStr, ".")
-	result, _ = p.traverseNested(keySegments)
-	if result != nil {
-		return result, nil
+	if len(keySegments) == 1 {
+		return nil, nil
+	} else {
+		result, _ = p.traverseNested(keySegments)
+		if result != nil {
+			return result, nil
+		}
 	}
 
 	return nil, nil
@@ -340,13 +344,13 @@ func (p *Page) traverseDirect(key string) (interface{}, error) {
 }
 
 func (p *Page) traverseNested(keySegments []string) (interface{}, error) {
-	result, err := traverse(keySegments, p.Params)
-	if err == nil {
+	result := traverse(keySegments, p.Params)
+	if result != nil {
 		return result, nil
 	}
 
-	result, err = traverse(keySegments, p.Site.Params)
-	if err == nil {
+	result = traverse(keySegments, p.Site.Params)
+	if result != nil {
 		return result, nil
 	}
 
@@ -354,19 +358,19 @@ func (p *Page) traverseNested(keySegments []string) (interface{}, error) {
 	return nil, nil
 }
 
-func traverse(keys []string, m map[string]interface{}) (interface{}, error) {
+func traverse(keys []string, m map[string]interface{}) interface{} {
 	// Shift first element off.
 	firstKey, rest := keys[0], keys[1:]
 	result := m[firstKey]
 
 	// No point in continuing here.
 	if result == nil {
-		return result, fmt.Errorf("no such key: " + fmt.Sprintf("%v", firstKey))
+		return result
 	}
 
 	if len(rest) == 0 {
 		// That was the last key.
-		return result, nil
+		return result
 	} else {
 		// That was not the last key.
 		return traverse(rest, cast.ToStringMap(result))

--- a/hugolib/pageSort.go
+++ b/hugolib/pageSort.go
@@ -16,7 +16,6 @@ package hugolib
 import (
 	"github.com/spf13/cast"
 	"sort"
-	"strings"
 )
 
 var spc = newPageCache()
@@ -281,11 +280,10 @@ func (p Pages) Reverse() Pages {
 func (p Pages) ByParam(paramsKey interface{}) Pages {
 	paramsKeyStr := cast.ToString(paramsKey)
 	key := "pageSort.ByParam." + paramsKeyStr
-	keys := strings.Split(paramsKeyStr, ".")
 
 	paramsKeyComparator := func(p1, p2 *Page) bool {
-		v1, _ := p1.Traverse(keys)
-		v2, _ := p2.Traverse(keys)
+		v1, _ := p1.Param(paramsKeyStr)
+		v2, _ := p2.Param(paramsKeyStr)
 		s1 := cast.ToString(v1)
 		s2 := cast.ToString(v2)
 

--- a/hugolib/pageSort.go
+++ b/hugolib/pageSort.go
@@ -14,9 +14,9 @@
 package hugolib
 
 import (
-	"sort"
-
 	"github.com/spf13/cast"
+	"sort"
+	"strings"
 )
 
 var spc = newPageCache()
@@ -281,10 +281,11 @@ func (p Pages) Reverse() Pages {
 func (p Pages) ByParam(paramsKey interface{}) Pages {
 	paramsKeyStr := cast.ToString(paramsKey)
 	key := "pageSort.ByParam." + paramsKeyStr
+	keys := strings.Split(paramsKeyStr, ".")
 
 	paramsKeyComparator := func(p1, p2 *Page) bool {
-		v1, _ := p1.Param(paramsKeyStr)
-		v2, _ := p2.Param(paramsKeyStr)
+		v1, _ := p1.Traverse(keys)
+		v2, _ := p2.Traverse(keys)
 		s1 := cast.ToString(v1)
 		s2 := cast.ToString(v2)
 

--- a/hugolib/pageSort_test.go
+++ b/hugolib/pageSort_test.go
@@ -20,9 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spf13/cast"
-	"github.com/spf13/hugo/helpers"
-	"github.com/spf13/hugo/source"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -183,18 +180,9 @@ func createSortTestPages(s *Site, num int) Pages {
 
 	for i := 0; i < num; i++ {
 		p := s.newPage(filepath.FromSlash(fmt.Sprintf("/x/y/p%d.md", i)))
-		pages[i] = &Page{
-			pageInit: &pageInit{},
-			URLPath: URLPath{
-				Section: "z",
-				URL:     fmt.Sprintf("http://base/x/y/p%d.html", i),
-			},
-			Site:   &info,
-			Source: Source{File: *source.NewFile(filepath.FromSlash(fmt.Sprintf("/x/y/p%d.md", i)))},
-			Params: map[string]interface{}{
-				"arbitrarily": map[string]interface{}{
-					"nested": ("xyz" + fmt.Sprintf("%v", 100-i)),
-				},
+		p.Params = map[string]interface{}{
+			"arbitrarily": map[string]interface{}{
+				"nested": ("xyz" + fmt.Sprintf("%v", 100-i)),
 			},
 		}
 

--- a/hugolib/pageSort_test.go
+++ b/hugolib/pageSort_test.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"github.com/spf13/cast"
+	"github.com/spf13/hugo/helpers"
+	"github.com/spf13/hugo/source"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -121,11 +123,11 @@ func TestPageSortReverse(t *testing.T) {
 
 func TestPageSortByParam(t *testing.T) {
 	t.Parallel()
-	var k interface{} = "arbitrary"
+	var k interface{} = "arbitrarily.nested"
 	s := newTestSite(t)
 
 	unsorted := createSortTestPages(s, 10)
-	delete(unsorted[9].Params, cast.ToString(k))
+	delete(unsorted[9].Params, "arbitrarily")
 
 	firstSetValue, _ := unsorted[0].Param(k)
 	secondSetValue, _ := unsorted[1].Param(k)
@@ -137,7 +139,7 @@ func TestPageSortByParam(t *testing.T) {
 	assert.Equal(t, "xyz92", lastSetValue)
 	assert.Equal(t, nil, unsetValue)
 
-	sorted := unsorted.ByParam("arbitrary")
+	sorted := unsorted.ByParam("arbitrarily.nested")
 	firstSetSortedValue, _ := sorted[0].Param(k)
 	secondSetSortedValue, _ := sorted[1].Param(k)
 	lastSetSortedValue, _ := sorted[8].Param(k)
@@ -181,8 +183,19 @@ func createSortTestPages(s *Site, num int) Pages {
 
 	for i := 0; i < num; i++ {
 		p := s.newPage(filepath.FromSlash(fmt.Sprintf("/x/y/p%d.md", i)))
-		p.Params = map[string]interface{}{
-			"arbitrary": "xyz" + fmt.Sprintf("%v", 100-i),
+		pages[i] = &Page{
+			pageInit: &pageInit{},
+			URLPath: URLPath{
+				Section: "z",
+				URL:     fmt.Sprintf("http://base/x/y/p%d.html", i),
+			},
+			Site:   &info,
+			Source: Source{File: *source.NewFile(filepath.FromSlash(fmt.Sprintf("/x/y/p%d.md", i)))},
+			Params: map[string]interface{}{
+				"arbitrarily": map[string]interface{}{
+					"nested": ("xyz" + fmt.Sprintf("%v", 100-i)),
+				},
+			},
 		}
 
 		w := 5

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -1336,7 +1336,7 @@ some content
 func TestPageParams(t *testing.T) {
 	t.Parallel()
 	s := newTestSite(t)
-	want := map[string]interface{}{
+	wantedMap := map[string]interface{}{
 		"tags": []string{"hugo", "web"},
 		// Issue #2752
 		"social": []interface{}{
@@ -1348,8 +1348,35 @@ func TestPageParams(t *testing.T) {
 	for i, c := range pagesParamsTemplate {
 		p, err := s.NewPageFrom(strings.NewReader(c), "content/post/params.md")
 		require.NoError(t, err, "err during parse", "#%d", i)
-		assert.Equal(t, want, p.Params, "#%d", i)
+		for key, _ := range wantedMap {
+			assert.Equal(t, wantedMap[key], p.Params[key], "#%d", key)
+		}
 	}
+}
+
+func TestTraverse(t *testing.T) {
+	exampleParams := `---
+rating: "5 stars"
+tags:
+  - hugo
+  - web
+social:
+  twitter: "@jxxf"
+  facebook: "https://example.com"
+---`
+	t.Parallel()
+	s := newTestSite(t)
+	p, _ := s.NewPageFrom(strings.NewReader(exampleParams), "content/post/params.md")
+	fmt.Println("%v", p.Params)
+
+	topLevelKeyValue, _ := p.Param("rating")
+	assert.Equal(t, "5 stars", topLevelKeyValue)
+
+	nestedStringKeyValue, _ := p.Param("social.twitter")
+	assert.Equal(t, "@jxxf", nestedStringKeyValue)
+
+	nonexistentKeyValue, _ := p.Param("doesn't.exist")
+	assert.Nil(t, nonexistentKeyValue)
 }
 
 func TestPageSimpleMethods(t *testing.T) {


### PR DESCRIPTION
Currently, the only way to access params with nested keys is to be explicit and static:

    {{ .Params.author.favorites.color }}

This, for example, doesn't work:

    {{ $k := "author.favorites.color" }}
    {{ .Param $k }} // Param doesn't understand nesting.

This doesn't work either:

    {{ $k := slice "author" "favorites" "color" }}
    {{ index .Param $k... }} // Go templates don't understand variadic args.

What would be ideal is to be able to say something like:

    {{ $k := slice "author" "favorites" "color" }}
    {{ .Param $k }}

and have it traverse the `Page.Params` and `Site.Params` maps.

This PR introduces a bound function, `Page.Traverse`, that produces these results. It has behavior identical to `Page.Param`, but it will traverse a map to an arbitrary depth instead of to just the first level, and it accepts a `[]string` instead of a single `interface{}`. If a key is specified that does not exist, `nil` is returned instead; this is not considered a panic-worthy error.

If we'd rather that this behavior be subsumed into `.Param` directly in lieu of a separate function, I'm happy to do that and to amend the commits accordingly. Either way, if we believe this is useful, I will also be happy to document accordingly.