### PR TITLE
[Import from Jekyll] Case insensitive translation of the 'more' tag

### DIFF
--- a/commands/import_jekyll.go
+++ b/commands/import_jekyll.go
@@ -518,7 +518,7 @@ func convertJekyllContent(m interface{}, content string) string {
 		re      *regexp.Regexp
 		replace string
 	}{
-		{regexp.MustCompile("<!-- more -->"), "<!--more-->"},
+		{regexp.MustCompile("(?i)<!-- more -->"), "<!--more-->"},
 		{regexp.MustCompile(`\{%\s*raw\s*%\}\s*(.*?)\s*\{%\s*endraw\s*%\}`), "$1"},
 		{regexp.MustCompile(`{%\s*highlight\s*(.*?)\s*%}`), "{{< highlight $1 >}}"},
 		{regexp.MustCompile(`{%\s*endhighlight\s*%}`), "{{< / highlight >}}"},

--- a/commands/import_jekyll_test.go
+++ b/commands/import_jekyll_test.go
@@ -88,6 +88,8 @@ func TestConvertJekyllContent(t *testing.T) {
 	}{
 		{map[interface{}]interface{}{},
 			`Test content\n<!-- more -->\npart2 content`, `Test content\n<!--more-->\npart2 content`},
+		{map[interface{}]interface{}{},
+			`Test content\n<!-- More -->\npart2 content`, `Test content\n<!--more-->\npart2 content`},
 		{map[interface{}]interface{}{"excerpt_separator": "<!--sep-->"},
 			`Test content\n<!--sep-->\npart2 content`, `Test content\n<!--more-->\npart2 content`},
 		{map[interface{}]interface{}{}, "{% raw %}text{% endraw %}", "text"},


### PR DESCRIPTION
This commit changes the translation of the `<!-- More -->` tag from Jekyll to be case insensitive, which is supported (in Octopress at least).
I added a test case for this one as well.