### PR TITLE
Taxonomies: Populate the KindTaxonomyTerm Pages list

### DIFF
--- a/docs/content/templates/rss.md
+++ b/docs/content/templates/rss.md
@@ -48,6 +48,14 @@ Hugo will use the following prioritized list. If a file isn’t present, then th
 * /themes/`THEME`/layouts/\_default/rss.xml
 * [Embedded rss.xml](#the-embedded-rss-xml:eceb479b7b3b2077408a2878a29e1320)
 
+### Taxonomy Terms RSS
+
+* /layouts/taxonomy/`SINGULAR`.terms.rss.xml
+* /layouts/\_default/rss.xml
+* /themes/`THEME`/layouts/taxonomy/`SINGULAR`.terms.rss.xml
+* /themes/`THEME`/layouts/\_default/rss.xml
+* [Embedded rss.xml](#the-embedded-rss-xml:eceb479b7b3b2077408a2878a29e1320)
+
 
 ## Configuring RSS
 

--- a/docs/content/templates/terms.md
+++ b/docs/content/templates/terms.md
@@ -57,6 +57,7 @@ Taxonomy Terms pages will additionally have:
 
 * **.Data.Singular** The singular name of the taxonomy
 * **.Data.Plural** The plural name of the taxonomy
+* **.Data.Pages** (or as **.Pages**) The taxonomy Terms index pages
 * **.Data.Terms** The taxonomy itself
 * **.Data.Terms.Alphabetical** The Terms alphabetized
 * **.Data.Terms.ByCount** The Terms ordered by popularity
@@ -121,7 +122,7 @@ Another example listing the content for each term (ordered by Date):
 
 ## Ordering
 
-Hugo can order the meta data in two different ways. It can be ordered:
+Hugo can order the term meta data in two different ways. It can be ordered:
 
 * by the number of contents assigned to that key, or
 * alphabetically.
@@ -162,3 +163,14 @@ Hugo can order the meta data in two different ways. It can be ordered:
     </section>
 
     {{ partial "footer.html" . }}
+
+Hugo can also order and paginate the term index pages in all the normal ways.
+
+### Example terms.html snippet (paginated and ordered by date)
+
+    <h1 id="title">{{ .Title }}</h1>
+    <ul>
+      {{ range .Paginator.Pages.ByDate.Reverse }}
+        <li><a href="{{ .Permalink }}">{{ .Title }}</a> {{ $.Data.Terms.Count .Data.Term }}</li>
+      {{ end }}
+    </ul>

--- a/hugolib/node_as_page_test.go
+++ b/hugolib/node_as_page_test.go
@@ -176,7 +176,10 @@ func doTestNodeAsPage(t *testing.T, ugly, preserveTaxonomyNames bool) {
 		"Lastmod: 2009-01-15",
 	)
 
-	// There are no pages to paginate over in the taxonomy terms.
+	// Check taxonomy terms paginator
+	th.assertFileContent(expectedFilePath(ugly, "public", "categories", "page", "2"),
+		"Taxonomy Terms Title: Taxonomy Term Categories",
+		"Pag: Taxonomy Web")
 
 	// RSS
 	th.assertFileContent(filepath.Join("public", "customrss.xml"), "Recent content in Home Sweet Home! on Hugo Rocks", "<rss")
@@ -184,6 +187,7 @@ func doTestNodeAsPage(t *testing.T, ugly, preserveTaxonomyNames bool) {
 	th.assertFileContent(filepath.Join("public", "sect2", "customrss.xml"), "Recent content in Section2 on Hugo Rocks", "<rss")
 	th.assertFileContent(filepath.Join("public", "categories", "hugo", "customrss.xml"), "Recent content in Taxonomy Hugo on Hugo Rocks", "<rss")
 	th.assertFileContent(filepath.Join("public", "categories", "web", "customrss.xml"), "Recent content in Taxonomy Web on Hugo Rocks", "<rss")
+	th.assertFileContent(filepath.Join("public", "categories", "customrss.xml"), "Recent content in Taxonomy Term Categories on Hugo Rocks", "<rss")
 
 }
 
@@ -792,6 +796,10 @@ Lastmod: {{ .Lastmod.Format "2006-01-02" }}
 	writeSource(t, fs, filepath.Join("layouts", "_default", "terms.html"), `
 Taxonomy Terms Title: {{ .Title }}
 Taxonomy Terms Content: {{ .Content }}
+# Pages: {{ len .Data.Pages }}
+{{ range .Paginator.Pages }}
+	Pag: {{ .Title }}
+{{ end }}
 {{ range $key, $value := .Data.Terms }}
 	k/v: {{ $key | lower }} / {{ printf "%s" $value }}
 {{ end }}

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -681,7 +681,8 @@ func (p *Page) rssLayouts() []string {
 		singular := p.s.taxonomiesPluralSingular[p.sections[0]]
 		return []string{"taxonomy/" + singular + ".rss.xml", "_default/rss.xml", "rss.xml", "_internal/_default/rss.xml"}
 	case KindTaxonomyTerm:
-	// No RSS for taxonomy terms
+		singular := p.s.taxonomiesPluralSingular[p.sections[0]]
+		return []string{"taxonomy/" + singular + ".terms.rss.xml", "_default/rss.xml", "rss.xml", "_internal/_default/rss.xml"}
 	case KindPage:
 		// No RSS for regular pages
 	}
@@ -1591,6 +1592,7 @@ func (p *Page) prepareData(s *Site) error {
 		p.Data[singular] = taxonomy
 		p.Data["Singular"] = singular
 		p.Data["Plural"] = plural
+		p.Data["Term"] = term
 		pages = taxonomy.Pages()
 	case KindTaxonomyTerm:
 		plural := p.sections[0]
@@ -1602,6 +1604,13 @@ func (p *Page) prepareData(s *Site) error {
 		// keep the following just for legacy reasons
 		p.Data["OrderedIndex"] = p.Data["Terms"]
 		p.Data["Index"] = p.Data["Terms"]
+
+		// A list of all KindTaxonomy pages with matching plural
+		for _, p := range s.findPagesByKind(KindTaxonomy) {
+			if p.sections[0] == plural {
+				pages = append(pages, p)
+			}
+		}
 	}
 
 	p.Data["Pages"] = pages

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -2037,7 +2037,7 @@ func (s *Site) newHomePage() *Page {
 func (s *Site) setPageURLs(p *Page, in string) {
 	p.URLPath.URL = s.PathSpec.URLizeAndPrep(in)
 	p.URLPath.Permalink = s.Info.permalink(p.URLPath.URL)
-	if p.Kind != KindPage && p.Kind != KindTaxonomyTerm {
+	if p.Kind != KindPage {
 		p.RSSLink = template.URL(s.Info.permalink(in + ".xml"))
 	}
 }

--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -72,7 +72,7 @@ func pageRenderer(s *Site, pages <-chan *Page, results chan<- error, wg *sync.Wa
 		}
 
 		// Taxonomy terms have no page set to paginate, so skip that for now.
-		if p.IsNode() && p.Kind != KindTaxonomyTerm {
+		if p.IsNode() {
 			if err := s.renderPaginator(p); err != nil {
 				results <- err
 			}

--- a/hugolib/taxonomy_test.go
+++ b/hugolib/taxonomy_test.go
@@ -15,7 +15,6 @@ package hugolib
 
 import (
 	"fmt"
-	"html/template"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -127,9 +126,24 @@ others:
 
 	s := h.Sites[0]
 
-	// Issue #1302
-	term := s.getPage(KindTaxonomyTerm, "others")
-	require.Equal(t, template.URL(""), term.RSSLink)
+	// Make sure that each KindTaxonomyTerm page has an appropriate number
+	// of KindTaxonomy pages in its Pages slice.
+	taxonomyTermPageCounts := map[string]int{
+		"tags":       2,
+		"categories": 2,
+		"others":     2,
+		"empties":    0,
+	}
+
+	for taxonomy, count := range taxonomyTermPageCounts {
+		term := s.getPage(KindTaxonomyTerm, taxonomy)
+		require.NotNil(t, term)
+		require.Len(t, term.Pages, count)
+
+		for _, page := range term.Pages {
+			require.Equal(t, KindTaxonomy, page.Kind)
+		}
+	}
 
 	// Issue #3070 preserveTaxonomyNames
 	if preserveTaxonomyNames {


### PR DESCRIPTION
Previously this was left empty, but it is very handy to have a list
of term pages for a given taxonomy.  This list can now be paginated
like other page lists.  It makes it possible to render summary
content from each terms index page for instance.  It also makes it
possible to sort the term pages in the same way that other page
lists can be sorted.