### PR TITLE
Replace cdn.mathjax.org with cdnjs.cloudflare.com

### DIFF
--- a/docs/content/tutorials/mathjax.md
+++ b/docs/content/tutorials/mathjax.md
@@ -20,10 +20,10 @@ This is not an introduction into actually using MathJax to render typeset mathem
 
 ## Enabling MathJax
 
-The first step is to enable MathJax on pages that you would like to have typeset math. There are multiple ways to do this (adventurous readers can consult the [Loading and Configuring](http://docs.mathjax.org/en/latest/configuration.html) section of the MathJax documentation for additional methods of including MathJax), but the easiest way is to use the secure MathJax CDN by including the following HTML snippet in the source of a page:
+The first step is to enable MathJax on pages that you would like to have typeset math. There are multiple ways to do this (adventurous readers can consult the [Loading and Configuring](http://docs.mathjax.org/en/latest/configuration.html) section of the MathJax documentation for additional methods of including MathJax), but the easiest way is to use [the officially recommended secure CDN](https://cdnjs.com/) by including the following HTML snippet in the source of a page:
 
     <script type="text/javascript"
-      src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
     </script>
 
 One way to ensure that this code is included in all pages is to put it in one of the templates that live in the `layouts/partials/` directory. For example, I have included this in the bottom of my template `footer.html` because I know that the footer will be included in every page of my website.


### PR DESCRIPTION
MathJax officially informed that [their self-hosted *cdn.mathjax.org* is retired](http://docs.mathjax.org/en/latest/configuration.html#loading-mathjax-from-a-cdn), and they currently recommend to use *cdnjs.cloudflare.com*.

Thus, this PR fixes corresponding MathJax document.

Note: Since *cdnjs.com* does not provide a link to the **latest** version of MathJax, sample snippet specifies to use version 2.7.1 (i.e., the latest version at this moment).