### PR TITLE
tpl/collections: Log an error on unsupported types in IsSet

### DIFF
--- a/tpl/collections/collections.go
+++ b/tpl/collections/collections.go
@@ -342,6 +342,8 @@ func (ns *Namespace) IsSet(a interface{}, key interface{}) (bool, error) {
 		if kv.Type() == av.Type().Key() {
 			return av.MapIndex(kv).IsValid(), nil
 		}
+	default:
+		ns.deps.Log.ERROR.Printf("calling IsSet with unsupported type %T will always return false", a)
 	}
 
 	return false, nil

--- a/tpl/collections/collections.go
+++ b/tpl/collections/collections.go
@@ -343,7 +343,7 @@ func (ns *Namespace) IsSet(a interface{}, key interface{}) (bool, error) {
 			return av.MapIndex(kv).IsValid(), nil
 		}
 	default:
-		ns.deps.Log.ERROR.Printf("calling IsSet with unsupported type %T will always return false", a)
+		ns.deps.Log.FEEDBACK.Printf("WARNING: calling IsSet with unsupported type %q (%T) will always return false.\n", av.Kind(), a)
 	}
 
 	return false, nil

--- a/tpl/collections/collections_test.go
+++ b/tpl/collections/collections_test.go
@@ -17,12 +17,20 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"io/ioutil"
+	"log"
 	"math/rand"
+	"os"
 	"reflect"
 	"testing"
 	"time"
 
+	"github.com/spf13/hugo/config"
 	"github.com/spf13/hugo/deps"
+	"github.com/spf13/hugo/helpers"
+	"github.com/spf13/hugo/hugofs"
+	jww "github.com/spf13/jwalterweatherman"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -288,7 +296,7 @@ func TestIntersect(t *testing.T) {
 func TestIsSet(t *testing.T) {
 	t.Parallel()
 
-	ns := New(&deps.Deps{})
+	ns := New(newDeps(viper.New()))
 
 	for i, test := range []struct {
 		a      interface{}
@@ -304,6 +312,7 @@ func TestIsSet(t *testing.T) {
 		{map[string]interface{}{"a": 1, "b": 2}, "bc", false, false, ""},
 
 		{time.Now(), "Day", false, false, ""},
+		{nil, "nil", false, false, ""},
 	} {
 		errMsg := fmt.Sprintf("[%d] %v", i, test)
 
@@ -599,4 +608,15 @@ func (x TstX) String() string {
 type TstX struct {
 	A, B       string
 	unexported string
+}
+
+func newDeps(cfg config.Provider) *deps.Deps {
+	l := helpers.NewLanguage("en", cfg)
+	l.Set("i18nDir", "i18n")
+	return &deps.Deps{
+		Cfg:         cfg,
+		Fs:          hugofs.NewMem(l),
+		ContentSpec: helpers.NewContentSpec(l),
+		Log:         jww.NewNotepad(jww.LevelError, jww.LevelError, os.Stdout, ioutil.Discard, "", log.Ldate|log.Ltime),
+	}
 }


### PR DESCRIPTION
Unsupported types are currently silently ignored by IsSet.  An earlier
attempt was made to solve the issue by returning an error.  That attempt
was reverted since it broke some existing themes.

So instead, we'll log an error.  Hopefully, people will stop using IsSet
in this way, and we can eventually return an error outright.

Updates #3092