### PR TITLE
Remove ENTRYPOINT from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,3 @@ COPY . $GOPATH/src/github.com/spf13/hugo
 
 RUN cd $GOPATH/src/github.com/spf13/hugo \
  	&& make install test
-
-ENTRYPOINT "/bin/sh"


### PR DESCRIPTION
It's pointless to set `/bin/sh` as entrypoint. `/bin/sh` is already the default command, and on the top of that, setting `/bin/sh` as entrypoint ignores the command.