### PR TITLE
tplimpl: Return false in "in" func when looking for nil

### DIFF
--- a/tpl/tplimpl/template_funcs.go
+++ b/tpl/tplimpl/template_funcs.go
@@ -473,6 +473,11 @@ func (ic *imageHandler) config(path interface{}) (image.Config, error) {
 
 // in returns whether v is in the set l.  l may be an array or slice.
 func in(l interface{}, v interface{}) bool {
+
+	if v == nil {
+		return false
+	}
+
 	lv := reflect.ValueOf(l)
 	vv := reflect.ValueOf(v)
 
@@ -486,8 +491,11 @@ func in(l interface{}, v interface{}) bool {
 			}
 			switch lvv.Kind() {
 			case reflect.String:
-				if vv.Type() == lvv.Type() && vv.String() == lvv.String() {
-					return true
+				switch vv.Kind() {
+				case reflect.String:
+					if vv.Type() == lvv.Type() && vv.String() == lvv.String() {
+						return true
+					}
 				}
 			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 				switch vv.Kind() {

--- a/tpl/tplimpl/template_funcs_test.go
+++ b/tpl/tplimpl/template_funcs_test.go
@@ -771,6 +771,7 @@ func TestIn(t *testing.T) {
 		{[]float64{1.234567, 2.45, 4.67}, 1.234568, false},
 		{"this substring should be found", "substring", true},
 		{"this substring should not be found", "subseastring", false},
+		{[]string{"a", "b", "c"}, nil, false},
 	} {
 		result := in(this.v1, this.v2)
 


### PR DESCRIPTION
When looking for nil in set of string, the in function should return false.
E.g.: in({[]string{"a", "b", "c"}, nil) will return false

Fixes #3225