### PR TITLE
[WIP] org: use Emacs as org mode interpreter

### DIFF
--- a/docs/content/content/supported-formats.md
+++ b/docs/content/content/supported-formats.md
@@ -13,7 +13,7 @@ weight: 15
 toc: true
 ---
 
-  Since 0.14, Hugo has defined a new concept called _external helpers_. It means that you can write your content using Asciidoc[tor], reStructuredText or Org-Mode. If you have files with associated extensions ([details](https://github.com/spf13/hugo/blob/77c60a3440806067109347d04eb5368b65ea0fe8/helpers/general.go#L65)), then Hugo will call external commands to generate the content (the exception being Org-Mode content, which is parsed natively).
+  Since 0.14, Hugo has defined a new concept called _external helpers_. It means that you can write your content using Asciidoc[tor], reStructuredText or Emacs org-mode. If you have files with associated extensions ([details](https://github.com/spf13/hugo/blob/77c60a3440806067109347d04eb5368b65ea0fe8/helpers/general.go#L65)), then Hugo will call external commands to generate the content.
 
   This means that you will have to install the associated tool on your machine to be able to use those formats.
 

--- a/parser/frontmatter.go
+++ b/parser/frontmatter.go
@@ -14,13 +14,15 @@
 package parser
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"regexp"
 	"strings"
 
-	"github.com/chaseadamsio/goorgeous"
 	toml "github.com/pelletier/go-toml"
 
 	"gopkg.in/yaml.v2"
@@ -226,8 +228,51 @@ func HandleJSONMetaData(datum []byte) (interface{}, error) {
 	return f, err
 }
 
+var reHeader = regexp.MustCompile(`^#\+(\w+?): (.*)`)
+
 // HandleOrgMetaData unmarshals org-mode encoded datum and returns a Go
 // interface representing the encoded data structure.
 func HandleOrgMetaData(datum []byte) (interface{}, error) {
-	return goorgeous.OrgHeaders(datum)
+	out := make(map[string]interface{})
+	if datum == nil {
+		// Return an empty map to be consistent with our other supported
+		// formats.
+		return out, nil
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(datum))
+
+	for scanner.Scan() {
+		data := scanner.Bytes()
+		fmt.Println(string(data))
+		if !(data[0] == '#' && data[1] == '+') {
+			return out, nil
+		}
+		matches := reHeader.FindSubmatch(data)
+
+		if len(matches) < 3 {
+			continue
+		}
+
+		key := string(matches[1])
+		val := matches[2]
+		switch {
+		case strings.ToLower(key) == "tags" || strings.ToLower(key) == "categories" || strings.ToLower(key) == "aliases":
+			bTags := bytes.Split(val, []byte(" "))
+			tags := make([]string, len(bTags))
+			for idx, tag := range bTags {
+				tags[idx] = string(tag)
+			}
+			out[key] = tags
+		case string(val) == "true":
+			out[key] = true
+		case string(val) == "false":
+			out[key] = false
+		default:
+			out[key] = string(val)
+		}
+
+	}
+	return out, nil
+
 }

--- a/parser/page_test.go
+++ b/parser/page_test.go
@@ -59,7 +59,7 @@ func TestPage(t *testing.T) {
 		},
 		{
 			testPageLeader + orgPageFrontMatter + orgPageContent,
-			orgPageContent,
+			orgPageFrontMatter + orgPageContent,
 			orgPageFrontMatter,
 			true,
 			map[string]interface{}{

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -33,12 +33,6 @@
 			"revisionTime": "2016-04-08T19:03:23Z"
 		},
 		{
-			"checksumSHA1": "tOtpDG/zYOvYRQeSHcg8IhZnRHQ=",
-			"path": "github.com/chaseadamsio/goorgeous",
-			"revision": "054aba677f27bd60872cfe68f8145dc57bdf4746",
-			"revisionTime": "2017-02-22T05:25:03Z"
-		},
-		{
 			"checksumSHA1": "ntacCkWfMT63DaehXLG5FeXWyNM=",
 			"path": "github.com/cpuguy83/go-md2man/md2man",
 			"revision": "a65d4d2de4d5f7c74868dfa9b202a3c8be315aaa",


### PR DESCRIPTION
Goorgeous was a good first run at the basic use cases for Org mode but there are two major problems with trying to keep a go parser (similar to asciidoc and rst):

1. Org mode itself is a moving target, varying from major versions and adding new functionality which would mean constantly trying to stay up to date with it's features for power users.
2. Different users are different versions of Org mode (9 was recently released and it has many difference from 8), which means trying to make everyone happy for their org version.

This PR leverages emacs as a subprocess the same way rst and asciidoc are used with one exception:

- `org-mode` uses its "frontmatter" to make decisions about how to render content, so rather than reading the frontmatter out and leaving the "content", the entire file's contents are left intact and a peek function gets the frontmatter to be passed along to the org parser.

https://github.com/chaseadamsio/goorgeous/issues/32#issuecomment-286092742

# Advantages

- Now users can use the Emacs Org version they feel comfortable with and can know that what they experience in Emacs for org-html-as-html is going to be what they get in Hugo.

# Disadvantages

- A new dependency on Emacs is introduced, which means the CI environment (or whatever environment is used to render and publish)

## Solution

- Docker with Emacs v 25 and diff. major versions of org-mode.

Rollup of changes:

- use Emacs as the org interpreter
- move org headers parsing from chaseadamsio/goorgeous to spf13/hugo
- remove goorgeous as dependency altogether

cc'ing the following users who've opened issues in goorgeous to give any feedback or concerns they have. @strow @yssource @priyadarshan @jackbaty @kaushalmodi 

@strow's workflow is to have `*.org` files in his `content` directory which means Hugo will overwrite his handrolled files. In the case that users want to ignore using Emacs org mode in Hugo, do we want to add a config option to [ignore invocation as suggested here](https://github.com/chaseadamsio/goorgeous/issues/32#issuecomment-285964518)? My gut reaction is to [suggest the workflow I recommended here](https://github.com/chaseadamsio/goorgeous/issues/32#issuecomment-286031146), but if we want to have an option to ignore rendering org files, I'm happy to add that.  

# Todo

- Update docs to reflect that Emacs is a requirement where rst docs exists.