### PR TITLE
Get rid of viper.Get(relativeURLs)

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -398,22 +398,21 @@ func InitializeConfig(subCmdVs ...*cobra.Command) (*deps.DepsCfg, error) {
 func createLogger(cfg config.Provider) (*jww.Notepad, error) {
 	var (
 		logHandle       = ioutil.Discard
+		logThreshold    = jww.LevelWarn
+		logFile         = cfg.GetString("logFile")
 		outHandle       = os.Stdout
 		stdoutThreshold = jww.LevelError
-		logThreshold    = jww.LevelWarn
 	)
 
-	if verboseLog || logging || (cfg.GetString("logFile") != "") {
-
+	if verboseLog || logging || (logFile != "") {
 		var err error
-		if cfg.GetString("logFile") != "" {
-			path := cfg.GetString("logFile")
-			logHandle, err = os.OpenFile(path, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0666)
+		if logFile != "" {
+			logHandle, err = os.OpenFile(logFile, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0666)
 			if err != nil {
-				return nil, newSystemError("Failed to open log file:", path, err)
+				return nil, newSystemError("Failed to open log file:", logFile, err)
 			}
 		} else {
-			logHandle, err = ioutil.TempFile(os.TempDir(), "hugo")
+			logHandle, err = ioutil.TempFile("", "hugo")
 			if err != nil {
 				return nil, newSystemError(err)
 			}

--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -461,13 +461,13 @@ func (c *commandeer) initializeFlags(cmd *cobra.Command) {
 }
 
 func (c *commandeer) setValueFromFlag(flags *flag.FlagSet, key string) {
-	if c.flagChanged(flags, key) {
+	if flagChanged(flags, key) {
 		f := flags.Lookup(key)
 		c.Set(key, f.Value.String())
 	}
 }
 
-func (c *commandeer) flagChanged(flags *flag.FlagSet, key string) bool {
+func flagChanged(flags *flag.FlagSet, key string) bool {
 	flag := flags.Lookup(key)
 	if flag == nil {
 		return false

--- a/commands/new.go
+++ b/commands/new.go
@@ -95,11 +95,11 @@ func NewContent(cmd *cobra.Command, args []string) error {
 
 	c := newCommandeer(cfg)
 
-	if c.flagChanged(cmd.Flags(), "format") {
+	if flagChanged(cmd.Flags(), "format") {
 		c.Set("metaDataFormat", configFormat)
 	}
 
-	if c.flagChanged(cmd.Flags(), "editor") {
+	if flagChanged(cmd.Flags(), "editor") {
 		c.Set("newContentEditor", contentEditor)
 	}
 

--- a/commands/server.go
+++ b/commands/server.go
@@ -108,7 +108,7 @@ func server(cmd *cobra.Command, args []string) error {
 
 	c := newCommandeer(cfg)
 
-	if c.flagChanged(cmd.Flags(), "disableLiveReload") {
+	if flagChanged(cmd.Flags(), "disableLiveReload") {
 		c.Set("disableLiveReload", disableLiveReload)
 	}
 
@@ -125,7 +125,7 @@ func server(cmd *cobra.Command, args []string) error {
 	if err == nil {
 		l.Close()
 	} else {
-		if c.flagChanged(serverCmd.Flags(), "port") {
+		if flagChanged(serverCmd.Flags(), "port") {
 			// port set explicitly by user -- he/she probably meant it!
 			return newSystemErrorF("Server startup failed: %s", err)
 		}

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -932,8 +932,7 @@ func (p *Page) RelPermalink() string {
 	p.relPermalinkInit.Do(func() {
 		link := p.getPermalink()
 
-		if p.s.Info.canonifyURLs {
-			// replacements for relpermalink with baseURL on the form http://myhost.com/sub/ will fail later on
+		if p.s.Info.canonifyURLs { // replacements for relpermalink with baseURL on the form http://myhost.com/sub/ will fail later on
 			// have to return the URL relative from baseURL
 			relpath, err := helpers.GetRelativePath(link.String(), string(p.Site.BaseURL))
 			if err != nil {

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -249,6 +249,7 @@ type SiteInfo struct {
 	Params                map[string]interface{}
 	BuildDrafts           bool
 	canonifyURLs          bool
+	relativeURLs          bool
 	preserveTaxonomyNames bool
 	Data                  *map[string]interface{}
 
@@ -977,6 +978,7 @@ func (s *Site) initializeSiteInfo() {
 		GoogleAnalytics:                lang.GetString("googleAnalytics"),
 		BuildDrafts:                    s.Cfg.GetBool("buildDrafts"),
 		canonifyURLs:                   s.Cfg.GetBool("canonifyURLs"),
+		relativeURLs:                   s.Cfg.GetBool("relativeURLs"),
 		preserveTaxonomyNames:          lang.GetBool("preserveTaxonomyNames"),
 		PageCollections:                s.PageCollections,
 		Files:                          &s.Files,
@@ -1742,7 +1744,7 @@ func (s *Site) renderAndWriteXML(name string, dest string, d interface{}, layout
 	defer bp.PutBuffer(outBuffer)
 
 	var path []byte
-	if s.Cfg.GetBool("relativeURLs") {
+	if s.Info.relativeURLs {
 		path = []byte(helpers.GetDottedRelativePath(dest))
 	} else {
 		s := s.Cfg.GetString("baseURL")
@@ -1782,9 +1784,8 @@ func (s *Site) renderAndWritePage(name string, dest string, d interface{}, layou
 	}
 
 	transformLinks := transform.NewEmptyTransforms()
-	relativeURLs := s.Cfg.GetBool("relativeURLs")
 
-	if relativeURLs || s.Info.canonifyURLs {
+	if s.Info.relativeURLs || s.Info.canonifyURLs {
 		transformLinks = append(transformLinks, transform.AbsURL)
 	}
 
@@ -1801,7 +1802,7 @@ func (s *Site) renderAndWritePage(name string, dest string, d interface{}, layou
 
 	var path []byte
 
-	if relativeURLs {
+	if s.Info.relativeURLs {
 		translated, err := pageTarget.(target.OptionalTranslator).TranslateRelative(dest)
 		if err != nil {
 			return err
@@ -1980,7 +1981,7 @@ func (s *Site) writeDestAlias(path, permalink string, p *Page) (err error) {
 }
 
 func (s *Site) publishDestAlias(aliasPublisher target.AliasPublisher, path, permalink string, p *Page) (err error) {
-	if s.Cfg.GetBool("relativeURLs") {
+	if s.Info.relativeURLs {
 		// convert `permalink` into URI relative to location of `path`
 		baseURL := helpers.SanitizeURLKeepTrailingSlash(s.Cfg.GetString("baseURL"))
 		if strings.HasPrefix(permalink, baseURL) {


### PR DESCRIPTION
Updates #3064

Viper calls:
**example/blog**
```
  69 baseurl
  13 disablerss
  10 rssuri
   9 rsslimit
   8 defaultcontentlanguage
   5 publishdir
   5 languages
   5 builddrafts
   4 taxonomies
   4 pygmentscodefences
   4 ignorefiles
   4 defaultextension
   4 defaultContentLanguage
   4 buildfuture
   4 buildexpired
   3 workingDir
   3 theme
   3 multilingual
   3 blackfriday
   3 baseURL
   2 uglyurls
   2 uglyURLs
   2 themesDir
   2 staticDir
   2 removePathAccents
   2 paginatePath
   2 layoutDir
   2 hascjklanguage
   2 footnotereturnlinkcontents
   2 footnoteanchorprefix
   2 enableemoji
   2 disablePathToLower
   2 defaultcontentlanguageinsubdir
   2 defaultContentLanguageInSubdir
   2 contentdir
   2 canonifyurls
   2 canonifyURLs
   1 workingdir
   1 verbose
   1 title
   1 themesdir
   1 staticdir
   1 social
   1 sitemap
   1 sectionpagesmenu
   1 removepathaccents
   1 relativeurls
   1 relativeURLs
   1 publishDir
   1 preservetaxonomynames
   1 pluralizelisttitles
   1 permalinks
   1 params
   1 paginatepath
   1 noTimes
   1 noChmod
   1 menu
   1 logFile
   1 layoutdir
   1 languagecode
   1 i18ndir
   1 googleanalytics
   1 enablerobotstxt
   1 enablemissingtranslationplaceholders
   1 enablegitinfo
   1 disqusshortname
   1 disablesitemap
   1 disablepathtolower
   1 disablekinds
   1 disablehugogeneratorinject
   1 disable404
   1 datadir
   1 copyright
   1 cleanDestinationDir
   1 cacheDir
   1 author
```
---
**example/multilingual**
```
  47 baseurl
  23 languages
  22 builddrafts
  20 buildfuture
  20 buildexpired
  18 disablerss
  16 ignorefiles
  11 blackfriday
  10 usemodtimeasfallback
  10 publishdir
  10 hascjklanguage
  10 footnotereturnlinkcontents
  10 footnoteanchorprefix
  10 enableemoji
   8 taxonomies
   8 rssuri
   7 defaultcontentlanguage
   6 rsslimit
   5 sitemap
   4 uglyurls
   4 theme
   4 multilingual
   4 defaultextension
   4 defaultcontentlanguageinsubdir
   4 canonifyurls
   3 workingDir
   3 disablesitemap
   3 defaultContentLanguage
   3 baseURL
   2 workingdir
   2 uglyURLs
   2 themesdir
   2 themesDir
   2 staticdir
   2 staticDir
   2 social
   2 sectionpagesmenu
   2 removepathaccents
   2 removePathAccents
   2 relativeurls
   2 preservetaxonomynames
   2 pluralizelisttitles
   2 permalinks
   2 params
   2 paginatepath
   2 paginatePath
   2 layoutdir
   2 layoutDir
   2 languagecode
   2 googleanalytics
   2 enablerobotstxt
   2 disqusshortname
   2 disablepathtolower
   2 disablekinds
   2 disablehugogeneratorinject
   2 disablePathToLower
   2 disable404
   2 defaultContentLanguageInSubdir
   2 copyright
   2 contentdir
   2 canonifyURLs
   2 author
   1 verbose
   1 relativeURLs
   1 publishDir
   1 noTimes
   1 noChmod
   1 logFile
   1 i18ndir
   1 enablemissingtranslationplaceholders
   1 enablegitinfo
   1 datadir
   1 cleanDestinationDir
   1 cacheDir
```
---
**docs**
```
 596 pygmentscodefences
 441 baseurl
 434 defaultcontentlanguage
 431 languages
 429 builddrafts
 428 buildfuture
 428 buildexpired
 374 defaultextension
 301 disablerss
 231 ignorefiles
 215 blackfriday
 214 hascjklanguage
 214 footnotereturnlinkcontents
 214 footnoteanchorprefix
 214 enableemoji
  88 rssuri
  87 rsslimit
  11 pluralizelisttitles
   5 publishdir
   4 taxonomies
   4 defaultContentLanguage
   3 workingDir
   3 theme
   3 multilingual
   3 contentdir
   3 baseURL
   2 workingdir
   2 uglyurls
   2 uglyURLs
   2 themesDir
   2 staticDir
   2 removePathAccents
   2 paginatePath
   2 layoutDir
   2 disablePathToLower
   2 defaultcontentlanguageinsubdir
   2 defaultContentLanguageInSubdir
   2 canonifyurls
   2 canonifyURLs
   1 verbose
   1 title
   1 themesdir
   1 staticdir
   1 social
   1 sitemap
   1 sectionpagesmenu
   1 removepathaccents
   1 relativeurls
   1 relativeURLs
   1 publishDir
   1 preservetaxonomynames
   1 permalinks
   1 params
   1 paginatepath
   1 noTimes
   1 noChmod
   1 menu
   1 logFile
   1 layoutdir
   1 languagecode
   1 i18ndir
   1 googleanalytics
   1 enablerobotstxt
   1 enablemissingtranslationplaceholders
   1 enablegitinfo
   1 disqusshortname
   1 disablesitemap
   1 disablepathtolower
   1 disablekinds
   1 disablehugogeneratorinject
   1 disable404
   1 datadir
   1 copyright
   1 cleanDestinationDir
   1 cacheDir
```