### PR TITLE
hugolib, output: Do not lower case template names

### DIFF
--- a/hugolib/site_output_test.go
+++ b/hugolib/site_output_test.go
@@ -114,6 +114,8 @@ other = "Olboge"
 
 	th, h := newTestSitesFromConfig(t, mf, siteConfig,
 
+		// Case issue partials #3333
+		"layouts/partials/GoHugo.html", `Go Hugo Partial`,
 		"layouts/_default/baseof.json", `START JSON:{{block "main" .}}default content{{ end }}:END JSON`,
 		"layouts/_default/baseof.html", `START HTML:{{block "main" .}}default content{{ end }}:END HTML`,
 
@@ -137,6 +139,8 @@ List HTML|{{.Title }}|
 <atom:link href={{ .Permalink }} rel="self" type="{{ .MediaType }}" />
 {{- end -}}
 {{ .Site.Language.Lang }}: {{ T "elbow" -}}
+Partial Hugo 1: {{ partial "GoHugo.html" . }}
+Partial Hugo 2: {{ partial "GoHugo" . -}}
 {{ end }}
 `,
 	)

--- a/output/layout_base.go
+++ b/output/layout_base.go
@@ -101,7 +101,7 @@ func CreateTemplateNames(d TemplateLookupDescriptor) (TemplateNames, error) {
 	filenameNoSuffix := parts[0]
 
 	id.OverlayFilename = fullPath
-	id.Name = strings.ToLower(name)
+	id.Name = name
 
 	if isPlainText {
 		id.Name = "_text/" + id.Name


### PR DESCRIPTION
This regression was introduced in Hugo 0.20.

Fixes #3333