### PR TITLE
Fix documentation of non-existent 'editor' config

### DIFF
--- a/docs/content/overview/configuration.md
+++ b/docs/content/overview/configuration.md
@@ -134,8 +134,6 @@ along with their current, default values:
     disable404:                 false
     # Do not inject generator meta tag on homepage
     disableHugoGeneratorInject: false
-    # edit new content with this editor, if provided
-    editor:                     ""
     # Enable Emoji emoticons support for page content.
     # See www.emoji-cheat-sheet.com
     enableEmoji:				false
@@ -153,6 +151,7 @@ along with their current, default values:
     logFile:                    ""
     # "yaml", "toml", "json"
     metaDataFormat:             "toml"
+    # Edit new content with this editor, if provided
     newContentEditor:           ""
     # Don't sync permission mode of files
     noChmod:                    false


### PR DESCRIPTION
Looks like this was erroneously added two years ago in commit 1827680beaf10c0710b3daed2cf1f6679c9a070a. I suspect the author misinterpreted the `--editor` [command line option](https://github.com/spf13/hugo/blob/1827680beaf10c0710b3daed2cf1f6679c9a070a/commands/hugo.go#L92) which [overrides the `newContentEditor` configuration option](https://github.com/spf13/hugo/blob/1827680beaf10c0710b3daed2cf1f6679c9a070a/commands/hugo.go#L173-L175).