### PR TITLE
tpl: Use og:updated_time OpenGraph tag on nodes

### DIFF
--- a/tpl/tplimpl/template_embedded.go
+++ b/tpl/tplimpl/template_embedded.go
@@ -172,7 +172,7 @@ func (t *GoHTMLTemplate) EmbedTemplates() {
 {{ else if not .Date.IsZero }}<meta property="article:published_time" content="{{ .Date.Format "2006-01-02T15:04:05-07:00" | safeHTML }}"/>{{ end }}
 {{ if not .Lastmod.IsZero }}<meta property="article:modified_time" content="{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | safeHTML }}"/>{{ end }}
 {{ else }}
-{{ if not .Date.IsZero }}<meta property="article:modified_time" content="{{ .Date.Format "2006-01-02T15:04:05-07:00" | safeHTML }}"/>{{ end }}
+{{ if not .Date.IsZero }}<meta property="og:updated_time" content="{{ .Date.Format "2006-01-02T15:04:05-07:00" | safeHTML }}"/>{{ end }}
 {{ end }}{{ with .Params.audio }}
 <meta property="og:audio" content="{{ . }}" />{{ end }}{{ with .Params.locale }}
 <meta property="og:locale" content="{{ . }}" />{{ end }}{{ with .Site.Params.title }}


### PR DESCRIPTION
Quick fix for a minor error I found in my earlier [commit improving the OpenGraph tags](https://github.com/spf13/hugo/pull/2979) generated by Hugo's internal opengraph template. The commit message there was correct, but the code left out one of the stated changes: nodes are of type "website" and according to the [Facebook docs](https://developers.facebook.com/docs/reference/opengraph/object-type/website/) they should use `og:updated_time`.