### PR TITLE
Properly capitalize GitHub.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,12 +23,12 @@ The Hugo community and maintainers are [very active](https://github.com/spf13/hu
 ## Asking Support Questions
 
 We have an active [discussion forum](http://discuss.gohugo.io) where users and developers can ask questions.
-Please don't use the Github issue tracker to ask questions.
+Please don't use the GitHub issue tracker to ask questions.
 
 ## Reporting Issues
 
 If you believe you have found a defect in Hugo or its documentation, use
-the Github [issue tracker](https://github.com/spf13/hugo/issues) to report the problem to the Hugo maintainers.
+the GitHub [issue tracker](https://github.com/spf13/hugo/issues) to report the problem to the Hugo maintainers.
 If you're not sure if it's a bug or not, start by asking in the [discussion forum](http://discuss.gohugo.io).
 When reporting the issue, please provide the version of Hugo in use (`hugo version`) and your operating system.
 
@@ -123,7 +123,7 @@ started:
     git commit -a -v
     ```
 
-1. Fork Hugo in Github.
+1. Fork Hugo in GitHub.
 
 1. Add your fork as a new remote (the remote name, "fork" in this example, is arbitrary):
 

--- a/README.md
+++ b/README.md
@@ -79,12 +79,12 @@ The Hugo community and maintainers are [very active](https://github.com/spf13/hu
 ### Asking Support Questions
 
 We have an active [discussion forum](http://discuss.gohugo.io) where users and developers can ask questions.
-Please don't use the Github issue tracker to ask questions.
+Please don't use the GitHub issue tracker to ask questions.
 
 ### Reporting Issues
 
 If you believe you have found a defect in Hugo or its documentation, use
-the Github issue tracker to report the problem to the Hugo maintainers.
+the GitHub issue tracker to report the problem to the Hugo maintainers.
 If you're not sure if it's a bug or not, start by asking in the [discussion forum](http://discuss.gohugo.io).
 When reporting the issue, please provide the version of Hugo in use (`hugo version`).
 

--- a/docs/content/community/contributing.md
+++ b/docs/content/community/contributing.md
@@ -60,7 +60,7 @@ You **must use govendor** to fetch Hugo's dependencies.
 
 You got your new website running and it's powered by Hugo? Great. You can add your website with a few steps to the [showcase](/showcase/).
 
-First, make sure that you created a [fork](https://help.github.com/articles/fork-a-repo/) of Hugo on Github and cloned your fork on your local computer. Next, create a separate branch for your additions:
+First, make sure that you created a [fork](https://help.github.com/articles/fork-a-repo/) of Hugo on GitHub and cloned your fork on your local computer. Next, create a separate branch for your additions:
 
 ```
 # You can choose a different descriptive branch name if you like

--- a/docs/content/community/press.md
+++ b/docs/content/community/press.md
@@ -77,7 +77,7 @@ Hugo has been featured in the following Blog Posts, Press and Media.
 | [<span lang="ja">Hugoでブログをつくった</span>](http://porgy13.github.io/post/new-hugo-blog/) | porgy13 | 2015-02-07 |
 | [<span lang="ja">Hugoにブログを移行した</span>](http://keichi.net/post/first/) | Keichi Takahashi | 2015-02-04 |
 | [<span lang="zh-CN">Hugo静态网站生成器中文教程</span>](http://nanshu.wang/post/2015-01-31/) | Nanshu Wang | 2015-01-31 |
-| [<span lang="ja">Hugo + Github Pages + Wercker CI = ¥0（無料）<br>でコマンド 1 発（自動化）でサイト<br>・ブログを公開・運営・分析・収益化</span>](http://qiita.com/yoheimuta/items/8a619cac356bed89a4c9) | Yohei Yoshimuta | 2015-01-31 |
+| [<span lang="ja">Hugo + GitHub Pages + Wercker CI = ¥0（無料）<br>でコマンド 1 発（自動化）でサイト<br>・ブログを公開・運営・分析・収益化</span>](http://qiita.com/yoheimuta/items/8a619cac356bed89a4c9) | Yohei Yoshimuta | 2015-01-31 |
 | [Running Hugo websites on anynines](http://blog.anynines.com/running-hugo-websites-on-anynines/) | Julian Weber | 2015-01-30 |
 | [MiddlemanからHugoへ移行した](http://re-dzine.net/2015/01/hugo/) | Haruki Konishi | 2015-01-21 |
 | [WordPress から Hugo に乗り換えました](http://rakuishi.com/archives/wordpress-to-hugo/)  | rakuishi | 2015-01-20 |

--- a/docs/content/meta/release-notes.md
+++ b/docs/content/meta/release-notes.md
@@ -326,7 +326,7 @@ times decreased anywhere from 10% to 99%.
 * Add `themesDir` option to configuration {{<gh 1556>}}
 * Add support for Go 1.6 `block` keyword in templates {{<gh 1832>}}
 * Partial static sync {{<gh 1644>}}
-* Source file based relative linking (a la Github) {{<gh 0x0f6b334b6715253b030c4e783b88e911b6e53e56>}}
+* Source file based relative linking (a la GitHub) {{<gh 0x0f6b334b6715253b030c4e783b88e911b6e53e56>}}
 *  Add `ByLastmod` sort function to pages. {{<gh 0xeb627ca16de6fb5e8646279edd295a8bf0f72bf1 >}}
 * New templates functions:
 	* `readFile` {{<gh 1551 >}}

--- a/docs/content/tutorials/automated-deployments.md
+++ b/docs/content/tutorials/automated-deployments.md
@@ -209,7 +209,7 @@ build:
         flags: --buildDrafts=true
 ```
 
-As you can see, we have two steps in the build pipeline. The first step downloads the theme, and the second step runs arjen's hugo-build step. To use a different theme, you can replace the link to the herring-cove source with another theme's repository - just make sure the name of the folder you download the theme to (./themes/your-theme-name) matches the theme name you tell arjen/hugo-build to use (theme: your-theme-name). Now we'll test that it all works as it should by pushing up our wercker.yml file to Github and seeing the magic at work.
+As you can see, we have two steps in the build pipeline. The first step downloads the theme, and the second step runs arjen's hugo-build step. To use a different theme, you can replace the link to the herring-cove source with another theme's repository - just make sure the name of the folder you download the theme to (./themes/your-theme-name) matches the theme name you tell arjen/hugo-build to use (theme: your-theme-name). Now we'll test that it all works as it should by pushing up our wercker.yml file to GitHub and seeing the magic at work.
 
 ```bash
 git commit -a -m "Add wercker.yml"
@@ -236,7 +236,7 @@ In order to deploy to GitHub Pages we need to add a deploy pipeline.
 
 ## Adding a deploy step
 
-Next, we need to add a step to our deploy pipeline that will deploy the Hugo-built website to your Github pages repository. Once again searching through the Steps registry, we find that the most popular step is the **lukevevier/gh-pages** step so we add the configuration for that to our wercker.yml file. Additionally, we need to ensure that the box we run on has git and ssh installed. We can do this using the **install-packages** command, which then turns the wercker.yml file into this:
+Next, we need to add a step to our deploy pipeline that will deploy the Hugo-built website to your GitHub pages repository. Once again searching through the Steps registry, we find that the most popular step is the **lukevevier/gh-pages** step so we add the configuration for that to our wercker.yml file. Additionally, we need to ensure that the box we run on has git and ssh installed. We can do this using the **install-packages** command, which then turns the wercker.yml file into this:
 
 ```yaml
 box: debian
@@ -260,7 +260,7 @@ How does the GitHub Pages configuration work? We've selected a couple of things,
 
 Secondly we've configured the basedir to **public**, this is the directory that will be used as the website on GitHub Pages.
 
-And lastly, you can see here that this has a **$GIT_TOKEN** variable. This is used for pushing our changes up to GitHub and we will need to configure this before we can do that. To do this, go to your application page and click on the "Environment" tab. Under Application Environment Variables, put **$GIT_TOKEN** for the Key. Now you'll need to create an access token in GitHub. How to do that is described on a [GitHub help page](https://help.github.com/articles/creating-an-access-token-for-command-line-use/). Copy and paste the access token you generated from Github into the Value box. **Make sure you check Protected** and then hit Add. 
+And lastly, you can see here that this has a **$GIT_TOKEN** variable. This is used for pushing our changes up to GitHub and we will need to configure this before we can do that. To do this, go to your application page and click on the "Environment" tab. Under Application Environment Variables, put **$GIT_TOKEN** for the Key. Now you'll need to create an access token in GitHub. How to do that is described on a [GitHub help page](https://help.github.com/articles/creating-an-access-token-for-command-line-use/). Copy and paste the access token you generated from GitHub into the Value box. **Make sure you check Protected** and then hit Add. 
 
 ![][14]
 

--- a/docs/content/tutorials/how-to-contribute-to-hugo.md
+++ b/docs/content/tutorials/how-to-contribute-to-hugo.md
@@ -114,7 +114,7 @@ If you're not fimiliar with this term, GitHub's [help pages](https://help.github
 
 #### Fork by hand
 
-Open the [Hugo repository](https://github.com/spf13/hugo) on Github and click on the "Fork" button in the top right.
+Open the [Hugo repository](https://github.com/spf13/hugo) on GitHub and click on the "Fork" button in the top right.
 
 ![Fork button](/img/tutorials/how-to-contribute-to-hugo/forking-a-repository.png)
 


### PR DESCRIPTION
It's a pet peeve of mine to see words like GitHub not capitalized correctly. I've fixed occurrences of `Github` to `GitHub` everywhere that isn't code.