### PR TITLE
hugolib: Simplify replaceShortcodeTokens

### DIFF
--- a/hugolib/hugo_sites.go
+++ b/hugolib/hugo_sites.go
@@ -561,7 +561,6 @@ func (s *Site) preparePagesForRender(cfg *BuildCfg) {
 				}
 
 				if p.Markup != "html" {
-
 					// Now we know enough to create a summary of the page and count some words
 					summaryContent, err := p.setUserDefinedSummaryIfProvided(workContentCopy)
 
@@ -578,14 +577,12 @@ func (s *Site) preparePagesForRender(cfg *BuildCfg) {
 							s.Log.ERROR.Printf("Failed to set user auto summary for page %q: %s", p.pathOrTitle(), err)
 						}
 					}
-
 				} else {
 					p.Content = helpers.BytesToHTML(workContentCopy)
 				}
 
-				//analyze for raw stats
+				// Analyze for raw stats
 				p.analyzePage()
-
 			}
 		}(pageChan, wg)
 	}
@@ -606,19 +603,19 @@ func (h *HugoSites) Pages() Pages {
 }
 
 func handleShortcodes(p *Page, rawContentCopy []byte) ([]byte, error) {
-	if p.shortcodeState != nil && len(p.shortcodeState.contentShortcodes) > 0 {
-		p.s.Log.DEBUG.Printf("Replace %d shortcodes in %q", len(p.shortcodeState.contentShortcodes), p.BaseFileName())
-		err := p.shortcodeState.executeShortcodesForDelta(p)
+	if p.shortcodeState == nil || len(p.shortcodeState.contentShortcodes) == 0 {
+		return rawContentCopy, nil
+	}
 
-		if err != nil {
-			return rawContentCopy, err
-		}
+	p.s.Log.DEBUG.Printf("Replace %d shortcodes in %q", len(p.shortcodeState.contentShortcodes), p.BaseFileName())
+	err := p.shortcodeState.executeShortcodesForDelta(p)
+	if err != nil {
+		return rawContentCopy, err
+	}
 
-		rawContentCopy, err = replaceShortcodeTokens(rawContentCopy, shortcodePlaceholderPrefix, p.shortcodeState.renderedShortcodes)
-
-		if err != nil {
-			p.s.Log.FATAL.Printf("Failed to replace shortcode tokens in %s:\n%s", p.BaseFileName(), err.Error())
-		}
+	rawContentCopy, err = replaceShortcodeTokens(rawContentCopy, p.shortcodeState.renderedShortcodes)
+	if err != nil {
+		p.s.Log.FATAL.Printf("Failed to replace shortcode tokens in %s: %s", p.BaseFileName(), err)
 	}
 
 	return rawContentCopy, nil

--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -619,7 +619,6 @@ Loop:
 }
 
 // Replace prefixed shortcode tokens (HUGOSHORTCODE-1, HUGOSHORTCODE-2) with the real content.
-// Note: This function will rewrite the input slice.
 func replaceShortcodeTokens(source []byte, replacements map[string]string) ([]byte, error) {
 	if len(replacements) == 0 {
 		return source, nil
@@ -684,11 +683,7 @@ func replaceShortcodeTokens(source []byte, replacements map[string]string) ([]by
 		}
 	}
 
-	buf.Write(source[lastShortcodeEnd:])
-	source = make([]byte, buf.Len())
-	copy(source, buf.Bytes())
-
-	return source, nil
+	return append(buf.Bytes(), source[lastShortcodeEnd:]...), nil
 }
 
 func getShortcodeTemplateForTemplateKey(key scKey, shortcodeName string, t tpl.TemplateFinder) *tpl.TemplateAdapter {

--- a/hugolib/shortcode.go
+++ b/hugolib/shortcode.go
@@ -553,7 +553,6 @@ Loop:
 }
 
 func (s *shortcodeHandler) extractShortcodes(stringToParse string, p *Page) (string, error) {
-
 	startIdx := strings.Index(stringToParse, "{{")
 
 	// short cut for docs with no shortcodes
@@ -570,10 +569,9 @@ func (s *shortcodeHandler) extractShortcodes(stringToParse string, p *Page) (str
 
 	result := bp.GetBuffer()
 	defer bp.PutBuffer(result)
-	//var result bytes.Buffer
 
-	// the parser is guaranteed to return items in proper order or fail, so …
-	// … it's safe to keep some "global" state
+	// the parser is guaranteed to return items in proper order or fail, so
+	// it's safe to keep some "global" state
 	var currItem item
 	var currShortcode shortcode
 
@@ -622,48 +620,73 @@ Loop:
 
 // Replace prefixed shortcode tokens (HUGOSHORTCODE-1, HUGOSHORTCODE-2) with the real content.
 // Note: This function will rewrite the input slice.
-func replaceShortcodeTokens(source []byte, prefix string, replacements map[string]string) ([]byte, error) {
-
+func replaceShortcodeTokens(source []byte, replacements map[string]string) ([]byte, error) {
 	if len(replacements) == 0 {
 		return source, nil
 	}
 
-	sourceLen := len(source)
-	start := 0
-
-	pre := []byte("HAHA" + prefix)
+	pre := []byte("HAHA" + shortcodePlaceholderPrefix)
 	post := []byte("HBHB")
 	pStart := []byte("<p>")
 	pEnd := []byte("</p>")
 
-	k := bytes.Index(source[start:], pre)
+	preIndex := bytes.Index(source, pre)
+	if preIndex < 0 {
+		return source, nil
+	}
 
-	for k != -1 {
-		j := start + k
-		postIdx := bytes.Index(source[j:], post)
-		if postIdx < 0 {
-			// this should never happen, but let the caller decide to panic or not
-			return nil, errors.New("illegal state in content; shortcode token missing end delim")
+	buf := bp.GetBuffer()
+	defer bp.PutBuffer(buf)
+
+	lastShortcodeEnd := 0
+	for {
+		postIndex := bytes.Index(source[preIndex:], post)
+		if postIndex < 0 {
+			return nil, errors.New("illegal state in content: shortcode token missing end delim")
 		}
 
-		end := j + postIdx + 4
+		shortcodeEnd := preIndex + postIndex + len(post)
 
-		newVal := []byte(replacements[string(source[j:end])])
-
-		// Issue #1148: Check for wrapping p-tags <p>
-		if j >= 3 && bytes.Equal(source[j-3:j], pStart) {
-			if (k+4) < sourceLen && bytes.Equal(source[end:end+4], pEnd) {
-				j -= 3
-				end += 4
+		replacement := []byte(replacements[string(source[preIndex:shortcodeEnd])])
+		// If replacement also contains shortcodes.
+		if bytes.Contains(replacement, pre) {
+			var err error
+			replacement, err = replaceShortcodeTokens(replacement, replacements)
+			if err != nil {
+				return nil, err
 			}
 		}
 
-		// This and other cool slice tricks: https://github.com/golang/go/wiki/SliceTricks
-		source = append(source[:j], append(newVal, source[end:]...)...)
-		start = j
-		k = bytes.Index(source[start:], pre)
+		// Issue #1148: Check for wrapping p-tags <p>
+		containPs := false
+		if preIndex >= len(pStart) && bytes.Equal(source[preIndex-len(pStart):preIndex], pStart) {
+			if preIndex+len(pEnd) < len(source) && bytes.Equal(source[shortcodeEnd:shortcodeEnd+len(pEnd)], pEnd) {
+				containPs = true
+			}
+		}
 
+		if containPs {
+			// Don't write <p>.
+			buf.Write(source[lastShortcodeEnd : preIndex-len(pStart)])
+			// Skip </p>.
+			shortcodeEnd += len(pEnd)
+		} else {
+			buf.Write(source[lastShortcodeEnd:preIndex])
+		}
+		buf.Write(replacement)
+
+		lastShortcodeEnd = shortcodeEnd
+		nextPre := bytes.Index(source[shortcodeEnd:], pre)
+		if nextPre < 0 {
+			break
+		} else {
+			preIndex = shortcodeEnd + nextPre
+		}
 	}
+
+	buf.Write(source[lastShortcodeEnd:])
+	source = make([]byte, buf.Len())
+	copy(source, buf.Bytes())
 
 	return source, nil
 }

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -243,7 +243,7 @@ And then:
 This is **plain** text.
 
 {{< /inside >}}
-`, "<div><h1 id=\"more-here\">More Here</h1>\n\n<p><a href=\"http://spf13.com\">link</a> and text</p>\n</div>\n\n<p>And then:</p>\n\n<p><div>\n# More Here\n\nThis is **plain** text.\n\n</div>", wt)
+`, "<div><h1 id=\"more-here\">More Here</h1>\n\n<p><a href=\"http://spf13.com\">link</a> and text</p>\n</div>\n\n<p>And then:</p>\n\n<div>\n# More Here\n\nThis is **plain** text.\n\n</div>", wt)
 }
 
 func TestEmbeddedSC(t *testing.T) {

--- a/hugolib/shortcode_test.go
+++ b/hugolib/shortcode_test.go
@@ -439,7 +439,7 @@ func TestShortcodesInSite(t *testing.T) {
 		// Deliberately forced to pass even if they maybe shouldn't.
 		{"sect/doc2.md", `a
 
-{{< b >}}
+{{< b >}}		
 {{< c >}}
 {{< d >}}
 
@@ -448,7 +448,7 @@ e`,
 			"<p>a</p>\n\n<p>b<br />\nc\nd</p>\n\n<p>e</p>\n"},
 		{"sect/doc3.md", `a
 
-{{< b >}}
+{{< b >}}		
 {{< c >}}
 
 {{< d >}}
@@ -476,7 +476,7 @@ e`,
 			filepath.FromSlash("public/sect/doc4/index.html"),
 			"<p>a\nb\nb\nb\nb\nb</p>\n"},
 		// #2192 #2209: Shortcodes in markdown headers
-		{"sect/doc5.md", `# {{< b >}}
+		{"sect/doc5.md", `# {{< b >}}	
 ## {{% c %}}`,
 			filepath.FromSlash("public/sect/doc5/index.html"), "\n\n<h1 id=\"hahahugoshortcode-1hbhb\">b</h1>\n\n<h2 id=\"hahahugoshortcode-2hbhb\">c</h2>\n"},
 		// #2223 pygments
@@ -536,7 +536,6 @@ tags:
 		templ.AddTemplate("_internal/shortcodes/tags.html", "{{ len .Page.Site.Taxonomies.tags }}")
 
 		return nil
-
 	}
 
 	cfg, fs := newTestCfg()
@@ -752,9 +751,7 @@ func BenchmarkReplaceShortcodeTokens(b *testing.B) {
 			if len(results) != len(test.expect) {
 				b.Fatalf("[%d] replaceShortcodeTokens, got \n%s but expected \n%s", j, results, test.expect)
 			}
-
 		}
-
 	}
 }
 
@@ -786,6 +783,7 @@ func BenchmarkReplaceManyShortcodes(b *testing.B) {
 }
 
 func TestReplaceShortcodeTokens(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		input             string
 		replacements      map[string]string


### PR DESCRIPTION
Simplify the code of `replaceShortcodeTokens`:
* Delete some unclear variables like `j` and `k`. It was hard to understand the code
* Use `bytes.Buffer` from pool for `source`, so this function doesn't allocate a lot of memory
* Delete `prefix` argument, why in real cases it's always `shortcodePlaceholderPrefix`

Earlier replaceShortCodeTokens consumed ~11% of all memory hugo consumes for `hugo -s docs`:
![2017-05-07 21 26 32](https://cloud.githubusercontent.com/assets/13235519/25785120/15e4c712-3379-11e7-81eb-bb0b6d738238.png)
Now it's only ~1%

Benchmarks:
Best result before:
```
Average time per operation: 428ms
Average memory allocated per operation: 127350kB
Average allocations per operation: 2137892
```

After:
```
Average time per operation: 425ms
Average memory allocated per operation: 113991kB
Average allocations per operation: 2137522
```
---
**UPDATE: Tests are passed**
The only problem now is, what it can't pass 2 tests yet:
```
$ go test ./hugolib
Source changed content/sect/doc2.en.md
Source changed content/new1.en.md
Source changed content/new2.en.md
Source changed content/new1.fr.md
Source changed content/sect/doc1.en.md
Source changed content/new1renamed.en.md
Source changed content/new1.en.md
Template changed layouts/_default/single.html
i18n changed i18n/fr.yaml
Template changed layouts/shortcodes/shortcode.html
ERROR 2017/05/07 23:06:35 missing : template: missing:1: function "funcdoesnotexists" not defined
ERROR 2017/05/07 23:06:35 init : template: missing:1: function "funcdoesnotexists" not defined
ERROR 2017/05/07 23:06:35 asciidoctor / asciidoc not found in $PATH: Please install.
                  Leaving AsciiDoc content unrendered.
ERROR 2017/05/07 23:06:35 rst2html / rst2html.py not found in $PATH: Please install.
                  Leaving reStructuredText content unrendered.
--- FAIL: TestShortcodesInSite (0.04s)
        Error Trace:    testhelpers_test.go:42
	            	shortcode_test.go:561
	Error:      	Should be true
	Messages:   	File no match for
	            	"<p>a</p>\n\n<p>b<br />\nc\nd</p>\n\n<p>e</p>\n" in
	            	"public/sect/doc2/index.html":
	            	<p>a</p>

	            	<p>b
	            	c
	            	d</p>

	            	<p>e</p>
--- FAIL: TestInnerSCWithAndWithoutMarkdown (0.02s)
	shortcode_test.go:90: Shortcode render didn't match. got
		"<div><h1 id=\"more-here\">More Here</h1>\n\n<p><a href=\"http://spf13.com\">link</a> and text</p>\n</div>\n\n<p>And then:</p>\n\n<div>\n# More Here\n\nThis is **plain** text.\n\n</div>" but expected
		"<div><h1 id=\"more-here\">More Here</h1>\n\n<p><a href=\"http://spf13.com\">link</a> and text</p>\n</div>\n\n<p>And then:</p>\n\n<p><div>\n# More Here\n\nThis is **plain** text.\n\n</div>"
ERROR 2017/05/07 23:06:35 No shortcode param at .Get 1 in page simple.md, have params: [47238zzb]
WARNING: Site config's rssURI is deprecated and will be removed in a future release. Set baseName in outputFormats.RSS.
ERROR 2017/05/07 23:06:36 Two or more menu items have the same name/identifier in Menu "m1": "n2".
Rename or set an unique identifier.
ERROR 2017/05/07 23:06:36 Two or more menu items have the same name/identifier in Menu "m1": "i2".
Rename or set an unique identifier.
ERROR 2017/05/07 23:06:36 Two or more menu items have the same name/identifier in Menu "m1": "i2".
Rename or set an unique identifier.
ERROR 2017/05/07 23:06:36 Two or more menu items have the same name/identifier in Menu "m1": "n2".
Rename or set an unique identifier.
Skipping shortname timezone tests.
ERROR 2017/05/07 23:06:36 Failed to parse date '2010-05-02_15:29:31+08:00' in page page/with/invalid/date
WARNING: Page's Now is deprecated and will be removed in a future release. Use now (the template func).
ERROR 2017/05/07 23:06:36 page content/post/broken.md has both draft and published settings in its frontmatter. Using draft.
ERROR 2017/05/07 23:06:36 both draft and published parameters were found in page's frontmatter
ERROR 2017/05/07 23:06:36 unable to read frontmatter at filepos 45: EOF
FAIL
FAIL	github.com/spf13/hugo/hugolib	1.882s
```
First tests added by https://github.com/spf13/hugo/commit/1ce184b7f1df10ad8815dfe891e053eb04f099ea and it says, what they should not be passed. And they are not passed in my PR :(
In second test `<p>` lacks. I don't know why.

TODO:
- [x] Pass tests
- [ ] Add more comments

/cc @bep 