### PR TITLE
docs: Make install command compatible with Fish, Zsh and Fish

### DIFF
--- a/docs/content/overview/installing.md
+++ b/docs/content/overview/installing.md
@@ -37,7 +37,7 @@ Ideally, you should install it somewhere in your `PATH` for easy use.
 `/usr/local/bin` is the most probable location.
 
 On macOS, if you have [Homebrew](http://brew.sh/), installation is even
-easier: just run `brew update && brew install hugo`.
+easier: just run `brew update; brew install hugo`.
 
 For a more detailed explanation follow the corresponding installation guides:
 


### PR DESCRIPTION
"&&" is not supported by Bash but ";" is universally accepted.
The behavior of semicolon is a little bit different than double
ampersand but in a case of a package manager update then install,
it makes sense.

Fixes #3190 