### PR TITLE
hugolib: Correctly identify "my_index_page.md"

### DIFF
--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -1859,8 +1859,15 @@ func sectionsFromFilename(filename string) []string {
 	return sections
 }
 
+const (
+	regularPageFileNameDoesNotStartWith = "_index"
+
+	// There can be "my_regular_index_page.md but not /_index_file.md
+	regularPageFileNameDoesNotContain = helpers.FilePathSeparator + regularPageFileNameDoesNotStartWith
+)
+
 func kindFromFilename(filename string) string {
-	if !strings.Contains(filename, "_index") {
+	if !strings.HasPrefix(filename, regularPageFileNameDoesNotStartWith) && !strings.Contains(filename, regularPageFileNameDoesNotContain) {
 		return KindPage
 	}
 

--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -201,6 +201,20 @@ func TestLastChange(t *testing.T) {
 	require.Equal(t, 2017, s.Info.LastChange.Year(), "Site.LastChange should be set to the page with latest Lastmod (year 2017)")
 }
 
+// Issue #_index
+func TestPageWithUnderScoreIndexInFilename(t *testing.T) {
+	t.Parallel()
+
+	cfg, fs := newTestCfg()
+
+	writeSource(t, fs, filepath.Join("content", "sect/my_index_file.md"), "---\ntitle: doc1\nweight: 1\ndate: 2014-05-29\n---\n# doc1\n*some content*")
+
+	s := buildSingleSite(t, deps.DepsCfg{Fs: fs, Cfg: cfg}, BuildCfg{SkipRender: true})
+
+	require.Len(t, s.RegularPages, 1)
+
+}
+
 // Issue #957
 func TestCrossrefs(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
The above example was earlier identified as a section page and not a regular page.

Fixes #3234