### PR TITLE
hugolib: add .Frontmatter variable to Page

### DIFF
--- a/docs/content/templates/variables.md
+++ b/docs/content/templates/variables.md
@@ -34,6 +34,7 @@ matter, content or derived from file location.
 **.Description** The description for the page.<br>
 **.Draft** A boolean, `true` if the content is marked as a draft in the front matter.<br>
 **.ExpiryDate** The date where the content is scheduled to expire on.<br>
+**.Frontmatter** Raw metadata header.<br>
 **.FuzzyWordCount** The approximate number of words in the content.<br>
 **.Hugo** See [Hugo Variables]({{< relref "#hugo-variables" >}}) below.<br>
 **.IsHome** True if this is the home page.<br>

--- a/hugolib/page.go
+++ b/hugolib/page.go
@@ -1291,6 +1291,10 @@ func (p *Page) RawContent() string {
 	return string(p.rawContent)
 }
 
+func (p *Page) Frontmatter() string {
+	return string(p.frontmatter)
+}
+
 func (p *Page) SetSourceContent(content []byte) {
 	p.Source.Content = content
 }

--- a/hugolib/page_test.go
+++ b/hugolib/page_test.go
@@ -749,6 +749,27 @@ title: Raw
 
 }
 
+func TestPageFrontmatter(t *testing.T) {
+	t.Parallel()
+	cfg, fs := newTestCfg()
+
+	writeSource(t, fs, filepath.Join("content", "frontmatter.md"), `---
+title: Frontmatter
+---
+**Some text**`)
+
+	writeSource(t, fs, filepath.Join("layouts", "_default", "single.html"), `{{ .Frontmatter }}`)
+
+	s := buildSingleSite(t, deps.DepsCfg{Fs: fs, Cfg: cfg}, BuildCfg{SkipRender: true})
+
+	require.Len(t, s.RegularPages, 1)
+	p := s.RegularPages[0]
+
+	require.Contains(t, p.Frontmatter(), `---
+title: Frontmatter
+---`)
+}
+
 func TestPageWithShortCodeInSummary(t *testing.T) {
 	t.Parallel()
 	assertFunc := func(t *testing.T, ext string, pages Pages) {


### PR DESCRIPTION
There is an access to raw content but no access to raw frontmatter. This PR fills this gap.
I need the raw frontmatter in my rendered content because I want to postprocess it in some way and I need whole metadata header inside the htmls that I will replace later.