### PR TITLE
Ignore non-source files on partial rebuild.

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -728,6 +728,9 @@ func (s *Site) reProcess(events []fsnotify.Event) (whatChanged, error) {
 		go pageConverter(pageChan, convertResults, wg2)
 	}
 
+	sp := source.NewSourceSpec(s.Cfg, s.Fs)
+	fs := sp.NewFilesystem("")
+
 	for _, ev := range sourceChanged {
 		// The incrementalReadCollator below will also make changes to the site's pages,
 		// so we do this first to prevent races.
@@ -746,6 +749,15 @@ func (s *Site) reProcess(events []fsnotify.Event) (whatChanged, error) {
 			if ex, err := afero.Exists(s.Fs.Source, ev.Name); !ex || err != nil {
 				path, _ := helpers.GetRelativePath(ev.Name, s.getContentDir(ev.Name))
 				s.removePageByPath(path)
+				continue
+			}
+		}
+
+		// ignore files shouldn't be proceed
+		if fi, err := s.Fs.Source.Stat(ev.Name); err != nil {
+			continue
+		} else {
+			if ok, err := fs.ShouldRead(ev.Name, fi); err != nil || !ok {
 				continue
 			}
 		}

--- a/source/filesystem.go
+++ b/source/filesystem.go
@@ -90,7 +90,7 @@ func (f *Filesystem) captureFiles() {
 			return nil
 		}
 
-		b, err := f.shouldRead(filePath, fi)
+		b, err := f.ShouldRead(filePath, fi)
 		if err != nil {
 			return err
 		}
@@ -118,7 +118,7 @@ func (f *Filesystem) captureFiles() {
 
 }
 
-func (f *Filesystem) shouldRead(filePath string, fi os.FileInfo) (bool, error) {
+func (f *Filesystem) ShouldRead(filePath string, fi os.FileInfo) (bool, error) {
 	if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
 		link, err := filepath.EvalSymlinks(filePath)
 		if err != nil {


### PR DESCRIPTION
Partial rebuild does not have the same logic as normal rebuild on
selecting which file to build. This change makes it possible to
share the file select logic between two kinds of build.

Fix #3325.