### PR TITLE
Set extldflags to static when building

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,7 +1,7 @@
 build:
   main: main.go
   binary: hugo
-  ldflags_template: -s -w -X hugolib.BuildDate={{.Date}} -extldflags "-static"
+  ldflags_template: -s -w -X hugolib.BuildDate={{.Date}} -linkmode external -extldflags "-static"
   goos:
     - darwin
     - linux

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,7 +1,7 @@
 build:
   main: main.go
   binary: hugo
-  ldflags_template: -s -w -X hugolib.BuildDate={{.Date}}
+  ldflags_template: -s -w -X hugolib.BuildDate={{.Date}} -extldflags "-static"
   goos:
     - darwin
     - linux


### PR DESCRIPTION
This sets the `-static` ldflag when building Hugo, so that it can be run in a minimal Docker container.

EDIT: Does in fact work fine when building for Windows

Closes #3382