### PR TITLE
Speed up GetPage

### DIFF
--- a/hugolib/page_collections.go
+++ b/hugolib/page_collections.go
@@ -51,8 +51,8 @@ func newPageCollectionsFromPages(pages Pages) *PageCollections {
 	return &PageCollections{rawAllPages: pages}
 }
 
-func (c *PageCollections) getPage(typ string, path ...string) *Page {
-	pages := c.findPagesByKindIn(typ, c.Pages)
+func (c *PageCollections) getFirstPageMatchIn(ps Pages, typ string, path ...string) *Page {
+	pages := c.findPagesByKindIn(typ, ps)
 
 	if len(pages) == 0 {
 		return nil
@@ -78,6 +78,20 @@ func (c *PageCollections) getPage(typ string, path ...string) *Page {
 	}
 
 	return nil
+
+}
+
+func (c *PageCollections) getPage(typ string, path ...string) *Page {
+	var pages Pages
+
+	if typ == KindPage {
+		pages = c.RegularPages
+	} else {
+		pages = c.indexPages
+	}
+
+	return c.getFirstPageMatchIn(pages, typ, path...)
+
 }
 
 func (*PageCollections) findPagesByKindIn(kind string, inPages Pages) Pages {

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1906,8 +1906,11 @@ func (s *Site) Stats() {
 // This will return nil when no page could be found.
 //
 // The valid page types are: home, section, taxonomy and taxonomyTerm
-func (s *SiteInfo) GetPage(typ string, path ...string) *Page {
-	return s.getPage(typ, path...)
+func (s *SiteInfo) GetPage(typ string, path ...string) (*Page, error) {
+	if typ == KindPage {
+		return nil, errors.New("GetPage not supported for regular pages")
+	}
+	return s.getPage(typ, path...), nil
 }
 
 func (s *Site) permalinkForOutputFormat(link string, f output.Format) (string, error) {


### PR DESCRIPTION
When we know to look into the index pages collection, do that:

```
benchmark              old ns/op     new ns/op     delta
BenchmarkGetPage-4     51483         7072          -86.26%

benchmark              old allocs     new allocs     delta
BenchmarkGetPage-4     71             71             +0.00%

benchmark              old bytes     new bytes     delta
BenchmarkGetPage-4     2648          2648          +0.00%
```

This commit also returns an error if .Site.GetPage is called with the regular Page Kind, as that is currently not supported.

Fixes #3503
