### PR TITLE
hugolib: Render 404 page for default content language only

### DIFF
--- a/hugolib/site_render.go
+++ b/hugolib/site_render.go
@@ -239,6 +239,10 @@ func (s *Site) render404() error {
 		return nil
 	}
 
+	if s.owner.multilingual.enabled() && (s.Language.Lang != s.owner.multilingual.DefaultLang.Lang) {
+		return nil
+	}
+
 	p := s.newNodePage(kind404)
 
 	p.Title = "404 Page not found"


### PR DESCRIPTION
This prevents 404.html from being re-rendered for each site.

Resolves https://github.com/spf13/hugo/issues/3075