### PR TITLE
parser: Improve TOML frontmatter parser performance

### DIFF
--- a/parser/frontmatter.go
+++ b/parser/frontmatter.go
@@ -176,8 +176,7 @@ func HandleTOMLMetaData(datum []byte) (interface{}, error) {
 	m := map[string]interface{}{}
 	datum = removeTOMLIdentifier(datum)
 
-	tree, err := toml.Load(string(datum))
-
+	tree, err := toml.LoadReader(bytes.NewReader(datum))
 	if err != nil {
 		return m, err
 	}


### PR DESCRIPTION
Difference between `toml.Load(string(datum))` and
`toml.LoadReader(bytes.NewReader(datum))`:
```
benchmark           old ns/op     new ns/op     delta
BenchmarkLoad-4     82068         78489         -4.36%

benchmark           old allocs     new allocs     delta
BenchmarkLoad-4     494            493            -0.20%

benchmark           old bytes     new bytes     delta
BenchmarkLoad-4     17009         16913         -0.56%
```