### PR TITLE
source: Cache language config

### DIFF
--- a/source/file.go
+++ b/source/file.go
@@ -27,10 +27,15 @@ import (
 type SourceSpec struct {
 	Cfg config.Provider
 	Fs  *hugofs.Fs
+
+	languages              map[string]interface{}
+	defaultContentLanguage string
 }
 
 func NewSourceSpec(cfg config.Provider, fs *hugofs.Fs) SourceSpec {
-	return SourceSpec{Cfg: cfg, Fs: fs}
+	defaultLang := cfg.GetString("defaultContentLanguage")
+	languages := cfg.GetStringMap("languages")
+	return SourceSpec{Cfg: cfg, Fs: fs, languages: languages, defaultContentLanguage: defaultLang}
 }
 
 // File represents a source content file.
@@ -139,8 +144,8 @@ func (sp SourceSpec) NewFile(relpath string) *File {
 	f.baseName = helpers.Filename(f.LogicalName())
 
 	lang := strings.TrimPrefix(filepath.Ext(f.baseName), ".")
-	if _, ok := sp.Cfg.GetStringMap("languages")[lang]; lang == "" || !ok {
-		f.lang = sp.Cfg.GetString("defaultContentLanguage")
+	if _, ok := sp.languages[lang]; lang == "" || !ok {
+		f.lang = sp.defaultContentLanguage
 		f.translationBaseName = f.baseName
 	} else {
 		f.lang = lang


### PR DESCRIPTION
```
benchmark                                                                                                                     old ns/op     new ns/op     delta
BenchmarkSiteBuilding/frontmatter=YAML|num_root_sections=1|num_pages=5000|tags_per_page=0|shortcodes=false|render=false-4     552742744     501838152     -9.21%

benchmark                                                                                                                     old allocs     new allocs     delta
BenchmarkSiteBuilding/frontmatter=YAML|num_root_sections=1|num_pages=5000|tags_per_page=0|shortcodes=false|render=false-4     3047393        2957378        -2.95%

benchmark                                                                                                                     old bytes     new bytes     delta
BenchmarkSiteBuilding/frontmatter=YAML|num_root_sections=1|num_pages=5000|tags_per_page=0|shortcodes=false|render=false-4     356533864     354291924     -0.63%
```