### PR TITLE
hugolib: add default config for ignoreFiles

### DIFF
--- a/hugolib/config.go
+++ b/hugolib/config.go
@@ -112,4 +112,5 @@ func loadDefaultSettingsFor(v *viper.Viper) {
 	v.SetDefault("defaultContentLanguageInSubdir", false)
 	v.SetDefault("enableMissingTranslationPlaceholders", false)
 	v.SetDefault("enableGitInfo", false)
+	v.SetDefault("ignoreFiles", make([]string, 0))
 }


### PR DESCRIPTION
From @bep's recommendation from spf13/hugo/pull/3424, this PR fixes the `hugo server` command not using `ignoreFiles`. Just added the `ignoreFiles` default to the `config.go` and that fixed it. This should close out the `org` issue that @strow was having and then I can get back to making the go org library better. :)
