### PR TITLE
hubolib: Embed Page in WeightedPage

### DIFF
--- a/hugolib/taxonomy.go
+++ b/hugolib/taxonomy.go
@@ -39,7 +39,7 @@ type WeightedPages []WeightedPage
 // A WeightedPage is a Page with a weight.
 type WeightedPage struct {
 	Weight int
-	Page   *Page
+	*Page
 }
 
 func (w WeightedPage) String() string {


### PR DESCRIPTION
People can still say `.Page`, but by embedding it `WeightedPages` can be used interchangeably with `Pages` in templates.

Fixes #3435