### PR TITLE
all: Handle all returned errors

### DIFF
--- a/commands/gendoc.go
+++ b/commands/gendoc.go
@@ -53,7 +53,9 @@ for rendering in Hugo.`,
 		}
 		if found, _ := helpers.Exists(gendocdir, hugofs.Os); !found {
 			jww.FEEDBACK.Println("Directory", gendocdir, "does not exist, creating...")
-			hugofs.Os.MkdirAll(gendocdir, 0777)
+			if err := hugofs.Os.MkdirAll(gendocdir, 0777); err != nil {
+				return err
+			}
 		}
 		now := time.Now().Format(time.RFC3339)
 		prepender := func(filename string) string {

--- a/commands/genman.go
+++ b/commands/genman.go
@@ -43,7 +43,9 @@ in the "man" directory under the current directory.`,
 		}
 		if found, _ := helpers.Exists(genmandir, hugofs.Os); !found {
 			jww.FEEDBACK.Println("Directory", genmandir, "does not exist, creating...")
-			hugofs.Os.MkdirAll(genmandir, 0777)
+			if err := hugofs.Os.MkdirAll(genmandir, 0777); err != nil {
+				return err
+			}
 		}
 		cmd.Root().DisableAutoGenTag = true
 

--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -551,7 +551,9 @@ func (s *Site) preparePagesForRender(cfg *BuildCfg) {
 					p.Content = helpers.BytesToHTML(workContentCopy)
 
 					if summaryContent == nil {
-						p.setAutoSummary()
+						if err := p.setAutoSummary(); err != nil {
+							s.Log.ERROR.Printf("Failed to set user auto summary for page %q: %s", p.pathOrTitle(), err)
+						}
 					}
 
 				} else {

--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -147,7 +147,9 @@ func (s *Site) renderPaginator(p *PageOutput) error {
 
 		// TODO(bep) output do better
 		link := newOutputFormat(p.Page, p.outputFormat).Permalink()
-		s.writeDestAlias(target, link, nil)
+		if err := s.writeDestAlias(target, link, nil); err != nil {
+			return err
+		}
 
 		pagers := p.paginator.Pagers()
 

--- a/transform/hugogeneratorinject.go
+++ b/transform/hugogeneratorinject.go
@@ -27,7 +27,9 @@ var hugoGeneratorTag = fmt.Sprintf(`<meta name="generator" content="Hugo %s" />`
 // HugoGeneratorInject injects a meta generator tag for Hugo if none present.
 func HugoGeneratorInject(ct contentTransformer) {
 	if metaTagsCheck.Match(ct.Content()) {
-		ct.Write(ct.Content())
+		if _, err := ct.Write(ct.Content()); err != nil {
+			helpers.DistinctWarnLog.Println("Failed to inject Hugo generator tag:", err)
+		}
 		return
 	}
 
@@ -41,5 +43,8 @@ func HugoGeneratorInject(ct contentTransformer) {
 		newcontent = bytes.Replace(ct.Content(), []byte(head), replace, 1)
 	}
 
-	ct.Write(newcontent)
+	if _, err := ct.Write(newcontent); err != nil {
+		helpers.DistinctWarnLog.Println("Failed to inject Hugo generator tag:", err)
+	}
+
 }


### PR DESCRIPTION
As reported by `errcheck`.