### PR TITLE
all: Temporarily revert to BurntSushi for TOML front matter handling

### DIFF
--- a/commands/new.go
+++ b/commands/new.go
@@ -355,7 +355,7 @@ func newContentPathSection(path string) (string, string) {
 }
 
 func createConfig(fs *hugofs.Fs, inpath string, kind string) (err error) {
-	in := map[string]interface{}{
+	in := map[string]string{
 		"baseURL":      "http://example.org/",
 		"title":        "My New Hugo Site",
 		"languageCode": "en-us",

--- a/hugolib/menu_old_test.go
+++ b/hugolib/menu_old_test.go
@@ -25,7 +25,7 @@ import (
 
 	"path/filepath"
 
-	toml "github.com/pelletier/go-toml"
+	"github.com/BurntSushi/toml"
 	"github.com/spf13/hugo/source"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -634,12 +634,7 @@ func setupMenuTests(t *testing.T, pageSources []source.ByteSource, configKeyValu
 }
 
 func tomlToMap(s string) (map[string]interface{}, error) {
-	tree, err := toml.Load(s)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return tree.ToMap(), nil
-
+	var data = make(map[string]interface{})
+	_, err := toml.Decode(s, &data)
+	return data, err
 }

--- a/parser/frontmatter.go
+++ b/parser/frontmatter.go
@@ -20,8 +20,8 @@ import (
 	"io"
 	"strings"
 
+	"github.com/BurntSushi/toml"
 	"github.com/chaseadamsio/goorgeous"
-	toml "github.com/pelletier/go-toml"
 
 	"gopkg.in/yaml.v2"
 )
@@ -52,13 +52,7 @@ func InterfaceToConfig(in interface{}, mark rune, w io.Writer) error {
 		return err
 
 	case rune(TOMLLead[0]):
-		tree, err := toml.TreeFromMap(in.(map[string]interface{}))
-		if err != nil {
-			return err
-		}
-
-		_, err = tree.WriteTo(w)
-		return err
+		return toml.NewEncoder(w).Encode(in)
 	case rune(JSONLead[0]):
 		b, err := json.MarshalIndent(in, "", "   ")
 		if err != nil {
@@ -176,14 +170,10 @@ func HandleTOMLMetaData(datum []byte) (interface{}, error) {
 	m := map[string]interface{}{}
 	datum = removeTOMLIdentifier(datum)
 
-	tree, err := toml.LoadReader(bytes.NewReader(datum))
-	if err != nil {
-		return m, err
-	}
+	_, err := toml.Decode(string(datum), &m)
 
-	m = tree.ToMap()
+	return m, err
 
-	return m, nil
 }
 
 // removeTOMLIdentifier removes, if necessary, beginning and ending TOML


### PR DESCRIPTION
We still have go-toml as a transitive dependency, and it is the way to go eventually, but we care about speed, so let us wait that one out.

Note that the issue this fixes is about taxonomies, but I guess this is a general issue for sites with many pages that uses TOML as front matter.

```
benchmark                                                                                                                      old ns/op     new ns/op     delta
BenchmarkSiteBuilding/frontmatter=TOML,num_root_sections=1,num_pages=5000,tags_per_page=0,shortcodes=false,render=false-4      559588018     519948664     -7.08%
BenchmarkSiteBuilding/frontmatter=TOML,num_root_sections=1,num_pages=5000,tags_per_page=1,shortcodes=false,render=false-4      777332160     517742822     -33.39%
BenchmarkSiteBuilding/frontmatter=TOML,num_root_sections=1,num_pages=5000,tags_per_page=5,shortcodes=false,render=false-4      731425010     579082320     -20.83%
BenchmarkSiteBuilding/frontmatter=TOML,num_root_sections=1,num_pages=5000,tags_per_page=20,shortcodes=false,render=false-4     955919053     680114689     -28.85%

benchmark                                                                                                                      old allocs     new allocs     delta
BenchmarkSiteBuilding/frontmatter=TOML,num_root_sections=1,num_pages=5000,tags_per_page=0,shortcodes=false,render=false-4      3538011        2967864        -16.11%
BenchmarkSiteBuilding/frontmatter=TOML,num_root_sections=1,num_pages=5000,tags_per_page=1,shortcodes=false,render=false-4      3755649        3052225        -18.73%
BenchmarkSiteBuilding/frontmatter=TOML,num_root_sections=1,num_pages=5000,tags_per_page=5,shortcodes=false,render=false-4      4783132        3343569        -30.10%
BenchmarkSiteBuilding/frontmatter=TOML,num_root_sections=1,num_pages=5000,tags_per_page=20,shortcodes=false,render=false-4     8749762        4352321        -50.26%

benchmark                                                                                                                      old bytes     new bytes     delta
BenchmarkSiteBuilding/frontmatter=TOML,num_root_sections=1,num_pages=5000,tags_per_page=0,shortcodes=false,render=false-4      371997008     340437445     -8.48%
BenchmarkSiteBuilding/frontmatter=TOML,num_root_sections=1,num_pages=5000,tags_per_page=1,shortcodes=false,render=false-4      375536344     342876828     -8.70%
BenchmarkSiteBuilding/frontmatter=TOML,num_root_sections=1,num_pages=5000,tags_per_page=5,shortcodes=false,render=false-4      402182716     351249516     -12.66%
BenchmarkSiteBuilding/frontmatter=TOML,num_root_sections=1,num_pages=5000,tags_per_page=20,shortcodes=false,render=false-4     503704984     389290704     -22.71%
```

See #3541
Fixes #3464

/cc @bogem @spf13 @moorereason