### PR TITLE
commands: Added new option `cleanDestinationDirKeepDotFolder`

### DIFF
--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -213,7 +213,7 @@ func initRootPersistentFlags() {
 // Called by initHugoBuilderFlags.
 func initHugoBuildCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("cleanDestinationDir", false, "Remove files from destination not found in static directories")
-	cmd.Flags().Bool("cleanDestinationDirKeepDot", false, "Remove files from destination not found in static directories, but keep dot folders")
+	cmd.Flags().Bool("cleanDestinationDirKeepDotFolders", false, "Remove files from destination not found in static directories. Ignore `dot` folders in the destination")
 	cmd.Flags().BoolP("buildDrafts", "D", false, "include content marked as draft")
 	cmd.Flags().BoolP("buildFuture", "F", false, "include content with publishdate in the future")
 	cmd.Flags().BoolP("buildExpired", "E", false, "include expired content")
@@ -433,7 +433,7 @@ func (c *commandeer) initializeFlags(cmd *cobra.Command) {
 	persFlagKeys := []string{"verbose", "logFile"}
 	flagKeys := []string{
 		"cleanDestinationDir",
-		"cleanDestinationDirKeepDot",
+		"cleanDestinationDirKeepDotFolders",
 		"buildDrafts",
 		"buildFuture",
 		"buildExpired",
@@ -580,12 +580,12 @@ func (c *commandeer) copyStatic() error {
 	syncer.DestFs = c.Fs.Destination
 	// Now that we are using a unionFs for the static directories
 	// We can effectively clean the publishDir on initial sync
-	syncer.Delete = c.Cfg.GetBool("cleanDestinationDir") || c.Cfg.GetBool("cleanDestinationDirKeepDot")
+	syncer.Delete = c.Cfg.GetBool("cleanDestinationDir") || c.Cfg.GetBool("cleanDestinationDirKeepDotFolders")
 
 	if syncer.Delete {
 		c.Logger.INFO.Println("removing all files from destination that don't exist in static dirs")
 
-		if c.Cfg.GetBool("cleanDestinationDirKeepDot") {
+		if c.Cfg.GetBool("cleanDestinationDirKeepDotFolders") {
 			syncer.DeleteFilter = func(f os.FileInfo) bool {
 				return f.IsDir() && len(f.Name()) > 0 && string(f.Name()[0]) == "."
 			}

--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -213,7 +213,6 @@ func initRootPersistentFlags() {
 // Called by initHugoBuilderFlags.
 func initHugoBuildCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("cleanDestinationDir", false, "Remove files from destination not found in static directories")
-	cmd.Flags().Bool("cleanDestinationDirKeepDotFolders", false, "Remove files from destination not found in static directories. Ignore `dot` folders in the destination")
 	cmd.Flags().BoolP("buildDrafts", "D", false, "include content marked as draft")
 	cmd.Flags().BoolP("buildFuture", "F", false, "include content with publishdate in the future")
 	cmd.Flags().BoolP("buildExpired", "E", false, "include expired content")
@@ -433,7 +432,6 @@ func (c *commandeer) initializeFlags(cmd *cobra.Command) {
 	persFlagKeys := []string{"verbose", "logFile"}
 	flagKeys := []string{
 		"cleanDestinationDir",
-		"cleanDestinationDirKeepDotFolders",
 		"buildDrafts",
 		"buildFuture",
 		"buildExpired",
@@ -580,15 +578,13 @@ func (c *commandeer) copyStatic() error {
 	syncer.DestFs = c.Fs.Destination
 	// Now that we are using a unionFs for the static directories
 	// We can effectively clean the publishDir on initial sync
-	syncer.Delete = c.Cfg.GetBool("cleanDestinationDir") || c.Cfg.GetBool("cleanDestinationDirKeepDotFolders")
+	syncer.Delete = c.Cfg.GetBool("cleanDestinationDir")
 
 	if syncer.Delete {
 		c.Logger.INFO.Println("removing all files from destination that don't exist in static dirs")
 
-		if c.Cfg.GetBool("cleanDestinationDirKeepDotFolders") {
-			syncer.DeleteFilter = func(f os.FileInfo) bool {
-				return f.IsDir() && len(f.Name()) > 0 && string(f.Name()[0]) == "."
-			}
+		syncer.DeleteFilter = func(f os.FileInfo) bool {
+			return f.IsDir() && strings.HasPrefix(f.Name(), ".")
 		}
 	}
 	c.Logger.INFO.Println("syncing static files to", publishDir)

--- a/docs/content/commands/hugo_benchmark.md
+++ b/docs/content/commands/hugo_benchmark.md
@@ -21,37 +21,37 @@ hugo benchmark
 ### Options
 
 ```
-  -b, --baseURL string                      hostname (and path) to the root, e.g. http://spf13.com/
-  -D, --buildDrafts                         include content marked as draft
-  -E, --buildExpired                        include expired content
-  -F, --buildFuture                         include content with publishdate in the future
-      --cacheDir string                     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/
-      --canonifyURLs                        if true, all relative URLs will be canonicalized using baseURL
-      --cleanDestinationDir                 Remove files from destination not found in static directories
-  -c, --contentDir string                   filesystem path to content directory
-  -n, --count int                           number of times to build the site (default 13)
-      --cpuprofile string                   path/filename for the CPU profile file
-  -d, --destination string                  filesystem path to write files to
-      --disable404                          Do not render 404 page
-      --disableKinds stringSlice            Disable different kind of pages (home, RSS etc.)
-      --disableRSS                          Do not build RSS files
-      --disableSitemap                      Do not build Sitemap file
-      --enableGitInfo                       Add Git revision, date and author info to the pages
-      --forceSyncStatic                     Copy all files when static is changed.
-      --i18n-warnings                       Print missing translations
-      --ignoreCache                         Ignores the cache directory
-  -l, --layoutDir string                    filesystem path to layout directory
-      --memprofile string                   path/filename for the memory profile file
-      --noChmod                             Don't sync permission mode of files
-      --noTimes                             Don't sync modification time of files
-      --pluralizeListTitles                 Pluralize titles in lists using inflect (default true)
-      --preserveTaxonomyNames               Preserve taxonomy names as written ("Gérard Depardieu" vs "gerard-depardieu")
-      --renderToMemory                      render to memory (only useful for benchmark testing)
-  -s, --source string                       filesystem path to read files relative from
-      --stepAnalysis                        display memory and timing of different steps of the program
-  -t, --theme string                        theme to use (located in /themes/THEMENAME/)
-      --themesDir string                    filesystem path to themes directory
-      --uglyURLs                            if true, use /filename.html instead of /filename/
+  -b, --baseURL string             hostname (and path) to the root, e.g. http://spf13.com/
+  -D, --buildDrafts                include content marked as draft
+  -E, --buildExpired               include expired content
+  -F, --buildFuture                include content with publishdate in the future
+      --cacheDir string            filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/
+      --canonifyURLs               if true, all relative URLs will be canonicalized using baseURL
+      --cleanDestinationDir        Remove files from destination not found in static directories
+  -c, --contentDir string          filesystem path to content directory
+  -n, --count int                  number of times to build the site (default 13)
+      --cpuprofile string          path/filename for the CPU profile file
+  -d, --destination string         filesystem path to write files to
+      --disable404                 Do not render 404 page
+      --disableKinds stringSlice   Disable different kind of pages (home, RSS etc.)
+      --disableRSS                 Do not build RSS files
+      --disableSitemap             Do not build Sitemap file
+      --enableGitInfo              Add Git revision, date and author info to the pages
+      --forceSyncStatic            Copy all files when static is changed.
+      --i18n-warnings              Print missing translations
+      --ignoreCache                Ignores the cache directory
+  -l, --layoutDir string           filesystem path to layout directory
+      --memprofile string          path/filename for the memory profile file
+      --noChmod                    Don't sync permission mode of files
+      --noTimes                    Don't sync modification time of files
+      --pluralizeListTitles        Pluralize titles in lists using inflect (default true)
+      --preserveTaxonomyNames      Preserve taxonomy names as written ("Gérard Depardieu" vs "gerard-depardieu")
+      --renderToMemory             render to memory (only useful for benchmark testing)
+  -s, --source string              filesystem path to read files relative from
+      --stepAnalysis               display memory and timing of different steps of the program
+  -t, --theme string               theme to use (located in /themes/THEMENAME/)
+      --themesDir string           filesystem path to themes directory
+      --uglyURLs                   if true, use /filename.html instead of /filename/
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/commands/hugo_benchmark.md
+++ b/docs/content/commands/hugo_benchmark.md
@@ -28,7 +28,6 @@ hugo benchmark
       --cacheDir string                     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/
       --canonifyURLs                        if true, all relative URLs will be canonicalized using baseURL
       --cleanDestinationDir                 Remove files from destination not found in static directories
-      --cleanDestinationDirKeepDotFolders   Remove files from destination not found in static directories. Ignore `dot` folders in the destination
   -c, --contentDir string                   filesystem path to content directory
   -n, --count int                           number of times to build the site (default 13)
       --cpuprofile string                   path/filename for the CPU profile file

--- a/docs/content/commands/hugo_benchmark.md
+++ b/docs/content/commands/hugo_benchmark.md
@@ -21,37 +21,38 @@ hugo benchmark
 ### Options
 
 ```
-  -b, --baseURL string             hostname (and path) to the root, e.g. http://spf13.com/
-  -D, --buildDrafts                include content marked as draft
-  -E, --buildExpired               include expired content
-  -F, --buildFuture                include content with publishdate in the future
-      --cacheDir string            filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/
-      --canonifyURLs               if true, all relative URLs will be canonicalized using baseURL
-      --cleanDestinationDir        Remove files from destination not found in static directories
-  -c, --contentDir string          filesystem path to content directory
-  -n, --count int                  number of times to build the site (default 13)
-      --cpuprofile string          path/filename for the CPU profile file
-  -d, --destination string         filesystem path to write files to
-      --disable404                 Do not render 404 page
-      --disableKinds stringSlice   Disable different kind of pages (home, RSS etc.)
-      --disableRSS                 Do not build RSS files
-      --disableSitemap             Do not build Sitemap file
-      --enableGitInfo              Add Git revision, date and author info to the pages
-      --forceSyncStatic            Copy all files when static is changed.
-      --i18n-warnings              Print missing translations
-      --ignoreCache                Ignores the cache directory
-  -l, --layoutDir string           filesystem path to layout directory
-      --memprofile string          path/filename for the memory profile file
-      --noChmod                    Don't sync permission mode of files
-      --noTimes                    Don't sync modification time of files
-      --pluralizeListTitles        Pluralize titles in lists using inflect (default true)
-      --preserveTaxonomyNames      Preserve taxonomy names as written ("Gérard Depardieu" vs "gerard-depardieu")
-      --renderToMemory             render to memory (only useful for benchmark testing)
-  -s, --source string              filesystem path to read files relative from
-      --stepAnalysis               display memory and timing of different steps of the program
-  -t, --theme string               theme to use (located in /themes/THEMENAME/)
-      --themesDir string           filesystem path to themes directory
-      --uglyURLs                   if true, use /filename.html instead of /filename/
+  -b, --baseURL string                      hostname (and path) to the root, e.g. http://spf13.com/
+  -D, --buildDrafts                         include content marked as draft
+  -E, --buildExpired                        include expired content
+  -F, --buildFuture                         include content with publishdate in the future
+      --cacheDir string                     filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/
+      --canonifyURLs                        if true, all relative URLs will be canonicalized using baseURL
+      --cleanDestinationDir                 Remove files from destination not found in static directories
+      --cleanDestinationDirKeepDotFolders   Remove files from destination not found in static directories. Ignore `dot` folders in the destination
+  -c, --contentDir string                   filesystem path to content directory
+  -n, --count int                           number of times to build the site (default 13)
+      --cpuprofile string                   path/filename for the CPU profile file
+  -d, --destination string                  filesystem path to write files to
+      --disable404                          Do not render 404 page
+      --disableKinds stringSlice            Disable different kind of pages (home, RSS etc.)
+      --disableRSS                          Do not build RSS files
+      --disableSitemap                      Do not build Sitemap file
+      --enableGitInfo                       Add Git revision, date and author info to the pages
+      --forceSyncStatic                     Copy all files when static is changed.
+      --i18n-warnings                       Print missing translations
+      --ignoreCache                         Ignores the cache directory
+  -l, --layoutDir string                    filesystem path to layout directory
+      --memprofile string                   path/filename for the memory profile file
+      --noChmod                             Don't sync permission mode of files
+      --noTimes                             Don't sync modification time of files
+      --pluralizeListTitles                 Pluralize titles in lists using inflect (default true)
+      --preserveTaxonomyNames               Preserve taxonomy names as written ("Gérard Depardieu" vs "gerard-depardieu")
+      --renderToMemory                      render to memory (only useful for benchmark testing)
+  -s, --source string                       filesystem path to read files relative from
+      --stepAnalysis                        display memory and timing of different steps of the program
+  -t, --theme string                        theme to use (located in /themes/THEMENAME/)
+      --themesDir string                    filesystem path to themes directory
+      --uglyURLs                            if true, use /filename.html instead of /filename/
 ```
 
 ### Options inherited from parent commands

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -281,10 +281,10 @@
 			"revisionTime": "2017-02-17T16:44:07Z"
 		},
 		{
-			"checksumSHA1": "NOrvS8XdRlWNXTvGi+oqEHlQYWA=",
+			"checksumSHA1": "XSh/IxmHbGUf4tYB61wn9zK4g7U=",
 			"path": "github.com/spf13/fsync",
-			"revision": "cb2da332d00cbc04e4f3f677520dc3e7cc11874b",
-			"revisionTime": "2016-11-30T04:45:28Z"
+			"revision": "12a01e648f05a938100a26858d2d59a120307a18",
+			"revisionTime": "2017-03-20T14:25:52Z"
 		},
 		{
 			"checksumSHA1": "9pkkhgKp3mwSreiML3plQlQYdLQ=",


### PR DESCRIPTION
Add a new option to ignore 'dot' folders when deleting files in destination dir.

Fixes #3208