### PR TITLE
hugolib: Fix HugoSites.createMissingPages

### DIFF
--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -322,21 +322,8 @@ func (h *HugoSites) createMissingPages() error {
 			taxonomyPages := s.findPagesByKind(KindTaxonomy)
 			taxonomyTermsPages := s.findPagesByKind(KindTaxonomyTerm)
 			for _, plural := range taxonomies {
-				tax := s.Taxonomies[plural]
-				foundTaxonomyTermsPage := false
-				for key := range tax {
-					foundTaxonomyPage := false
-					origKey := key
-
-					if s.Info.preserveTaxonomyNames {
-						key = s.PathSpec.MakePathSanitized(key)
-					}
-					for _, p := range taxonomyPages {
-						if p.sections[0] == plural && p.sections[1] == key {
-							foundTaxonomyPage = true
-							break
-						}
-					}
+				if s.isEnabled(KindTaxonomyTerm) {
+					foundTaxonomyTermsPage := false
 					for _, p := range taxonomyTermsPages {
 						if p.sections[0] == plural {
 							foundTaxonomyTermsPage = true
@@ -344,21 +331,34 @@ func (h *HugoSites) createMissingPages() error {
 						}
 					}
 
-					if s.isEnabled(KindTaxonomy) {
-						if !foundTaxonomyPage {
-							n := s.newTaxonomyPage(plural, origKey)
-							s.Pages = append(s.Pages, n)
-							newPages = append(newPages, n)
-						}
-					}
-				}
-
-				if s.isEnabled(KindTaxonomyTerm) {
 					if !foundTaxonomyTermsPage {
 						foundTaxonomyTermsPage = true
 						n := s.newTaxonomyTermsPage(plural)
 						s.Pages = append(s.Pages, n)
 						newPages = append(newPages, n)
+					}
+				}
+
+				if s.isEnabled(KindTaxonomy) {
+					for key := range s.Taxonomies[plural] {
+						foundTaxonomyPage := false
+						origKey := key
+
+						if s.Info.preserveTaxonomyNames {
+							key = s.PathSpec.MakePathSanitized(key)
+						}
+						for _, p := range taxonomyPages {
+							if p.sections[0] == plural && p.sections[1] == key {
+								foundTaxonomyPage = true
+								break
+							}
+						}
+
+						if !foundTaxonomyPage {
+							n := s.newTaxonomyPage(plural, origKey)
+							s.Pages = append(s.Pages, n)
+							newPages = append(newPages, n)
+						}
 					}
 				}
 			}

--- a/hugolib/node_as_page_test.go
+++ b/hugolib/node_as_page_test.go
@@ -96,14 +96,14 @@ func doTestNodeAsPage(t *testing.T, ugly, preserveTaxonomyNames bool) {
 
 	require.Len(t, nodes, 8)
 
-	home := nodes[6] // oldest
+	home := nodes[7] // oldest
 
 	require.True(t, home.IsHome())
 	require.True(t, home.IsNode())
 	require.False(t, home.IsPage())
 	require.True(t, home.Path() != "")
 
-	section2 := nodes[4]
+	section2 := nodes[5]
 	require.Equal(t, "Section2", section2.Title)
 
 	pages := sites.findAllPagesByKind(KindPage)
@@ -719,6 +719,14 @@ lastMod : %q
 ---
 Taxonomy Term Categories **Content!**
 `, date.Add(13*24*time.Hour).Format(time.RFC822), date.Add(14*24*time.Hour).Format(time.RFC822)))
+
+	writeSource(t, fs, filepath.Join("content", "tags", filename), fmt.Sprintf(`---
+title: Taxonomy Term Tags
+date : %q
+lastMod : %q
+---
+Taxonomy Term Tags **Content!**
+`, date.Add(15*24*time.Hour).Format(time.RFC822), date.Add(16*24*time.Hour).Format(time.RFC822)))
 
 }
 


### PR DESCRIPTION
Previously it would only check for existing KindTaxonomyTerm pages
if the taxonomy had any terms defined.  So for a taxonomy with no terms
but a taxonomy terms page it would generate a second empty terms page.