### PR TITLE
hugolib: Avoid index.md in /index/index.html

### DIFF
--- a/hugolib/page_paths.go
+++ b/hugolib/page_paths.go
@@ -141,6 +141,15 @@ func createTargetPath(d targetPathDescriptor) string {
 
 	isUgly := d.UglyURLs && !d.Type.NoUgly
 
+	// If the page output format's base name is the same as the page base name,
+	// we treat it as an ugly path, i.e.
+	// my-blog-post-1/index.md => my-blog-post-1/index.html
+	// (given the default values for that content file, i.e. no slug set etc.).
+	// This introduces the behaviour from < Hugo 0.20, see issue #3396.
+	if d.BaseName != "" && d.BaseName == d.Type.BaseName {
+		isUgly = true
+	}
+
 	if d.Kind != KindPage && len(d.Sections) > 0 {
 		pagePath = filepath.Join(d.Sections...)
 		needsBase = false

--- a/hugolib/page_paths_test.go
+++ b/hugolib/page_paths_test.go
@@ -62,6 +62,16 @@ func TestPageTargetPath(t *testing.T) {
 								BaseName: "mypage",
 								Sections: []string{"a"},
 								Type:     output.HTMLFormat}, "/a/b/mypage/index.html"},
+
+						{
+							// Issue #3396
+							"HTML page with index as base", targetPathDescriptor{
+								Kind:     KindPage,
+								Dir:      "/a/b",
+								BaseName: "index",
+								Sections: []string{"a"},
+								Type:     output.HTMLFormat}, "/a/b/index.html"},
+
 						{
 							"HTML page with special chars", targetPathDescriptor{
 								Kind:     KindPage,
@@ -139,7 +149,9 @@ func TestPageTargetPath(t *testing.T) {
 						expected := test.expected
 
 						// TODO(bep) simplify
-						if test.d.Kind == KindHome && test.d.Type.Path != "" {
+						if test.d.BaseName == test.d.Type.BaseName {
+
+						} else if test.d.Kind == KindHome && test.d.Type.Path != "" {
 						} else if (!strings.HasPrefix(expected, "/index") || test.d.Addends != "") && test.d.URL == "" && isUgly {
 							expected = strings.Replace(expected,
 								"/"+test.d.Type.BaseName+"."+test.d.Type.MediaType.Suffix,

--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -959,11 +959,13 @@ func TestRefLinking(t *testing.T) {
 	}{
 		// Note: There are no magic in the index.md name. This was fixed in Hugo 0.20.
 		// Before that, index.md would wrongly resolve to "/".
-		{"index.md", "", true, "/index/"},
+		// See #3396 -- there is an ambiguity in the examples below, even if they do work.
+		// TODO(bep) better test cases
+		{"index.md", "", true, "/"},
 		{"common.md", "", true, "/level2/common/"},
 		{"3-root.md", "", true, "/level2/level3/3-root/"},
-		{"index.md", "amp", true, "/amp/index/"},
-		{"index.md", "amp", false, "http://auth/amp/index/"},
+		{"index.md", "amp", true, "/amp/"},
+		{"index.md", "amp", false, "http://auth/amp/"},
 	} {
 		if out, err := site.Info.refLink(test.link, currentPage, test.relative, test.outputFormat); err != nil || out != test.expected {
 			t.Errorf("[%d] Expected %s to resolve to (%s), got (%s) - error: %s", i, test.link, test.expected, out, err)
@@ -981,9 +983,11 @@ func TestSourceRelativeLinksing(t *testing.T) {
 
 	okresults := map[string]resultMap{
 		"index.md": map[string]string{
-			"/docs/rootfile.md":             "/rootfile/",
-			"rootfile.md":                   "/rootfile/",
-			"index.md":                      "/index/",
+			"/docs/rootfile.md": "/rootfile/",
+			"rootfile.md":       "/rootfile/",
+			// See #3396 -- this may potentially be ambiguous (i.e. name conflict with home page).
+			// But the user have chosen so. This index.md patterns is more relevant in /sub-folders.
+			"index.md":                      "/",
 			"level2/2-root.md":              "/level2/2-root/",
 			"/docs/level2/2-root.md":        "/level2/2-root/",
 			"level2/level3/3-root.md":       "/level2/level3/3-root/",


### PR DESCRIPTION
Hugo 0.20 broke some sites that grouped their blog post and images together in subfolders.

This commit re-introduces that behaviour:

* If the file base name resolves to the same as the base name for the output type (i.e. "index" for HTML), the user probably meant it, so we treat that as an `uglyURL`, i.e. `my-blog-post-1.md`=> `/my-blog-post-1/index.html`
* The main use case for this is to group blog post and images together.
* Note that for the top level folder there will be a potential name conflict with a `section` `index.html` (if enabled)
* This issue will not be relevant for subfolders in sections
* Hugo will soon add support for nested sections, but we will have to find a way to separate them from the rest (`/content/_mysubsection` maybe).

Fixes #3396