### PR TITLE
Add translation links to the default sitemap template

### DIFF
--- a/docs/content/templates/sitemap.md
+++ b/docs/content/templates/sitemap.md
@@ -31,16 +31,29 @@ one.
 
 ## Hugo’s sitemap.xml
 
-This template respects the version 0.9 of the [Sitemap
-Protocol](http://www.sitemaps.org/protocol.html).
+This template uses the version 0.9 of the [Sitemap
+Protocol](http://www.sitemaps.org/protocol.html) with Google's [hreflang
+attributes](https://support.google.com/webmasters/answer/2620865?hl=en&topic=2370587&ctx=topic)
+for linking to translated content.
 
-    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+      xmlns:xhtml="http://www.w3.org/1999/xhtml">
       {{ range .Data.Pages }}
       <url>
         <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
         <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
         <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
-        <priority>{{ .Sitemap.Priority }}</priority>{{ end }}
+        <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+        <xhtml:link
+                    rel="alternate"
+                    hreflang="{{ .Lang }}"
+                    href="{{ .Permalink }}"
+                    />{{ end }}
+        <xhtml:link
+                    rel="alternate"
+                    hreflang="{{ .Lang }}"
+                    href="{{ .Permalink }}"
+                    />{{ end }}
       </url>
       {{ end }}
     </urlset>

--- a/tpl/tplimpl/template_embedded.go
+++ b/tpl/tplimpl/template_embedded.go
@@ -87,13 +87,24 @@ func (t *templateHandler) embedTemplates() {
   </channel>
 </rss>`)
 
-	t.addInternalTemplate("_default", "sitemap.xml", `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+	t.addInternalTemplate("_default", "sitemap.xml", `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages }}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
     <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
-    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}
+    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Lang }}"
+                href="{{ .Permalink }}"
+                />{{ end }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Lang }}"
+                href="{{ .Permalink }}"
+                />{{ end }}
   </url>
   {{ end }}
 </urlset>`)


### PR DESCRIPTION
For pages with translations, add links with hreflang attributes to the
default sitemap template. This helps Google to show the correct
language page in its search results. The syntax used is based on
Google's example at [1].

Also update the sitemap template docs to reflect the changes in the
default template.

[1] https://support.google.com/webmasters/answer/2620865?hl=en&topic=2370587&ctx=topic

Fixes #2569