### PR TITLE
Fixed incorrect specification of directory structure

### DIFF
--- a/docs/content/overview/source-directory.md
+++ b/docs/content/overview/source-directory.md
@@ -64,7 +64,7 @@ An example directory may look like:
     |   ├── partials
     |   |   ├── header.html
     |   |   └── footer.html
-    |   ├── taxonomies
+    |   ├── taxonomy
     |   |   ├── category.html
     |   |   ├── post.html
     |   |   ├── quote.html


### PR DESCRIPTION
Hugo looks for the list/single templates of a taxonomy in `/layouts/taxonomy`, not `/layouts/taxonomies` as correctly mentioned in [this doc page](https://gohugo.io/templates/list/). This change is simply a minor reconciliation.