### PR TITLE
docs: update references to JSON

### DIFF
--- a/docs/data/docs.json
+++ b/docs/data/docs.json
@@ -191,13 +191,13 @@
       },
       {
         "Example": "JSON regular, \"type: demotype\" in front matter.",
-        "OutputFormat": "CSV",
-        "Suffix": "csv",
+        "OutputFormat": "JSON",
+        "Suffix": "json",
         "Template Lookup Order": [
-          "layouts/demotype/single.csv.csv",
-          "layouts/demotype/single.csv",
-          "layouts/_default/single.csv.csv",
-          "layouts/_default/single.csv"
+          "layouts/demotype/single.json.json",
+          "layouts/demotype/single.json",
+          "layouts/_default/single.json.json",
+          "layouts/_default/single.json"
         ]
       },
       {


### PR DESCRIPTION
Looks like this was a bad copy/paste where CSV should've been JSON