### PR TITLE
Add a widget mechanism to Hugo

### DIFF
--- a/helpers/path.go
+++ b/helpers/path.go
@@ -173,6 +173,12 @@ func (p *PathSpec) GetStaticDirPath() string {
 	return p.AbsPathify(p.staticDir)
 }
 
+// GetWidgetsDirPath returns the absolute path to the widgets'
+// directory for the current Hugo project.
+func (p *PathSpec) GetWidgetsDirPath() string {
+	return p.AbsPathify(p.widgetsDir)
+}
+
 // GetThemeDir gets the root directory of the current theme, if there is one.
 // If there is no theme, returns the empty string.
 func (p *PathSpec) GetThemeDir() string {

--- a/helpers/pathspec.go
+++ b/helpers/pathspec.go
@@ -39,6 +39,7 @@ type PathSpec struct {
 	// Directories
 	themesDir  string
 	layoutDir  string
+	widgetsDir string
 	workingDir string
 	staticDir  string
 
@@ -82,6 +83,7 @@ func NewPathSpec(fs *hugofs.Fs, cfg config.Provider) (*PathSpec, error) {
 		BaseURL:                        baseURL,
 		themesDir:                      cfg.GetString("themesDir"),
 		layoutDir:                      cfg.GetString("layoutDir"),
+		widgetsDir:                     cfg.GetString("widgetsDir"),
 		workingDir:                     cfg.GetString("workingDir"),
 		staticDir:                      cfg.GetString("staticDir"),
 		theme:                          cfg.GetString("theme"),
@@ -107,6 +109,11 @@ func (p *PathSpec) WorkingDir() string {
 // LayoutDir returns the relative layout dir in the currenct Hugo project.
 func (p *PathSpec) LayoutDir() string {
 	return p.layoutDir
+}
+
+// WidgetsDir returns the relative layout dir in the currenct Hugo project.
+func (p *PathSpec) WidgetsDir() string {
+	return p.widgetsDir
 }
 
 // Theme returns the theme name if set.

--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -68,6 +68,7 @@ func loadDefaultSettingsFor(v *viper.Viper) {
 	v.SetDefault("contentDir", "content")
 	v.SetDefault("layoutDir", "layouts")
 	v.SetDefault("staticDir", "static")
+	v.SetDefault("widgetsDir", "widgets")
 	v.SetDefault("archetypeDir", "archetypes")
 	v.SetDefault("publishDir", "public")
 	v.SetDefault("dataDir", "data")

--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -147,6 +147,18 @@ func (s *Site) withSiteTemplates(withTemplates ...func(templ tpl.TemplateHandler
 			}
 		}
 
+		// Here we handle the widgets. The site gets all HTML
+		// code to inject it inside the template, when the
+		// {{ widgets "mywidgetarea" }} is called.
+
+		// Load all templates placed in the widgets/ directory.
+		// TODO already done inside injectWidgets().
+		//templ.LoadTemplates(s.PathSpec.GetWidgetsDirPath(), "widgets")
+
+		if err := s.injectWidgets(templ); err != nil {
+			s.Log.ERROR.Printf("Failed to load widgets: %s", err)
+		}
+
 		return nil
 	}
 }

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -95,6 +95,7 @@ type Site struct {
 	Sections Taxonomy
 	Info     SiteInfo
 	Menus    Menus
+	Widgets  Widgets
 	timer    *nitro.B
 
 	layoutHandler *output.LayoutHandler
@@ -296,6 +297,7 @@ type SiteInfo struct {
 	*PageCollections
 	Files                 *[]*source.File
 	Menus                 *Menus
+	Widgets               *Widgets
 	Hugo                  *HugoInfo
 	Title                 string
 	RSSLink               string
@@ -1097,6 +1099,7 @@ func (s *Site) initializeSiteInfo() {
 		Data:                           &s.Data,
 		owner:                          s.owner,
 		s:                              s,
+		Widgets:                        &s.Widgets,
 	}
 
 	s.Info.RSSLink = s.permalink(lang.GetString("rssURI"))
@@ -1152,6 +1155,18 @@ func (s *Site) getThemeDataDir(path string) string {
 		return ""
 	}
 	return s.getRealDir(filepath.Join(s.PathSpec.GetThemeDir(), s.dataDir()), path)
+}
+
+func (s *Site) widgetDir() string {
+	return s.Cfg.GetString("widgetsDir")
+}
+
+func (s *Site) getWidgetDir(path string) string {
+	return s.getRealDir(s.Cfg.GetString("widgetDir"), path)
+}
+
+func (s *Site) isWidgetDirEvent(e fsnotify.Event) bool {
+	return s.getWidgetDir(e.Name) != ""
 }
 
 func (s *Site) layoutDir() string {

--- a/hugolib/widget.go
+++ b/hugolib/widget.go
@@ -1,0 +1,145 @@
+// Copyright 2016-present The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hugolib
+
+import (
+	"html/template"
+
+	"github.com/spf13/cast"
+	"github.com/spf13/hugo/tpl"
+)
+
+// TODO See the shortcode system to see the structure
+
+// Data structures and methods
+// ===========================
+
+// A WidgetEntry represents a widget item defined
+// in the site config.
+// (TODO: See hugolib/menu.go for the data structure)
+type Widget struct {
+	Type       string
+	Params     map[string]interface{}
+	Identifier string
+	Weight     int
+	Template   *template.Template
+}
+
+func newWidget(widgetType string, options interface{}) (*Widget, error) {
+	return &Widget{Type: widgetType, Params: options.(map[string]interface{})}, nil
+}
+
+type WidgetArea struct {
+	Name     string
+	Widgets  []*Widget
+	Template *template.Template
+}
+
+func newWidgetArea(waname string) *WidgetArea {
+	// TODO ??
+	return &WidgetArea{Name: waname, Widgets: nil, Template: nil}
+}
+
+type Widgets map[string]*WidgetArea
+
+// Internal widgets building
+// =========================
+
+// WidgetsConfig parses the widgets config variable
+// (is a collection) and calls every widget configuration.
+func (s *Site) getWidgetsFromConfig() Widgets {
+	ret := Widgets{}
+
+	if conf := s.Cfg.GetStringMap("widgets"); conf != nil {
+		for waname, widgetarea := range conf {
+			// wa is a widget area defined in the conf file
+			wa, err := cast.ToSliceE(widgetarea)
+			if err != nil {
+				s.Log.ERROR.Printf("unable to process widgets in site config\n")
+				s.Log.ERROR.Println(err)
+			}
+
+			// Instantiate a WidgetArea
+			waobj := newWidgetArea(waname)
+
+			// Retrieve all widgets
+			for _, w := range wa {
+				iw, err := cast.ToStringMapE(w)
+
+				if err != nil {
+					s.Log.ERROR.Printf("unable to process widget inside widget area in site config\n")
+					s.Log.ERROR.Println(err)
+				}
+
+				// iw represents a widget inside a widget area
+				wtype := cast.ToString(iw["type"])
+				woptions, err := cast.ToStringMapE(iw["options"])
+				wobj, err := newWidget(wtype, woptions)
+
+				if err != nil {
+					s.Log.ERROR.Printf("unable to instantiate widget: %s\n", iw)
+					s.Log.ERROR.Println(err)
+				}
+
+				// then append it to the widget area object
+				waobj.Widgets = append(waobj.Widgets, wobj)
+			}
+
+			// don't forget to append that widget area to the
+			// Widgets object
+			ret[waname] = waobj
+		}
+	}
+
+	return ret
+}
+
+// instantiateWidget retrieves the widget's files
+// and creates the templates
+func (s *Site) instantiateWidget(temp tpl.TemplateHandler, wa *WidgetArea, w *Widget) *Widget {
+	// Load this widget's templates
+	// using the site object's owner.tmpl
+	temp.LoadTemplates(s.PathSpec.GetWidgetsDirPath()+"/"+w.Type+"/layouts", "widgets/"+w.Type)
+
+	return w
+}
+
+// Main widgets entry point
+// ========================
+
+// This function adds the whole widgets' template code
+// in the Site object. This is of type template.HTML.
+// This function is called from hugo_sites.
+func (s *Site) injectWidgets(temp tpl.TemplateHandler) error {
+	// Get widgets. This gives all information we need but
+	// does not already read widget files.
+	widgets := s.getWidgetsFromConfig()
+
+	for _, widgetarea := range widgets {
+		// _ is waname, if ever we need
+
+		for _, w := range widgetarea.Widgets {
+			w = s.instantiateWidget(temp, widgetarea, w)
+		}
+	}
+
+	// We now have all widgets with their templates.
+	// Generate all widget areas with their templates
+	// Now the template's content will be used inside
+	// the main template files inside tpl/template_funcs
+	// and in the templates using {{ widgets "mywidgetarea" }}
+	s.Widgets = widgets
+
+	return nil
+}

--- a/tpl/tplimpl/template_embedded.go
+++ b/tpl/tplimpl/template_embedded.go
@@ -56,6 +56,7 @@ func (t *templateHandler) embedShortcodes() {
 	t.addInternalShortcode("gist.html", `<script src="//gist.github.com/{{ index .Params 0 }}/{{ index .Params 1 }}.js{{if len .Params | eq 3 }}?file={{ index .Params 2 }}{{end}}"></script>`)
 	t.addInternalShortcode("tweet.html", `{{ (getJSON "https://api.twitter.com/1/statuses/oembed.json?id=" (index .Params 0)).html | safeHTML }}`)
 	t.addInternalShortcode("instagram.html", `{{ if len .Params | eq 2 }}{{ if eq (.Get 1) "hidecaption" }}{{ with getJSON "https://api.instagram.com/oembed/?url=https://instagram.com/p/" (index .Params 0) "/&hidecaption=1" }}{{ .html | safeHTML }}{{ end }}{{ end }}{{ else }}{{ with getJSON "https://api.instagram.com/oembed/?url=https://instagram.com/p/" (index .Params 0) "/&hidecaption=0" }}{{ .html | safeHTML }}{{ end }}{{ end }}`)
+	t.addInternalShortcode("widgets.html", `{{ widgets (.Get 0) $ }}`)
 }
 
 func (t *templateHandler) embedTemplates() {
@@ -150,6 +151,24 @@ func (t *templateHandler) embedTemplates() {
     </ul>
     {{ end }}`)
 
+	t.addInternalTemplate("", "widgets.html", `{{- range .c.Site.Widgets -}}
+{{- if eq .Name $._wa -}}{{/* Display only the current widget area */}}
+<div class="widget-area widget-area-{{ .Name }}">
+  {{- $waname := .Name -}}
+  {{ range .Widgets -}}
+  <div class="widget widget-{{ .Type }}">
+    {{ $context := (dict "$" $.c "wa" $._wa "w" .Type "Params" .Params) }}
+    {{ partial (print .Type "/widget.html") "widgets" $context }}
+  </div>
+  {{- end }}{{/* end range widgets */}}
+</div>
+{{/* end if */}}{{- end -}}
+{{/* end range widget areas */}}{{- end -}}`)
+
+	t.addInternalTemplate("widgets", "text/widget.html", `{{- if isset .Params "content" -}}
+  {{- .Params.content | safeHTML -}}
+{{- else -}}<pre>Here is a text widget, but there is nothing to print. Please define options.content inside every text widget in your config.</pre>
+{{- end -}}`)
 	t.addInternalTemplate("", "disqus.html", `{{ if .Site.DisqusShortname }}<div id="disqus_thread"></div>
 <script type="text/javascript">
     var disqus_shortname = '{{ .Site.DisqusShortname }}';

--- a/tpl/tplimpl/template_embedded.go
+++ b/tpl/tplimpl/template_embedded.go
@@ -155,9 +155,10 @@ func (t *templateHandler) embedTemplates() {
 {{- if eq .Name $._wa -}}{{/* Display only the current widget area */}}
 <div class="widget-area widget-area-{{ .Name }}">
   {{- $waname := .Name -}}
+  {{- $wa := . -}}
   {{ range .Widgets -}}
   <div class="widget widget-{{ .Type }}">
-    {{ $context := (dict "$" $.c "wa" $._wa "w" .Type "Params" .Params) }}
+    {{ $context := (dict "$" $.c "WidgetArea" $wa "Widget" .) }}
     {{ partial (print .Type "/widget.html") "widgets" $context }}
   </div>
   {{- end }}{{/* end range widgets */}}

--- a/tpl/tplimpl/template_funcs.go
+++ b/tpl/tplimpl/template_funcs.go
@@ -39,6 +39,7 @@ import (
 	_ "github.com/spf13/hugo/tpl/time"
 	_ "github.com/spf13/hugo/tpl/transform"
 	_ "github.com/spf13/hugo/tpl/urls"
+	_ "github.com/spf13/hugo/tpl/widget"
 )
 
 func (t *templateFuncster) initFuncMap() {

--- a/tpl/widget/init.go
+++ b/tpl/widget/init.go
@@ -1,0 +1,49 @@
+// Copyright 2017 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package widget
+
+import (
+	"github.com/spf13/hugo/deps"
+	"github.com/spf13/hugo/tpl/internal"
+)
+
+const name = "widget"
+
+func init() {
+	f := func(d *deps.Deps) *internal.TemplateFuncsNamespace {
+		ctx := New(d)
+
+		// TODO modify the template _internal/widgets.html to
+		// allow output even if no widget area have been set in
+		// config file (see tpl/tplimpl/template_embedded.go).
+		/*examples := [][1]string{
+			{`{{ widgets "footer" . }}`, `<div class="widget-area widget-area-footer">YOUR WIDGETS GENERATED HERE</div>`},
+		}*/
+
+		ns := &internal.TemplateFuncsNamespace{
+			Name:    name,
+			Context: func() interface{} { return ctx },
+		}
+
+		ns.AddMethodMapping(ctx.Widgets,
+			[]string{"widgets"},
+			[][2]string{},
+		)
+
+		return ns
+
+	}
+
+	internal.AddTemplateFuncsNamespace(f)
+}

--- a/tpl/widget/widget.go
+++ b/tpl/widget/widget.go
@@ -1,0 +1,59 @@
+// Copyright 2017 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package widget
+
+import (
+	"fmt"
+	"html/template"
+
+	bp "github.com/spf13/hugo/bufferpool"
+	"github.com/spf13/hugo/deps"
+)
+
+var TestTemplateProvider deps.ResourceProvider
+
+// New returns a new instance of the templates-namespaced template functions.
+func New(deps *deps.Deps) *Namespace {
+	return &Namespace{
+		deps: deps,
+	}
+}
+
+// Namespace provides template functions for the "templates" namespace.
+type Namespace struct {
+	deps *deps.Deps
+}
+
+// IncludeWidgetArea retrieves and display a widget area using the /widgets/ shortcode
+func (ns *Namespace) Widgets(name string, context interface{}) (interface{}, error) {
+	// Add (_wa: name) index/value to context to access it inside
+	// the embedded template (as Widget Area)
+	outcontext := make(map[string]interface{})
+	outcontext["c"] = context
+	outcontext["_wa"] = name
+
+	// See in template_embedded for widgets.html
+	templ := ns.deps.Tmpl.Lookup("_internal/widgets.html")
+	if templ != nil {
+		b := bp.GetBuffer()
+		defer bp.PutBuffer(b)
+
+		if err := templ.Execute(b, outcontext); err != nil {
+			return "", err
+		}
+
+		return template.HTML(b.String()), nil
+	}
+	return "", fmt.Errorf("Widget area %q not found", name)
+}

--- a/tpl/widget/widget.go
+++ b/tpl/widget/widget.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"html/template"
 
+	"github.com/spf13/cast"
 	bp "github.com/spf13/hugo/bufferpool"
 	"github.com/spf13/hugo/deps"
 )
@@ -39,9 +40,8 @@ type Namespace struct {
 func (ns *Namespace) Widgets(name string, context interface{}) (interface{}, error) {
 	// Add (_wa: name) index/value to context to access it inside
 	// the embedded template (as Widget Area)
-	outcontext := make(map[string]interface{})
-	outcontext["c"] = context
-	outcontext["_wa"] = name
+	outcontext := cast.ToStringMap(context)
+	outcontext["_wa"] = name // The widget area name
 
 	// See in template_embedded for widgets.html
 	templ := ns.deps.Tmpl.Lookup("_internal/widgets.html")


### PR DESCRIPTION
Here is a first attempt to get widgets into Hugo.

1. Create a site
2. Create a widget directory inside `/widgets`. It should look like this:
```
widgets/
└── text
    ├── layouts
    │   └── widget.html
    └── README.md
```
Note that the name `widget.html` is mandatory. *Currently the context is the content of the config parameter `widgets.[mywidgetarea].[mywidget].options`*. Variables are accessible with `.content` for a text widget like the following and as described in the config below.
```
{{- if isset . "content" -}}
  {{- .content | safeHTML -}}
{{- else -}}<pre>Here is a text widget, but there is nothing to print. Please define options.content inside every text widget in your config.</pre>
{{- end -}}
```

3. Configure your site with a `widgets` variable describing widgets inside widget areas:
```
widgets:
  sidebar:
    - type: text
      options:
        content: "<h1>IT WORKS from config</h1>"
        parser: html
  showcase:
    - type: text
      options:
        content: "Here lies a showcase."
  footer:
    - type: text
      options:
        content: "Powered by Hugo with widgets."
        foo: bar
```

4. Create a template using the `widgets` call. This can be done like this: `{{ widgets "sidebar" . }}`.
5. Create content. You can also use the widget's shortcode: `{{% widgets "showcase" %}}`
6. Build and enjoy.

- Currently the widgets' context is only the content of the config variable. We should add a wider context (easy).
- I have not studied the impact on performances.
- Else?

Fixes #2683
See #2535