### PR TITLE
hugolib: Make RSS item limit configurable

### DIFF
--- a/docs/content/overview/configuration.md
+++ b/docs/content/overview/configuration.md
@@ -171,6 +171,8 @@ along with their current, default values:
     pygmentsStyle:              "monokai"
     # true: use pygments-css or false: color-codes directly
     pygmentsUseClasses:         false
+    # maximum number of items in the RSS feed
+    rssLimit:                   15
     # default sitemap configuration map
     sitemap:
     # filesystem path to read files relative from

--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -102,6 +102,7 @@ func loadDefaultSettingsFor(v *viper.Viper) {
 	v.SetDefault("paginatePath", "page")
 	v.SetDefault("blackfriday", c.NewBlackfriday())
 	v.SetDefault("rSSUri", "index.xml")
+	v.SetDefault("rssLimit", 15)
 	v.SetDefault("sectionPagesMenu", "")
 	v.SetDefault("disablePathToLower", false)
 	v.SetDefault("hasCJKLanguage", false)

--- a/hugolib/rss_test.go
+++ b/hugolib/rss_test.go
@@ -15,6 +15,7 @@ package hugolib
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/hugo/deps"
@@ -27,11 +28,14 @@ func TestRSSOutput(t *testing.T) {
 		th      = testHelper{cfg}
 	)
 
+	rssLimit := len(weightedSources) - 1
+
 	rssURI := "customrss.xml"
 
 	cfg.Set("baseURL", "http://auth/bub/")
 	cfg.Set("rssURI", rssURI)
 	cfg.Set("title", "RSSTest")
+	cfg.Set("rssLimit", rssLimit)
 
 	for _, src := range weightedSources {
 		writeSource(t, fs, filepath.Join("content", "sect", src.Name), string(src.Content))
@@ -46,4 +50,10 @@ func TestRSSOutput(t *testing.T) {
 	// Taxonomy RSS
 	th.assertFileContent(t, fs, filepath.Join("public", "categories", "hugo", rssURI), true, "<?xml", "rss version", "Hugo on RSSTest")
 
+	// RSS Item Limit
+	content := readDestination(t, fs, filepath.Join("public", rssURI))
+	c := strings.Count(content, "<item>")
+	if c != rssLimit {
+		t.Errorf("incorrect RSS item count: expected %d, got %d", rssLimit, c)
+	}
 }

--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -152,9 +152,9 @@ func (s *Site) renderRSS(p *Page) error {
 		rssPage.Date = zeroDate
 	}
 
-	high := 50
-	if len(rssPage.Pages) > high {
-		rssPage.Pages = rssPage.Pages[:high]
+	limit := s.Cfg.GetInt("rssLimit")
+	if len(rssPage.Pages) > limit {
+		rssPage.Pages = rssPage.Pages[:limit]
 		rssPage.Data["Pages"] = rssPage.Pages
 	}
 	rssURI := s.Language.GetString("rssURI")

--- a/tpl/tplimpl/template_embedded.go
+++ b/tpl/tplimpl/template_embedded.go
@@ -77,7 +77,7 @@ func (t *GoHTMLTemplate) EmbedTemplates() {
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     <atom:link href="{{.Permalink}}" rel="self" type="application/rss+xml" />
-    {{ range first 15 .Data.Pages }}
+    {{ range .Data.Pages }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>


### PR DESCRIPTION
Add a new rssLimit site configuration option with default of 15.  Prior
to this fix, you could create your own RSS feed to override the default
limit of 15, but we still had a hardcoded limit of 50 items set in
`hugolib.renderRSS()`.

With this option in place, the `range first 15 .Data.Pages` logic is no
longer hardcoded into the embedded RSS template.

Because the size of the slice passed to the template is now limited to
rssLimit instead of 50, this commit is a breaking change for sites
with a custom RSS template that expects more than 15 items.

Fixes #3035