### PR TITLE
Remove duplicated link in Disqus template

### DIFF
--- a/tpl/tplimpl/template_embedded.go
+++ b/tpl/tplimpl/template_embedded.go
@@ -163,8 +163,7 @@ func (t *templateHandler) embedTemplates() {
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
 </script>
-<noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-<a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>{{end}}`)
+<noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>{{end}}`)
 
 	// Add SEO & Social metadata
 	t.addInternalTemplate("", "opengraph.html", `<meta property="og:title" content="{{ .Title }}" />


### PR DESCRIPTION
See https://help.disqus.com/customer/portal/articles/472097-universal-embed-code

Example of my website using `{{ template "_internal/disqus.html" . }}`:
![screenshot 2017-05-08 20 56 46](https://cloud.githubusercontent.com/assets/3886384/25820234/e2106f64-3430-11e7-81fd-0f782aa22b55.png)
