### PR TITLE
add ability to disable content based on extension

### DIFF
--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -112,4 +112,5 @@ func loadDefaultSettingsFor(v *viper.Viper) {
 	v.SetDefault("defaultContentLanguageInSubdir", false)
 	v.SetDefault("enableMissingTranslationPlaceholders", false)
 	v.SetDefault("enableGitInfo", false)
+	v.SetDefault("ignoreFiles", make([]string, 0))
 }


### PR DESCRIPTION
allows Hugo users to define content extensions they want to ignore during build. As an example, if a user wants to ignore files in their content directory that have `.org` extensions, they can set the following configuration in their `config.toml`:

```
[disableContentType]
  org = true
```

Original request from @strow: https://github.com/chaseadamsio/goorgeous/issues/32
Also mentioned in this PR: https://github.com/spf13/hugo/pull/3180#issuecomment-286499092