### PR TITLE
tplimpl: Allow text partials in HTML templates

### DIFF
--- a/tpl/tplimpl/template_funcs.go
+++ b/tpl/tplimpl/template_funcs.go
@@ -2221,5 +2221,5 @@ func (t *templateFuncster) initFuncMap() {
 	}
 
 	t.funcMap = funcMap
-	t.Tmpl.setFuncs(funcMap)
+	t.Tmpl.(*templateHandler).setFuncs(funcMap)
 }


### PR DESCRIPTION
Most obvius benefit of this is to include CSS partials with css file suffix into HTML templates.

A valid workaround would be to rename the file `mystyles.html`, but that doesn't work too good for external editors etc.

The css partial is  a method used in some themes before Hugo 0.20, but then it stopped working.

This commit reintroduces that behaviour.

Note that the regular layout lookups for text templates, i.e. "single.json" will be
prefixed with "_text/" on lookup and will only match in the text collection.

Fixes #3273