### PR TITLE
tpl/collections: Support interfaces in union

### DIFF
--- a/tpl/collections/collections.go
+++ b/tpl/collections/collections.go
@@ -261,6 +261,13 @@ func (ns *Namespace) In(l interface{}, v interface{}) bool {
 						return true
 					}
 				}
+			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+				switch vv.Kind() {
+				case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+					if vv.Uint() == lvv.Uint() {
+						return true
+					}
+				}
 			case reflect.Float32, reflect.Float64:
 				switch vv.Kind() {
 				case reflect.Float32, reflect.Float64:
@@ -564,7 +571,6 @@ func (ns *Namespace) Union(l1, l2 interface{}) (interface{}, error) {
 			if l1v.Type() != l2v.Type() &&
 				l1v.Type().Elem().Kind() != reflect.Interface &&
 				l2v.Type().Elem().Kind() != reflect.Interface {
-
 				return r.Interface(), nil
 			}
 

--- a/tpl/collections/collections_test.go
+++ b/tpl/collections/collections_test.go
@@ -571,21 +571,45 @@ func TestUnion(t *testing.T) {
 		expect interface{}
 		isErr  bool
 	}{
+		{nil, nil, []interface{}{}, false},
+		{nil, []string{"a", "b"}, []string{"a", "b"}, false},
+		{[]string{"a", "b"}, nil, []string{"a", "b"}, false},
+
+		// []A ∪ []B
+		{[]string{"1", "2"}, []int{3}, []string{}, false},
+		{[]int{1, 2}, []string{"1", "2"}, []int{}, false},
+
+		// []T ∪ []T
 		{[]string{"a", "b", "c", "c"}, []string{"a", "b", "b"}, []string{"a", "b", "c"}, false},
 		{[]string{"a", "b"}, []string{"a", "b", "c"}, []string{"a", "b", "c"}, false},
 		{[]string{"a", "b", "c"}, []string{"d", "e"}, []string{"a", "b", "c", "d", "e"}, false},
 		{[]string{}, []string{}, []string{}, false},
-		{[]string{"a", "b"}, nil, []string{"a", "b"}, false},
-		{nil, []string{"a", "b"}, []string{"a", "b"}, false},
-		{nil, nil, make([]interface{}, 0), true},
-		{[]string{"1", "2"}, []int{1, 2}, make([]string, 0), false},
-		{[]int{1, 2}, []string{"1", "2"}, make([]int, 0), false},
 		{[]int{1, 2, 3}, []int{3, 4, 5}, []int{1, 2, 3, 4, 5}, false},
 		{[]int{1, 2, 3}, []int{1, 2, 3}, []int{1, 2, 3}, false},
 		{[]int{1, 2, 4}, []int{2, 4}, []int{1, 2, 4}, false},
 		{[]int{2, 4}, []int{1, 2, 4}, []int{2, 4, 1}, false},
 		{[]int{1, 2, 4}, []int{3, 6}, []int{1, 2, 4, 3, 6}, false},
 		{[]float64{2.2, 4.4}, []float64{1.1, 2.2, 4.4}, []float64{2.2, 4.4, 1.1}, false},
+		{[]interface{}{"a", "b", "c", "c"}, []interface{}{"a", "b", "b"}, []interface{}{"a", "b", "c"}, false},
+
+		// []T ∪ []interface{}
+		{[]string{"1", "2"}, []interface{}{"9"}, []string{"1", "2", "9"}, false},
+		{[]int{2, 4}, []interface{}{1, 2, 4}, []int{2, 4, 1}, false},
+		{[]int8{2, 4}, []interface{}{int8(1), int8(2), int8(4)}, []int8{2, 4, 1}, false},
+		{[]int8{2, 4}, []interface{}{1, 2, 4}, []int8{2, 4, 1}, false},
+		{[]int16{2, 4}, []interface{}{1, 2, 4}, []int16{2, 4, 1}, false},
+		{[]int32{2, 4}, []interface{}{1, 2, 4}, []int32{2, 4, 1}, false},
+		{[]int64{2, 4}, []interface{}{1, 2, 4}, []int64{2, 4, 1}, false},
+		{[]float64{2.2, 4.4}, []interface{}{1.1, 2.2, 4.4}, []float64{2.2, 4.4, 1.1}, false},
+		{[]float32{2.2, 4.4}, []interface{}{1.1, 2.2, 4.4}, []float32{2.2, 4.4, 1.1}, false},
+
+		// []interface{} ∪ []T
+		{[]interface{}{"a", "b", "c", "c"}, []string{"a", "b", "b"}, []interface{}{"a", "b", "c"}, false},
+		{[]interface{}{}, []string{}, []interface{}{}, false},
+		{[]interface{}{1, 2}, []int{2, 3}, []interface{}{1, 2, 3}, false},
+		{[]interface{}{1, 2}, []int8{2, 3}, []interface{}{1, 2, int8(3)}, false},
+		{[]interface{}{1.1, 2.2}, []float64{2.2, 3.3}, []interface{}{1.1, 2.2, 3.3}, false},
+
 		// errors
 		{"not array or slice", []string{"a"}, false, true},
 		{[]string{"a"}, "not array or slice", false, true},

--- a/tpl/collections/collections_test.go
+++ b/tpl/collections/collections_test.go
@@ -298,6 +298,7 @@ func TestIntersect(t *testing.T) {
 		{[]interface{}{int16(1), int16(2), int16(3)}, []int16{1, 2, 2}, []interface{}{int16(1), int16(2)}},
 		{[]interface{}{int32(1), int32(2), int32(3)}, []int32{1, 2, 2}, []interface{}{int32(1), int32(2)}},
 		{[]interface{}{int64(1), int64(2), int64(3)}, []int64{1, 2, 2}, []interface{}{int64(1), int64(2)}},
+		{[]interface{}{uint(1), uint(2), uint(3)}, []uint{1, 2, 2}, []interface{}{uint(1), uint(2)}},
 		{[]interface{}{float32(1), float32(2), float32(3)}, []float32{1, 2, 2}, []interface{}{float32(1), float32(2)}},
 		{[]interface{}{float64(1), float64(2), float64(3)}, []float64{1, 2, 2}, []interface{}{float64(1), float64(2)}},
 
@@ -604,10 +605,11 @@ func TestUnion(t *testing.T) {
 		{[]float32{2.2, 4.4}, []interface{}{1.1, 2.2, 4.4}, []float32{2.2, 4.4, 1.1}, false},
 
 		// []interface{} ∪ []T
-		{[]interface{}{"a", "b", "c", "c"}, []string{"a", "b", "b"}, []interface{}{"a", "b", "c"}, false},
+		{[]interface{}{"a", "b", "c", "c"}, []string{"a", "b", "d"}, []interface{}{"a", "b", "c", "d"}, false},
 		{[]interface{}{}, []string{}, []interface{}{}, false},
 		{[]interface{}{1, 2}, []int{2, 3}, []interface{}{1, 2, 3}, false},
 		{[]interface{}{1, 2}, []int8{2, 3}, []interface{}{1, 2, int8(3)}, false},
+		{[]interface{}{uint(1), uint(2)}, []uint{2, 3}, []interface{}{uint(1), uint(2), uint(3)}, false},
 		{[]interface{}{1.1, 2.2}, []float64{2.2, 3.3}, []interface{}{1.1, 2.2, 3.3}, false},
 
 		// errors


### PR DESCRIPTION
Fixes #3411 

Also includes an additional commit to add missing uint support to `In`