### PR TITLE
docs: Use single link element for RSS in example

### DIFF
--- a/docs/content/templates/rss.md
+++ b/docs/content/templates/rss.md
@@ -113,8 +113,7 @@ In your `header.html` template, you can specify your RSS feed in your `<head></h
 
 ~~~html
 {{ if .RSSLink }}
-  <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-  <link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+  <link href="{{ .RSSLink }}" rel="alternate feed" type="application/rss+xml" title="{{ .Site.Title }}" />
 {{ end }}
 ~~~
 


### PR DESCRIPTION
The rel attribute supports specifying a set of values, not only a single
one. Using two link elements can also cause browsers to show the feed
twice in menus.