### PR TITLE
hugolib: Add site building benchmarks

### DIFF
--- a/hugolib/site_benchmark_test.go
+++ b/hugolib/site_benchmark_test.go
@@ -1,0 +1,182 @@
+// Copyright 2017-present The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hugolib
+
+import (
+	"fmt"
+	"math/rand"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+)
+
+type siteBuildingBenchmarkConfig struct {
+	NumPages     int
+	RootSections int
+	Render       bool
+	Shortcodes   bool
+	TagsPerPage  int
+}
+
+func (s siteBuildingBenchmarkConfig) String() string {
+	return fmt.Sprintf("num_root_sections=%d|num_pages=%d|tags_per_page=%d|shortcodes=%t|render=%t", s.RootSections, s.NumPages, s.TagsPerPage, s.Shortcodes, s.Render)
+}
+
+func BenchmarkSiteBuilding(b *testing.B) {
+	var conf siteBuildingBenchmarkConfig
+	for _, rootSections := range []int{1, 5} {
+		conf.RootSections = rootSections
+		for _, tagsPerPage := range []int{0, 1, 5, 20} {
+			conf.TagsPerPage = tagsPerPage
+			for _, numPages := range []int{10, 100, 500, 1000, 5000} {
+				conf.NumPages = numPages
+				for _, render := range []bool{false, true} {
+					conf.Render = render
+					for _, shortcodes := range []bool{false, true} {
+						conf.Shortcodes = shortcodes
+						doBenchMarkSiteBuilding(conf, b)
+					}
+				}
+			}
+		}
+	}
+}
+
+func doBenchMarkSiteBuilding(conf siteBuildingBenchmarkConfig, b *testing.B) {
+	b.Run(conf.String(), func(b *testing.B) {
+		sites := createHugoBenchmarkSites(b, b.N, conf)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			h := sites[0]
+
+			err := h.Build(BuildCfg{SkipRender: !conf.Render})
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			// Try to help the GC
+			sites[0] = nil
+			sites = sites[1:len(sites)]
+		}
+	})
+}
+
+func createHugoBenchmarkSites(b *testing.B, count int, cfg siteBuildingBenchmarkConfig) []*HugoSites {
+	someMarkdown := `
+An h1 header
+============
+
+Paragraphs are separated by a blank line.
+
+2nd paragraph. *Italic* and **bold**. Itemized lists
+look like:
+
+  * this one
+  * that one
+  * the other one
+
+Note that --- not considering the asterisk --- the actual text
+content starts at 4-columns in.
+
+> Block quotes are
+> written like so.
+>
+> They can span multiple paragraphs,
+> if you like.
+
+Use 3 dashes for an em-dash. Use 2 dashes for ranges (ex., "it's all
+in chapters 12--14"). Three dots ... will be converted to an ellipsis.
+Unicode is supported. ☺
+`
+
+	someMarkdownWithShortCode := someMarkdown + `
+
+{{< myShortcode >}}
+
+`
+
+	pageTemplate := `+++
+title = "%s"
+tags = %s
++++
+%s
+
+`
+
+	siteConfig := `
+baseURL = "http://example.com/blog"
+
+paginate = 10
+defaultContentLanguage = "en"
+
+[Taxonomies]
+tag = "tags"
+category = "categories"
+`
+	var (
+		contentPagesContent [3]string
+		tags                = make([]string, cfg.TagsPerPage)
+	)
+
+	for i := 0; i < len(tags); i++ {
+		tags[i] = fmt.Sprintf("Hugo %d", i)
+	}
+
+	tagsStr := "[]"
+	if cfg.TagsPerPage > 0 {
+		tagsStr = strings.Replace(fmt.Sprintf("%q", tags[0:cfg.TagsPerPage]), " ", ", ", -1)
+	}
+
+	if cfg.Shortcodes {
+		contentPagesContent = [3]string{
+			someMarkdownWithShortCode,
+			strings.Repeat(someMarkdownWithShortCode, 2),
+			strings.Repeat(someMarkdownWithShortCode, 3),
+		}
+	} else {
+		contentPagesContent = [3]string{
+			someMarkdown,
+			strings.Repeat(someMarkdown, 2),
+			strings.Repeat(someMarkdown, 3),
+		}
+	}
+
+	sites := make([]*HugoSites, count)
+	for i := 0; i < count; i++ {
+		// Maybe consider reusing the Source fs
+		mf := afero.NewMemMapFs()
+		th, h := newTestSitesFromConfig(b, mf, siteConfig,
+			"layouts/_default/single.html", `Single HTML|{{ .Title }}|{{ .Content }}`,
+			"layouts/_default/list.html", `List HTML|{{ .Title }}|{{ .Content }}`,
+			"layouts/shortcodes/myShortcode.html", `<p>MyShortcode</p>`)
+
+		fs := th.Fs
+
+		pagesPerSection := cfg.NumPages / cfg.RootSections
+
+		for i := 0; i < cfg.RootSections; i++ {
+			for j := 0; j < pagesPerSection; j++ {
+				content := fmt.Sprintf(pageTemplate, fmt.Sprintf("Title%d_%d", i, j), tagsStr, contentPagesContent[rand.Intn(3)])
+
+				writeSource(b, fs, filepath.Join("content", fmt.Sprintf("sect%d", i), fmt.Sprintf("page%d.md", j)), content)
+			}
+		}
+
+		sites[i] = h
+	}
+
+	return sites
+}


### PR DESCRIPTION
```
▶ go test -run="NONE" -bench="BenchmarkSiteBuilding.*"  -test.benchmem=true ./hugolib
BenchmarkSiteBuilding/num_root_sections=1/num_pages=10/render=false-4                 2000       1291745 ns/op      344566 B/op        4632 allocs/op
BenchmarkSiteBuilding/num_root_sections=1/num_pages=10/render=true-4                   500       2700312 ns/op      633817 B/op       10775 allocs/op
BenchmarkSiteBuilding/num_root_sections=1/num_pages=100/render=false-4                 200       7501431 ns/op     3242208 B/op       41776 allocs/op
BenchmarkSiteBuilding/num_root_sections=1/num_pages=100/render=true-4                  100      14165829 ns/op     4712458 B/op       73519 allocs/op
BenchmarkSiteBuilding/num_root_sections=1/num_pages=500/render=false-4                  30      37451925 ns/op    16107927 B/op      206770 allocs/op
BenchmarkSiteBuilding/num_root_sections=1/num_pages=500/render=true-4                   20      71672354 ns/op    24593242 B/op      352311 allocs/op
BenchmarkSiteBuilding/num_root_sections=5/num_pages=10/render=false-4                 1000       1016563 ns/op      357234 B/op        4877 allocs/op
BenchmarkSiteBuilding/num_root_sections=5/num_pages=10/render=true-4                   500       3131995 ns/op      792740 B/op       14077 allocs/op
BenchmarkSiteBuilding/num_root_sections=5/num_pages=100/render=false-4                 200       7756263 ns/op     3255768 B/op       42053 allocs/op
BenchmarkSiteBuilding/num_root_sections=5/num_pages=100/render=true-4                  100      16760263 ns/op     4865944 B/op       76860 allocs/op
BenchmarkSiteBuilding/num_root_sections=5/num_pages=500/render=false-4                  30      44964680 ns/op    16123086 B/op      207072 allocs/op
BenchmarkSiteBuilding/num_root_sections=5/num_pages=500/render=true-4                   20      76888686 ns/op    24227005 B/op      355699 allocs/op
```

Fixes #3535


/cc @bogem this is very much just a first outline, but if you have wishes/suggestions: shout!