### PR TITLE
Update Disqus alternative

### DIFF
--- a/docs/content/extras/comments.md
+++ b/docs/content/extras/comments.md
@@ -74,7 +74,7 @@ A few alternatives exist to [Disqus](https://disqus.com/):
 
 * [Discourse](http://www.discourse.org)
 * [IntenseDebate](http://intensedebate.com/)
-* [Livefyre](http://livefyre.com/)
+* [Livefyre](http://www.adobe.com/marketing-cloud/enterprise-content-management/ugc-content-platform.html)
 * [Muut](http://muut.com/)
 * [多说](http://duoshuo.com/) ([Duoshuo](http://duoshuo.com/), popular in China)
 * [isso](http://posativ.org/isso/) (Self-hosted, Python)


### PR DESCRIPTION
Livefyre.com is down.

Livefyre was integrated into Adobe's offering.

The product is now called Adobe Experience Manager Livefyre.

Wikipedia points to web.livefyre.com which redirects to the link I provided in the commit.