### PR TITLE
hugolib: Fix .Site.LastChange

### DIFF
--- a/hugolib/hugo_sites_build.go
+++ b/hugolib/hugo_sites_build.go
@@ -168,7 +168,7 @@ func (h *HugoSites) assemble(config *BuildCfg) error {
 
 	for _, s := range h.Sites {
 		s.refreshPageCaches()
-		s.setupPrevNext()
+		s.setupSitePages()
 	}
 
 	if err := h.assignMissingTranslations(); err != nil {

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -821,7 +821,9 @@ func (s *Site) process(config BuildCfg) (err error) {
 
 }
 
-func (s *Site) setupPrevNext() {
+func (s *Site) setupSitePages() {
+	var siteLastChange time.Time
+
 	for i, page := range s.Pages {
 		if i < len(s.Pages)-1 {
 			page.Next = s.Pages[i+1]
@@ -830,7 +832,18 @@ func (s *Site) setupPrevNext() {
 		if i > 0 {
 			page.Prev = s.Pages[i-1]
 		}
+
+		// Determine Site.Info.LastChange
+		// Note that the logic to determine which date to use for Lastmod
+		// is already applied, so this is *the* date to use.
+		// We cannot just pick the last page in the default sort, because
+		// that may not be ordered by date.
+		if page.Lastmod.After(siteLastChange) {
+			siteLastChange = page.Lastmod
+		}
 	}
+
+	s.Info.LastChange = siteLastChange
 }
 
 func (s *Site) render() (err error) {
@@ -1370,8 +1383,6 @@ func (s *Site) buildSiteMeta() (err error) {
 	s.assembleSections()
 
 	s.assembleMenus()
-
-	s.Info.LastChange = s.Pages[0].Lastmod
 
 	return
 }

--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -184,6 +184,23 @@ func TestFutureExpirationRender(t *testing.T) {
 	}
 }
 
+func TestLastChange(t *testing.T) {
+	t.Parallel()
+
+	cfg, fs := newTestCfg()
+
+	writeSource(t, fs, filepath.Join("content", "sect/doc1.md"), "---\ntitle: doc1\nweight: 1\ndate: 2014-05-29\n---\n# doc1\n*some content*")
+	writeSource(t, fs, filepath.Join("content", "sect/doc2.md"), "---\ntitle: doc2\nweight: 2\ndate: 2015-05-29\n---\n# doc2\n*some content*")
+	writeSource(t, fs, filepath.Join("content", "sect/doc3.md"), "---\ntitle: doc3\nweight: 3\ndate: 2017-05-29\n---\n# doc3\n*some content*")
+	writeSource(t, fs, filepath.Join("content", "sect/doc4.md"), "---\ntitle: doc4\nweight: 4\ndate: 2016-05-29\n---\n# doc4\n*some content*")
+	writeSource(t, fs, filepath.Join("content", "sect/doc5.md"), "---\ntitle: doc5\nweight: 3\n---\n# doc5\n*some content*")
+
+	s := buildSingleSite(t, deps.DepsCfg{Fs: fs, Cfg: cfg}, BuildCfg{SkipRender: true})
+
+	require.False(t, s.Info.LastChange.IsZero(), "Site.LastChange is zero")
+	require.Equal(t, 2017, s.Info.LastChange.Year(), "Site.LastChange should be set to the page with latest Lastmod (year 2017)")
+}
+
 // Issue #957
 func TestCrossrefs(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
This commit makes sure that the `.Site.LastChange` is fetched from the latest page modification date.

Previously, this value was fetched from the last page in the default page sort, which may not be the last by date if weight is set.

Fixes #2909
Closes #2910