### PR TITLE
Get rid of some viper.Get* calls

### DIFF
--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -95,7 +95,7 @@ func applyDepsIfNeeded(cfg deps.DepsCfg, sites ...*Site) error {
 			d = deps.New(cfg)
 			s.Deps = d
 
-			if err := d.LoadResources(); err != nil {
+			if err = d.LoadResources(); err != nil {
 				return err
 			}
 
@@ -123,9 +123,9 @@ func NewHugoSites(cfg deps.DepsCfg) (*HugoSites, error) {
 
 func (s *Site) withSiteTemplates(withTemplates ...func(templ tpl.Template) error) func(templ tpl.Template) error {
 	return func(templ tpl.Template) error {
-		templ.LoadTemplates(s.absLayoutDir())
-		if s.hasTheme() {
-			templ.LoadTemplatesWithPrefix(s.absThemeDir()+"/layouts", "theme")
+		templ.LoadTemplates(s.PathSpec.GetLayoutDirPath())
+		if s.PathSpec.ThemeSet() {
+			templ.LoadTemplatesWithPrefix(s.PathSpec.GetThemeDir()+"/layouts", "theme")
 		}
 
 		for _, wt := range withTemplates {

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -929,7 +929,7 @@ func (p *Page) URL() string {
 func (p *Page) RelPermalink() string {
 	link := p.getPermalink()
 
-	if p.s.Cfg.GetBool("canonifyURLs") {
+	if p.s.Info.canonifyURLs {
 		// replacements for relpermalink with baseURL on the form http://myhost.com/sub/ will fail later on
 		// have to return the URL relative from baseURL
 		relpath, err := helpers.GetRelativePath(link.String(), string(p.Site.BaseURL))


### PR DESCRIPTION
Enforce usage of PathSpec

Fixes #3060
Updates #2728

Viper usage:
**examples/blog**
```
  47 baseurl
  31 relativeurls
  23 languages
  22 builddrafts
  20 buildfuture
  20 buildexpired
  18 disablerss
  16 ignorefiles
  11 blackfriday
  10 usemodtimeasfallback
  10 publishdir
  10 hascjklanguage
  10 footnotereturnlinkcontents
  10 footnoteanchorprefix
  10 enableemoji
   8 taxonomies
   8 rssuri
   7 defaultcontentlanguage
   6 rsslimit
   5 sitemap
   4 uglyurls
   4 theme
   4 multilingual
   4 defaultextension
   4 defaultcontentlanguageinsubdir
   4 canonifyurls
   3 workingDir
   3 disablesitemap
   3 defaultContentLanguage
   3 baseURL
   2 workingdir
   2 uglyURLs
   2 themesdir
   2 themesDir
   2 staticdir
   2 staticDir
   2 social
   2 sectionpagesmenu
   2 removepathaccents
   2 removePathAccents
   2 preservetaxonomynames
   2 pluralizelisttitles
   2 permalinks
   2 params
   2 paginatepath
   2 paginatePath
   2 layoutdir
   2 layoutDir
   2 languagecode
   2 googleanalytics
   2 enablerobotstxt
   2 disqusshortname
   2 disablepathtolower
   2 disablekinds
   2 disablehugogeneratorinject
   2 disablePathToLower
   2 disable404
   2 defaultContentLanguageInSubdir
   2 copyright
   2 contentdir
   2 canonifyURLs
   2 author
   1 verbose
   1 relativeURLs
   1 publishDir
   1 noTimes
   1 noChmod
   1 logFile
   1 i18ndir
   1 enablemissingtranslationplaceholders
   1 enablegitinfo
   1 datadir
   1 cleanDestinationDir
   1 cacheDir
```
---
**examples/multilingual**
```
  47 baseurl
  31 relativeurls
  23 languages
  22 builddrafts
  20 buildfuture
  20 buildexpired
  18 disablerss
  16 ignorefiles
  11 blackfriday
  10 usemodtimeasfallback
  10 publishdir
  10 hascjklanguage
  10 footnotereturnlinkcontents
  10 footnoteanchorprefix
  10 enableemoji
   8 taxonomies
   8 rssuri
   7 defaultcontentlanguage
   6 rsslimit
   5 sitemap
   4 uglyurls
   4 theme
   4 multilingual
   4 defaultextension
   4 defaultcontentlanguageinsubdir
   4 canonifyurls
   3 workingDir
   3 disablesitemap
   3 defaultContentLanguage
   3 baseURL
   2 workingdir
   2 uglyURLs
   2 themesdir
   2 themesDir
   2 staticdir
   2 staticDir
   2 social
   2 sectionpagesmenu
   2 removepathaccents
   2 removePathAccents
   2 preservetaxonomynames
   2 pluralizelisttitles
   2 permalinks
   2 params
   2 paginatepath
   2 paginatePath
   2 layoutdir
   2 layoutDir
   2 languagecode
   2 googleanalytics
   2 enablerobotstxt
   2 disqusshortname
   2 disablepathtolower
   2 disablekinds
   2 disablehugogeneratorinject
   2 disablePathToLower
   2 disable404
   2 defaultContentLanguageInSubdir
   2 copyright
   2 contentdir
   2 canonifyURLs
   2 author
   1 verbose
   1 relativeURLs
   1 publishDir
   1 noTimes
   1 noChmod
   1 logFile
   1 i18ndir
   1 enablemissingtranslationplaceholders
   1 enablegitinfo
   1 datadir
   1 cleanDestinationDir
   1 cacheDir
```
---
**docs**
```
 596 pygmentscodefences
 455 relativeurls
 441 baseurl
 434 defaultcontentlanguage
 431 languages
 429 builddrafts
 428 buildfuture
 428 buildexpired
 374 defaultextension
 301 disablerss
 231 ignorefiles
 215 blackfriday
 214 hascjklanguage
 214 footnotereturnlinkcontents
 214 footnoteanchorprefix
 214 enableemoji
  88 rssuri
  87 rsslimit
  11 pluralizelisttitles
   5 publishdir
   4 taxonomies
   4 defaultContentLanguage
   3 workingDir
   3 theme
   3 multilingual
   3 contentdir
   3 baseURL
   2 workingdir
   2 uglyurls
   2 uglyURLs
   2 themesDir
   2 staticDir
   2 removePathAccents
   2 paginatePath
   2 layoutDir
   2 disablePathToLower
   2 defaultcontentlanguageinsubdir
   2 defaultContentLanguageInSubdir
   2 canonifyurls
   2 canonifyURLs
   1 verbose
   1 title
   1 themesdir
   1 staticdir
   1 social
   1 sitemap
   1 sectionpagesmenu
   1 removepathaccents
   1 relativeURLs
   1 publishDir
   1 preservetaxonomynames
   1 permalinks
   1 params
   1 paginatepath
   1 noTimes
   1 noChmod
   1 menu
   1 logFile
   1 layoutdir
   1 languagecode
   1 i18ndir
   1 googleanalytics
   1 enablerobotstxt
   1 enablemissingtranslationplaceholders
   1 enablegitinfo
   1 disqusshortname
   1 disablesitemap
   1 disablepathtolower
   1 disablekinds
   1 disablehugogeneratorinject
   1 disable404
   1 datadir
   1 copyright
   1 cleanDestinationDir
   1 cacheDir
```
