### PR TITLE
hugolib, tpl: Get rid of some redundant viper calls

### DIFF
--- a/tpl/tplimpl/template_funcs.go
+++ b/tpl/tplimpl/template_funcs.go
@@ -1392,7 +1392,8 @@ func (t *templateFuncster) markdownify(in interface{}) (template.HTML, error) {
 
 	m := t.ContentSpec.RenderBytes(&helpers.RenderingContext{
 		Cfg:     t.Cfg,
-		Content: []byte(text), PageFmt: "markdown"})
+		Content: []byte(text), PageFmt: "markdown",
+		Config: t.ContentSpec.NewBlackfriday()})
 	m = bytes.TrimPrefix(m, markdownTrimPrefix)
 	m = bytes.TrimSuffix(m, markdownTrimSuffix)
 	return template.HTML(m), nil


### PR DESCRIPTION
`markdownify` template function needs less time now to markdownify pages. 

Count of viper calls by building https://github.com/rdwatters/hugo-docs-concept
```
 962 publishdir
 749 pygmentscodefences
 650 defaultcontentlanguage
 645 languages
 640 builddrafts
 638 buildfuture
 638 buildexpired
 342 ignorefiles
 315 hascjklanguage
 313 enableemoji
 261 rsslimit
 261 disablerss
   9 rssuri
   5 defaultContentLanguage
   4 uglyurls
   4 theme
   4 taxonomies
   4 multilingual
   4 ignorecache
   4 defaultcontentlanguageinsubdir
   4 canonifyurls
   4 cachedir
   4 baseurl
   3 workingdir
   3 themesdir
   3 staticdir
   3 removepathaccents
   3 paginatepath
   3 layoutdir
   3 disablepathtolower
   2 workingDir
   2 themesDir
   2 contentdir
   2 blackfriday
   1 verbose
   1 uglyURLs
   1 title
   1 staticDir
   1 social
   1 sitemap
   1 sectionpagesmenu
   1 removePathAccents
   1 relativeurls
   1 relativeURLs
   1 publishDir
   1 preservetaxonomynames
   1 pluralizelisttitles
   1 permalinks
   1 params
   1 paginatePath
   1 noTimes
   1 noChmod
   1 menu
   1 logFile
   1 layoutDir
   1 languagecode
   1 i18ndir
   1 googleanalytics
   1 footnotereturnlinkcontents
   1 footnoteanchorprefix
   1 footnoteReturnLinkContents
   1 footnoteAnchorPrefix
   1 enablerobotstxt
   1 enablemissingtranslationplaceholders
   1 enablegitinfo
   1 disqusshortname
   1 disablesitemap
   1 disablekinds
   1 disablehugogeneratorinject
   1 disablePathToLower
   1 disable404
   1 defaultContentLanguageInSubdir
   1 datadir
   1 copyright
   1 cleanDestinationDir
   1 canonifyURLs
   1 cacheDir
   1 baseURL
   1 author
```
Performance gain: about 0.5-1 sec by building hugodocs.info on my MacBook Air 2014/1,4 GHz Intel Core i5/4 GB 1600 MHz DDR3

Updates #2728 
Updates https://github.com/rdwatters/hugo-docs-concept/issues/44

@bep I appreciate if you will provide benchmarks